### PR TITLE
Updated tag property of GetUsageSummaryOptions object

### DIFF
--- a/Deepgram/Usage/GetUsageSummaryOptions.cs
+++ b/Deepgram/Usage/GetUsageSummaryOptions.cs
@@ -24,10 +24,10 @@ namespace Deepgram.Usage
         public string ApiKeyId { get; set; }
 
         /// <summary>
-        /// Limits results to requests associated with the specified tag. 
+        /// Limits results to requests associated with the specified tag(s). 
         /// </summary>
         [JsonProperty("tag")]
-        public string Tag { get; set; }
+        public string[]? Tag { get; set; }
 
         /// <summary>
         /// Limits results to requests processed using the specified method.


### PR DESCRIPTION
The Tag property of the GetUsageSummaryOptions object was previously typed as a string. This limited filtering usage by one tag, while the API allows for filtering by many. Modified that property to be an array of strings to allow parity with the API.