### PR TITLE
minimal changes to support .net standard 2.0

### DIFF
--- a/Deepgram/Credentials.cs
+++ b/Deepgram/Credentials.cs
@@ -14,7 +14,7 @@ namespace Deepgram
         /// </summary>
         /// <param name="apiKey">Deepgram API Key</param>
         /// <param name="apiUrl">Url of Deepgram API</param>
-        public Credentials(string? apiKey = null, string? apiUrl = null)
+        public Credentials(string apiKey = null, string apiUrl = null)
         {
             ApiKey = apiKey;
             ApiUrl = apiUrl;
@@ -23,11 +23,11 @@ namespace Deepgram
         /// <summary>
         /// Deepgram API Key
         /// </summary>
-        public string? ApiKey { get; set; } = null;
+        public string ApiKey { get; set; } = null;
 
         /// <summary>
         /// On-premise Url of the Deepgram API
         /// </summary>
-        public string? ApiUrl { get; set; } = null;
+        public string ApiUrl { get; set; } = null;
     }
 }

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -1,9 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;netstandard2.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Nullable>enable</Nullable>
     <Description>.NET SDK for the Deepgram API</Description>
     <Copyright>2021 Deepgram</Copyright>
     <PackageProjectUrl>https://github.com/deepgram-devs/deepgram-dotnet-sdk</PackageProjectUrl>
@@ -33,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Deepgram/DeepgramClient.cs
+++ b/Deepgram/DeepgramClient.cs
@@ -43,7 +43,7 @@ namespace Deepgram
             return new LiveTranscriptionClient(_credentials);
         }
 
-        private void InitializeCredentials(Credentials? credentials = null)
+        private void InitializeCredentials(Credentials credentials = null)
         {
             string apiUrl = string.IsNullOrWhiteSpace(credentials?.ApiUrl) ? "" : credentials.ApiUrl;
             string apiKey = string.IsNullOrWhiteSpace(credentials?.ApiKey) ? "" : credentials.ApiKey;

--- a/Deepgram/Projects/Project.cs
+++ b/Deepgram/Projects/Project.cs
@@ -21,6 +21,6 @@ namespace Deepgram.Projects
         /// Name of the company associated with the Deepgram project
         /// </summary>
         [JsonProperty("company")]
-        public string? Company { get; set; }
+        public string Company { get; set; }
     }
 }

--- a/Deepgram/Projects/ProjectClient.cs
+++ b/Deepgram/Projects/ProjectClient.cs
@@ -50,7 +50,11 @@ namespace Deepgram.Projects
         public async Task<MessageResponse> UpdateProjectAsync(Project project)
         {
             return await ApiRequest.DoRequestAsync<MessageResponse>(
+#if NETSTANDARD2_0
+                new HttpMethod("PATCH"),
+#else
                 HttpMethod.Patch,
+#endif
                 $"/v1/projects/{project.Id}",
                 _credentials,
                 null,

--- a/Deepgram/Request/ApiRequest.cs
+++ b/Deepgram/Request/ApiRequest.cs
@@ -34,7 +34,7 @@ namespace Deepgram.Request
             request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("token", apiKey);
         }
 
-        private static void SetContent(ref HttpRequestMessage request, object? bodyObject)
+        private static void SetContent(ref HttpRequestMessage request, object bodyObject)
         {
             if (null != bodyObject)
             {
@@ -56,7 +56,7 @@ namespace Deepgram.Request
             request.Content = httpContent;
         }
 
-        internal static async Task<T> DoRequestAsync<T>(HttpMethod method, string uri, CleanCredentials credentials, object? queryParameters = null, object? bodyObject = null)
+        internal static async Task<T> DoRequestAsync<T>(HttpMethod method, string uri, CleanCredentials credentials, object queryParameters = null, object bodyObject = null)
         {
             var requestUri = GetUriWithQuerystring(credentials, uri, queryParameters);
 
@@ -71,7 +71,7 @@ namespace Deepgram.Request
             return await SendHttpRequestAsync<T>(req);
         }
 
-        internal static async Task<T> DoStreamRequestAsync<T>(HttpMethod method, string uri, CleanCredentials credentials, StreamSource streamSource, object? queryParameters = null)
+        internal static async Task<T> DoStreamRequestAsync<T>(HttpMethod method, string uri, CleanCredentials credentials, StreamSource streamSource, object queryParameters = null)
         {
             var requestUri = GetUriWithQuerystring(credentials, uri, queryParameters);
 
@@ -86,7 +86,7 @@ namespace Deepgram.Request
             return await SendHttpRequestAsync<T>(req);
         }
 
-        private static Uri GetUriWithQuerystring(CleanCredentials credentials, string uri, object? queryParameters)
+        private static Uri GetUriWithQuerystring(CleanCredentials credentials, string uri, object queryParameters)
         {
             if (null != queryParameters)
             {

--- a/Deepgram/Transcription/Channel.cs
+++ b/Deepgram/Transcription/Channel.cs
@@ -9,7 +9,7 @@ namespace Deepgram.Transcription
         /// Array of Search objects.
         /// </summary>
         [JsonProperty("search")]
-        public Search[]? Search { get; set; }
+        public Search[] Search { get; set; }
 
         /// <summary>
         /// Array of Alternative objects.

--- a/Deepgram/Transcription/IPrerecordedTranscriptionClient.cs
+++ b/Deepgram/Transcription/IPrerecordedTranscriptionClient.cs
@@ -11,7 +11,7 @@ namespace Deepgram.Transcription
         /// <param name="source">Url source to send for transcription</param>
         /// <param name="options">Feature options for the transcription</param>
         /// <returns>Transcription of the provided audio</returns>
-        Task<PrerecordedTranscription> GetTranscriptionAsync(UrlSource source, PrerecordedTranscriptionOptions? options);
+        Task<PrerecordedTranscription> GetTranscriptionAsync(UrlSource source, PrerecordedTranscriptionOptions options);
 
         /// <summary>
         /// Submits a request to the Deepgram API to transcribe prerecorded audio
@@ -19,6 +19,6 @@ namespace Deepgram.Transcription
         /// <param name="source">Audio source to send for transcription</param>
         /// <param name="options">Feature options for the transcription</param>
         /// <returns>Transcription of the provided audio</returns>
-        Task<PrerecordedTranscription> GetTranscriptionAsync(StreamSource source, PrerecordedTranscriptionOptions? options);
+        Task<PrerecordedTranscription> GetTranscriptionAsync(StreamSource source, PrerecordedTranscriptionOptions options);
     }
 }

--- a/Deepgram/Transcription/LiveTranscriptionClient.cs
+++ b/Deepgram/Transcription/LiveTranscriptionClient.cs
@@ -181,7 +181,7 @@ namespace Deepgram.Transcription
             EnqueueForSending(new MessageToSend(data));
         }
 
-        private Uri GetWSSUriWithQuerystring(string uri, object? queryParameters)
+        private Uri GetWSSUriWithQuerystring(string uri, object queryParameters)
         {
             if (null != queryParameters)
             {

--- a/Deepgram/Transcription/LiveTranscriptionOptions.cs
+++ b/Deepgram/Transcription/LiveTranscriptionOptions.cs
@@ -9,136 +9,136 @@ namespace Deepgram.Transcription
         /// AI model used to process submitted audio
         /// </summary>
         [JsonProperty("model")]
-        public string? Model { get; set; } = null;
+        public string Model { get; set; } = null;
 
         /// <summary>
         /// Version of the model to use.
         /// </summary>
         [JsonProperty("version")]
-        public string? Version { get; set; } = null;
+        public string Version { get; set; } = null;
 
         /// <summary>
         /// BCP-47 language tag that hints at the primary spoken language.
         /// </summary>
         [JsonProperty("language")]
-        public string? Language { get; set; } = null;
+        public string Language { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to add punctuation and capitalization to the transcript.
         /// </summary>
         [JsonProperty("punctuate")]
-        public bool? Punctuate { get; set; } = null;
+        public Nullable<bool> Punctuate { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to remove profanity from the transcript.
         /// </summary>
         [JsonProperty("profanity_filter")]
-        public bool? ProfanityFilter { get; set; } = null;
+        public Nullable<bool> ProfanityFilter { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to redact sensitive information, replacing redacted content with asterisks (*).
         /// </summary>
         /// <remarks>Possible values are: pci, numbers, ssn</remarks>
         [JsonProperty("redact")]
-        public string[]? Redaction { get; set; }
+        public string[] Redaction { get; set; }
 
         /// <summary>
         /// Indicates whether to recognize speaker changes. When set to true, each word in the transcript
         /// will be assigned a speaker number starting at 0. 
         /// </summary>
         [JsonProperty("diarize")]
-        public bool? Diarize { get; set; } = null;
+        public Nullable<bool> Diarize { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
         /// between characters identified as part of an alphanumeric string. 
         /// </summary>
         [JsonProperty("ner")]
-        public bool? NamedEntityRecognition { get; set; } = null;
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]
-        public bool? MultiChannel { get; set; } = null;
+        public Nullable<bool> MultiChannel { get; set; } = null;
 
         /// <summary>
         /// Maximum number of transcript alternatives to return.
         /// </summary>
         [JsonProperty("alternatives")]
-        public int? Alternatives { get; set; } = null;
+        public Nullable<int> Alternatives { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to convert numbers from written format (e.g., one) to numerical format (e.g., 1).
         /// </summary>
         [JsonProperty("numerals")]
-        public bool? Numerals { get; set; } = null;
+        public Nullable<bool> Numerals { get; set; } = null;
 
         /// <summary>
         /// Terms or phrases to search for in the submitted audio.
         /// </summary>
         [JsonProperty("search")]
-        public string[]? SearchTerms { get; set; }
+        public string[] SearchTerms { get; set; }
 
         /// <summary>
         /// Callback URL to provide if you would like your submitted audio to be processed asynchronously.
         /// When passed, Deepgram will immediately respond with a request_id. 
         /// </summary>
         [JsonProperty("callback")]
-        public string? Callback { get; set; } = null;
+        public string Callback { get; set; } = null;
 
         /// <summary>
         /// Keywords to which the model should pay particular attention to boosting or suppressing to help
         /// it understand context.
         /// </summary>
         [JsonProperty("keywords")]
-        public string[]? Keywords { get; set; }
+        public string[] Keywords { get; set; }
 
         /// <summary>
         /// Indicates whether Deepgram will segment speech into meaningful semantic units, which allows
         /// the model to interact more naturally and effectively with speakers' spontaneous speech patterns.
         /// </summary>
         [JsonProperty("utterances")]
-        public bool? Utterances { get; set; } = null;
+        public Nullable<bool> Utterances { get; set; } = null;
 
         /// <summary>
         /// Indicates whether the streaming endpoint should send you updates to its transcription as more 
         /// audio becomes available.
         /// </summary>
         [JsonProperty("interim_results")]
-        public bool? InterimResults { get; set; } = null;
+        public Nullable<bool> InterimResults { get; set; } = null;
 
         /// <summary>
         /// Indicates whether Deepgram will detect whether a speaker has finished speaking (or paused 
         /// for a significant period of time, indicating the completion of an idea).
         /// </summary>
         [JsonProperty("endpointing")]
-        public bool? Endpointing { get; set; } = null;
+        public Nullable<bool> Endpointing { get; set; } = null;
 
         /// <summary>
         /// Length of time in milliseconds of silence that voice activation detection (VAD) will use 
         /// to detect that a speaker has finished speaking.
         /// </summary>
         [JsonProperty("vad_turnoff")]
-        public int? VADTurnoff { get; set; } = null;
+        public Nullable<int> VADTurnoff { get; set; } = null;
 
         /// <summary>
         /// Expected encoding of the submitted streaming audio.
         /// </summary>
         [JsonProperty("encoding")]
-        public string? Encoding { get; set; } = null;
+        public string Encoding { get; set; } = null;
 
         /// <summary>
         /// Number of independent audio channels contained in submitted streaming audio.
         /// </summary>
         [JsonProperty("channels")]
-        public int? Channels { get; set; } = null;
+        public Nullable<int> Channels { get; set; } = null;
 
         /// <summary>
         /// Sample rate of submitted streaming audio. Required (and only read) when a value 
         /// is provided for encoding.
         /// </summary>
         [JsonProperty("sample_rate")]
-        public int? SampleRate { get; set; } = null;
+        public Nullable<int> SampleRate { get; set; } = null;
     }
 }

--- a/Deepgram/Transcription/PrerecordedTranscription.cs
+++ b/Deepgram/Transcription/PrerecordedTranscription.cs
@@ -9,13 +9,13 @@ namespace Deepgram.Transcription
         /// Metadata for the request
         /// </summary>
         [JsonProperty("metadata")]
-        public PrerecordedTranscriptionMetaData? MetaData { get; set; } = null;
+        public PrerecordedTranscriptionMetaData MetaData { get; set; } = null;
 
         /// <summary>
         /// Results of the transcription
         /// </summary>
         [JsonProperty("results")]
-        public PrerecordedTranscriptionResult? Results { get; set; } = null;
+        public PrerecordedTranscriptionResult Results { get; set; } = null;
 
         public string ToWebVTT()
         {

--- a/Deepgram/Transcription/PrerecordedTranscriptionClient.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionClient.cs
@@ -21,7 +21,7 @@ namespace Deepgram.Transcription
         /// <param name="source">Url source to send for transcription</param>
         /// <param name="options">Feature options for the transcription</param>
         /// <returns>Transcription of the provided audio</returns>
-        public async Task<PrerecordedTranscription> GetTranscriptionAsync(UrlSource source, PrerecordedTranscriptionOptions? options)
+        public async Task<PrerecordedTranscription> GetTranscriptionAsync(UrlSource source, PrerecordedTranscriptionOptions options)
         {
             return await ApiRequest.DoRequestAsync<PrerecordedTranscription>(
                 HttpMethod.Post,
@@ -37,7 +37,7 @@ namespace Deepgram.Transcription
         /// <param name="source">Audio source to send for transcription</param>
         /// <param name="options">Feature options for the transcription</param>
         /// <returns>Transcription of the provided audio</returns>
-        public async Task<PrerecordedTranscription> GetTranscriptionAsync(StreamSource source, PrerecordedTranscriptionOptions? options)
+        public async Task<PrerecordedTranscription> GetTranscriptionAsync(StreamSource source, PrerecordedTranscriptionOptions options)
         {
             return await ApiRequest.DoStreamRequestAsync<PrerecordedTranscription>(
                 HttpMethod.Post,

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
@@ -9,103 +9,103 @@ namespace Deepgram.Transcription
         /// AI model used to process submitted audio
         /// </summary>
         [JsonProperty("model")]
-        public string? Model { get; set; } = null;
+        public string Model { get; set; } = null;
 
         /// <summary>
         /// Version of the model to use.
         /// </summary>
         [JsonProperty("version")]
-        public string? Version { get; set; } = null;
+        public string Version { get; set; } = null;
 
         /// <summary>
         /// BCP-47 language tag that hints at the primary spoken language.
         /// </summary>
         [JsonProperty("language")]
-        public string? Language { get; set; } = null;
+        public string Language { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to add punctuation and capitalization to the transcript.
         /// </summary>
         [JsonProperty("punctuate")]
-        public bool? Punctuate { get; set; } = null;
+        public Nullable<bool> Punctuate { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to remove profanity from the transcript.
         /// </summary>
         [JsonProperty("profanity_filter")]
-        public bool? ProfanityFilter { get; set; } = null;
+        public Nullable<bool> ProfanityFilter { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to redact sensitive information, replacing redacted content with asterisks (*).
         /// </summary>
         /// <remarks>Possible values are: pci, numbers, ssn</remarks>
         [JsonProperty("redact")]
-        public string[]? Redaction { get; set; }
+        public string[] Redaction { get; set; }
 
         /// <summary>
         /// Indicates whether to recognize speaker changes. When set to true, each word in the transcript
         /// will be assigned a speaker number starting at 0. 
         /// </summary>
         [JsonProperty("diarize")]
-        public bool? Diarize { get; set; } = null;
+        public Nullable<bool> Diarize { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
         /// between characters identified as part of an alphanumeric string. 
         /// </summary>
         [JsonProperty("ner")]
-        public bool? NamedEntityRecognition { get; set; } = null;
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]
-        public bool? MultiChannel { get; set; } = null;
+        public Nullable<bool> MultiChannel { get; set; } = null;
 
         /// <summary>
         /// Maximum number of transcript alternatives to return.
         /// </summary>
         [JsonProperty("alternatives")]
-        public int? Alternatives { get; set; } = null;
+        public Nullable<int> Alternatives { get; set; } = null;
 
         /// <summary>
         /// Indicates whether to convert numbers from written format (e.g., one) to numerical format (e.g., 1).
         /// </summary>
         [JsonProperty("numerals")]
-        public bool? Numerals { get; set; } = null;
+        public Nullable<bool> Numerals { get; set; } = null;
 
         /// <summary>
         /// Terms or phrases to search for in the submitted audio.
         /// </summary>
         [JsonProperty("search")]
-        public string[]? SearchTerms { get; set; }
+        public string[] SearchTerms { get; set; }
 
         /// <summary>
         /// Callback URL to provide if you would like your submitted audio to be processed asynchronously.
         /// When passed, Deepgram will immediately respond with a request_id. 
         /// </summary>
         [JsonProperty("callback")]
-        public string? Callback { get; set; } = null;
+        public string Callback { get; set; } = null;
 
         /// <summary>
         /// Keywords to which the model should pay particular attention to boosting or suppressing to help
         /// it understand context.
         /// </summary>
         [JsonProperty("keywords")]
-        public string[]? Keywords { get; set; }
+        public string[] Keywords { get; set; }
 
         /// <summary>
         /// Indicates whether Deepgram will segment speech into meaningful semantic units, which allows
         /// the model to interact more naturally and effectively with speakers' spontaneous speech patterns.
         /// </summary>
         [JsonProperty("utterances")]
-        public bool? Utterances { get; set; } = null;
+        public Nullable<bool> Utterances { get; set; } = null;
 
         /// <summary>
         /// Length of time in seconds of silence between words that Deepgram will use when determining
         /// where to split utterances.
         /// </summary>
         [JsonProperty("utt_split")]
-        public decimal? UtteranceSplit { get; set; } = null;
+        public Nullable<decimal> UtteranceSplit { get; set; } = null;
     }
 }

--- a/Deepgram/Transcription/PrerecordedTranscriptionResult.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionResult.cs
@@ -9,12 +9,12 @@ namespace Deepgram.Transcription
         /// Array of Channel objects.
         /// </summary>
         [JsonProperty("channels")]
-        public Channel[]? Channels { get; set; }
+        public Channel[] Channels { get; set; }
 
         /// <summary>
         /// Array of Utterance objects. 
         /// </summary>
         [JsonProperty("utterances")]
-        public Utterance[]? Utterances { get; set; }
+        public Utterance[] Utterances { get; set; }
     }
 }

--- a/Deepgram/Usage/IUsageClient.cs
+++ b/Deepgram/Usage/IUsageClient.cs
@@ -11,7 +11,7 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>Usage Requests that fit the parameters provided</returns>
-        Task<ListAllRequestsResponse> ListAllRequestsAsync(string projectId, ListAllRequestsOptions? options);
+        Task<ListAllRequestsResponse> ListAllRequestsAsync(string projectId, ListAllRequestsOptions options);
 
         /// <summary>
         /// Returns details about a specific request to the Deepgram API
@@ -27,7 +27,7 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>Summary of usage statistics</returns>
-        Task<UsageSummary> GetUsageSummaryAsync(string projectId, GetUsageSummaryOptions? options);
+        Task<UsageSummary> GetUsageSummaryAsync(string projectId, GetUsageSummaryOptions options);
 
         /// <summary>
         /// Retrieves a list of features, models, tags, languages, and processing method used for requests in the specified project.
@@ -35,6 +35,6 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>List of features, models, tags, languages, and processing method used for requests in the specified project.</returns>
-        Task<UsageFields> GetUsageFieldsAsync(string projectId, GetUsageFieldsOptions? options);
+        Task<UsageFields> GetUsageFieldsAsync(string projectId, GetUsageFieldsOptions options);
     }
 }

--- a/Deepgram/Usage/UsageClient.cs
+++ b/Deepgram/Usage/UsageClient.cs
@@ -20,7 +20,7 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>Usage Requests that fit the parameters provided</returns>
-        public async Task<ListAllRequestsResponse> ListAllRequestsAsync(string projectId, ListAllRequestsOptions? options)
+        public async Task<ListAllRequestsResponse> ListAllRequestsAsync(string projectId, ListAllRequestsOptions options)
         {
             return await ApiRequest.DoRequestAsync<ListAllRequestsResponse>(    
                 HttpMethod.Get,
@@ -51,7 +51,7 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>Summary of usage statistics</returns>
-        public async Task<UsageSummary> GetUsageSummaryAsync(string projectId, GetUsageSummaryOptions? options)
+        public async Task<UsageSummary> GetUsageSummaryAsync(string projectId, GetUsageSummaryOptions options)
         {
             return await ApiRequest.DoRequestAsync<UsageSummary>(
                 HttpMethod.Get,
@@ -67,7 +67,7 @@ namespace Deepgram.Usage
         /// <param name="projectId">Unique identifier of the project to report on</param>
         /// <param name="options">Pagination & filtering options</param>
         /// <returns>List of features, models, tags, languages, and processing method used for requests in the specified project.</returns>
-        public async Task<UsageFields> GetUsageFieldsAsync(string projectId, GetUsageFieldsOptions? options)
+        public async Task<UsageFields> GetUsageFieldsAsync(string projectId, GetUsageFieldsOptions options)
         {
             return await ApiRequest.DoRequestAsync<UsageFields>(
                 HttpMethod.Get,

--- a/Deepgram/Usage/UsageRequest.cs
+++ b/Deepgram/Usage/UsageRequest.cs
@@ -34,12 +34,12 @@ namespace Deepgram.Usage
         /// </summary>
         /// <remarks>If a response has not yet been generated, this object will be empty.</remarks>
         [JsonProperty("response")]
-        public UsageRequestResponse? Response { get; set; }
+        public UsageRequestResponse Response { get; set; }
 
         /// <summary>
         /// Only exists if a callback was included in the request.
         /// </summary>
         [JsonProperty("callback")]
-        public UsageRequestCallback? Callback { get; set; }
+        public UsageRequestCallback Callback { get; set; }
     }
 }

--- a/Deepgram/Usage/UsageRequestResponse.cs
+++ b/Deepgram/Usage/UsageRequestResponse.cs
@@ -9,7 +9,7 @@ namespace Deepgram.Usage
         /// Details of the request
         /// </summary>
         [JsonProperty("details")]
-        public UsageRequestResponseDetail? Details {get;set;}
+        public UsageRequestResponseDetail Details {get;set;}
 
         /// <summary>
         /// If the request failed, this will contain the error message.

--- a/Deepgram/Usage/UsageRequestResponseDetail.cs
+++ b/Deepgram/Usage/UsageRequestResponseDetail.cs
@@ -9,31 +9,31 @@ namespace Deepgram.Usage
         /// Cost of the request in USD, if project is non-contract and the requesting account has appropriate permissions.
         /// </summary>
         [JsonProperty("usd")]
-        public decimal? USD { get; set; }
+        public Nullable<decimal> USD { get; set; }
 
         /// <summary>
         /// Length of time (in hours) of audio processed in the request.
         /// </summary>
         [JsonProperty("duration")]
-        public decimal? Duration { get; set; }
+        public Nullable<decimal> Duration { get; set; }
 
         /// <summary>
         /// Number of audio files processed in the request.
         /// </summary>
         [JsonProperty("total_audio")]
-        public int? TotalAudio { get; set; }
+        public Nullable<int> TotalAudio { get; set; }
 
         /// <summary>
         /// Number of channels in the audio associated with the request.
         /// </summary>
         [JsonProperty("channels")]
-        public int? Channels { get; set; }
+        public Nullable<int> Channels { get; set; }
 
         /// <summary>
         /// Number of audio streams associated with the request.
         /// </summary>
         [JsonProperty("streams")]
-        public int? Streams { get; set; }
+        public Nullable<int> Streams { get; set; }
 
         /// <summary>
         /// Model applied when running the request.
@@ -51,18 +51,18 @@ namespace Deepgram.Usage
         /// List of tags applied when running the request.
         /// </summary>
         [JsonProperty("tags")]
-        public string[]? Tags { get; set; }
+        public string[] Tags { get; set; }
 
         /// <summary>
         /// List of features used when running the request.
         /// </summary>
         [JsonProperty("features")]
-        public string[]? Features{ get; set; }
+        public string[] Features{ get; set; }
 
         /// <summary>
         /// Configuration used when running the request.
         /// </summary>
         [JsonProperty("config")]
-        public UsageRequestResponseConfig? Config { get; set; }
+        public UsageRequestResponseConfig Config { get; set; }
     }
 }


### PR DESCRIPTION
Here's a brief recap of the changes


* for reference types, removed explicit nullable type (`T?`)
* for value types, types that were nullable and used the `T?` operator was replaced with `Nullable<T>`
* there wasn't a constant for PATCH
* disabled C# 8.0 nullable feature
* added System.Threading.Channels as a dependency since .net standard 2.0 doesn't include it

For the C# 8.0 nullable feature, I didn't look at what it was originally, but if I'm understanding correctly, it makes reference types non-nullable unless specified by `T?`. That might not be desirable, `Nullable<T>` can replace it and works in netstandard2.0, but it won't compile with the nullable feature enabled. I'm not sure if that feature can be enabled when targeting netstandard2.0.

closes #7



┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1201885737791795/1202162386080505) by [Unito](https://www.unito.io)
