### PR TITLE
Updated logging to use ConcurrentDictionary

### DIFF
--- a/Deepgram/Logger/LogProvider.cs
+++ b/Deepgram/Logger/LogProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,7 +8,7 @@ namespace Deepgram.Logger
 {
     public class LogProvider
     {
-        private static IDictionary<string, ILogger> _loggers = new Dictionary<string, ILogger>();
+        private static IDictionary<string, ILogger> _loggers = new ConcurrentDictionary<string, ILogger>();
         private static ILoggerFactory _loggerFactory = new LoggerFactory();
 
         public static void SetLogFactory(ILoggerFactory factory)


### PR DESCRIPTION
A recent support request flagged an issue with concurrency that could be related to our `LogProvider`.

In reviewing it, I found we were using a `Dictionary` to store loggers. I replaced this with a `ConcurrentDictionary`. The `Dictionary` class is known to not be thread safe.