### PR TITLE
Add missing TotalHours as per API Docs

### DIFF
--- a/Deepgram/Usage/UsageSummaryResult.cs
+++ b/Deepgram/Usage/UsageSummaryResult.cs
@@ -24,6 +24,12 @@ namespace Deepgram.Usage
         public decimal Hours { get; set; }
 
         /// <summary>
+        /// Length of time (in hours) of audio processed in included requests.
+        /// </summary>
+        [JsonProperty("total_hours")]
+        public decimal TotalHours { get; set; }
+        
+        /// <summary>
         /// Number of included requests.
         /// </summary>
         [JsonProperty("requests")]

--- a/Deepgram/Usage/UsageSummaryResult.cs
+++ b/Deepgram/Usage/UsageSummaryResult.cs
@@ -18,7 +18,7 @@ namespace Deepgram.Usage
         public DateTime EndDateTime { get; set; }
 
         /// <summary>
-        /// Length of time (in hours) of audio processed in included requests.
+        /// Length of time (in hours) of audio submitted in included requests.
         /// </summary>
         [JsonProperty("hours")]
         public decimal Hours { get; set; }


### PR DESCRIPTION
Add missing ```TotalHours``` property to ```UsageSummaryResults``` class. Resolves #29.

Ref: https://developers.deepgram.com/api-reference/#usage-summary