### PR TITLE
Adding flag to require SSL or not

### DIFF
--- a/Deepgram/Credentials.cs
+++ b/Deepgram/Credentials.cs
@@ -14,10 +14,12 @@ namespace Deepgram
         /// </summary>
         /// <param name="apiKey">Deepgram API Key</param>
         /// <param name="apiUrl">Url of Deepgram API</param>
-        public Credentials(string apiKey = null, string apiUrl = null)
+        /// <param name="requireSSL">Require SSL on requests</param>
+        public Credentials(string apiKey = null, string apiUrl = null, bool requireSSL = true)
         {
             ApiKey = apiKey;
             ApiUrl = apiUrl;
+            RequireSSL = requireSSL;
         }
 
         /// <summary>
@@ -29,5 +31,10 @@ namespace Deepgram
         /// On-premise Url of the Deepgram API
         /// </summary>
         public string ApiUrl { get; set; } = null;
+
+        /// <summary>
+        /// Require SSL on requests
+        /// </summary>
+        public Nullable<bool> RequireSSL { get; set; } = null;
     }
 }

--- a/Deepgram/DeepgramClient.cs
+++ b/Deepgram/DeepgramClient.cs
@@ -47,6 +47,7 @@ namespace Deepgram
         {
             string apiUrl = string.IsNullOrWhiteSpace(credentials?.ApiUrl) ? "" : credentials.ApiUrl;
             string apiKey = string.IsNullOrWhiteSpace(credentials?.ApiKey) ? "" : credentials.ApiKey;
+            Nullable<bool> requireSSL = credentials?.RequireSSL;
 
             if (string.IsNullOrEmpty(apiKey))
             {
@@ -72,7 +73,19 @@ namespace Deepgram
                     apiUrl = possibleUri;
                 }
             }
-            _credentials = new CleanCredentials(apiKey, apiUrl);
+            if (!requireSSL.HasValue)
+            {
+                string possibleRequireSSL = Configuration.Instance.Settings["appSettings:Deepgram.Api.RequireSSL"];
+                if (string.IsNullOrEmpty(possibleRequireSSL))
+                {
+                    requireSSL = true;
+                }
+                else
+                {
+                    requireSSL = Convert.ToBoolean(possibleRequireSSL);
+                }
+            }
+            _credentials = new CleanCredentials(apiKey, apiUrl, requireSSL.Value);
         }
 
         private void InitializeClients()

--- a/Deepgram/Request/ApiRequest.cs
+++ b/Deepgram/Request/ApiRequest.cs
@@ -15,7 +15,7 @@ namespace Deepgram.Request
     public class ApiRequest
     {
         const string LOGGER_CATEGORY = "Deepgram.Request.ApiRequest";
-      
+
         private static void SetHeaders(ref HttpRequestMessage request, CleanCredentials credentials)
         {
             request.Headers.Add("Accept", "application/json");
@@ -89,12 +89,14 @@ namespace Deepgram.Request
 
         private static Uri GetUriWithQuerystring(CleanCredentials credentials, string uri, object queryParameters = null)
         {
+            string protocol = credentials.RequireSSL ? "https" : "http";
+
             if (null != queryParameters)
             {
                 var querystring = Helpers.GetParameters(queryParameters);
-                return new Uri($"https://{credentials.ApiUrl}{uri}?{querystring}");
+                return new Uri($"{protocol}://{credentials.ApiUrl}{uri}?{querystring}");
             }
-            return new Uri($"https://{credentials.ApiUrl}{uri}");
+            return new Uri($"{protocol}://{credentials.ApiUrl}{uri}");
         }
 
         private static async Task<T> SendHttpRequestAsync<T>(HttpRequestMessage request)

--- a/Deepgram/Request/CleanCredentials.cs
+++ b/Deepgram/Request/CleanCredentials.cs
@@ -9,7 +9,8 @@ namespace Deepgram.Request
         /// </summary>
         /// <param name="apiKey">Deepgram API Key</param>
         /// <param name="apiUrl">Url of Deepgram API</param>
-        public CleanCredentials(string apiKey, string apiUrl)
+        /// <param name="requireSSL">Require SSL on requests</param>
+        public CleanCredentials(string apiKey, string apiUrl, bool requireSSL)
         {
             ApiKey = apiKey;
 
@@ -21,6 +22,7 @@ namespace Deepgram.Request
             }
 
             ApiUrl = apiUrl;
+            RequireSSL = requireSSL;
         }
 
         /// <summary>
@@ -33,10 +35,14 @@ namespace Deepgram.Request
         /// </summary>
         public string ApiUrl { get; set; }
 
+        /// <summary>
+        /// Require SSL on requests
+        /// </summary>
+        public bool RequireSSL { get; set; }
+
         public Credentials ToCredentials()
         {
-            return new Credentials(ApiKey, ApiUrl);
+            return new Credentials(ApiKey, ApiUrl, RequireSSL);
         }
-
     }
 }

--- a/Deepgram/Transcription/LiveTranscriptionClient.cs
+++ b/Deepgram/Transcription/LiveTranscriptionClient.cs
@@ -183,12 +183,14 @@ namespace Deepgram.Transcription
 
         private Uri GetWSSUriWithQuerystring(string uri, LiveTranscriptionOptions queryParameters)
         {
+            string protocol = _credentials.RequireSSL ? "wss" : "ws";
+
             if (null != queryParameters)
             {
                 var queryString = Helpers.GetParameters(queryParameters);
-                return new Uri($"wss://{_credentials.ApiUrl}{uri}?{queryString}");
+                return new Uri($"{protocol}://{_credentials.ApiUrl}{uri}?{queryString}");
             }
-            return new Uri($"wss://{_credentials.ApiUrl}{uri}");
+            return new Uri($"{protocol}://{_credentials.ApiUrl}{uri}");
         }
 
         private async Task ProcessSenderQueue()


### PR DESCRIPTION
Added a constructor flag to require SSL on http or ws connections. This defaults to true, but can be set to false. This will primarily be used by on-prem customers.