### PR TITLE
fixing FinishAsync Null Reference error, making example in readme properly async

### DIFF
--- a/Deepgram/Transcription/LiveTranscriptionClient.cs
+++ b/Deepgram/Transcription/LiveTranscriptionClient.cs
@@ -169,7 +169,7 @@ namespace Deepgram.Transcription
                 return;
             }
 
-            await _clientWebSocket.SendAsync(new ArraySegment<byte>(), WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
+            await _clientWebSocket.SendAsync(new ArraySegment<byte>(Array.Empty<byte>()), WebSocketMessageType.Binary, true, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or
 
 - Provide the Deepgram API key and optional API Url in `appsettings.json`:
 
-```js
+```json
 {
   "appSettings": {
     "Deepgram.Api.Key": "YOUR_DEEPGRAM_API_KEY",
@@ -129,7 +129,7 @@ using (var deepgramLive = deepgramClient.CreateLiveTranscriptionClient())
     deepgramLive.TranscriptReceived += HandleTranscriptReceived;
 
     // Connection opened so start sending audio.
-    void HandleConnectionOpened(object? sender, ConnectionOpenEventArgs e)
+    async void HandleConnectionOpened(object? sender, ConnectionOpenEventArgs e)
     {
         byte[] buffer;
 
@@ -144,10 +144,10 @@ using (var deepgramLive = deepgramClient.CreateLiveTranscriptionClient())
         foreach (var chunk in chunks)
         {
             deepgramLive.SendData(chunk);
-            Task.Delay(50).Wait();
+            await Task.Delay(50);
         }
 
-        deepgramLive.FinishAsync();
+        await deepgramLive.FinishAsync();
     }
 
     void HandleTranscriptReceived(object? sender, TranscriptReceivedEventArgs e)


### PR DESCRIPTION
Bugfix in `FinshAsync` where it would throw an Argument Null exception since the internal buffer inside of the `ArraySegment<byte>` was not initialized. Also made the ConnectionOpened event handler in the README async, (this is the one, weird case where it's ok to have an async void)