### PR TITLE
fix: Handle response difference between synchronous and asynchronous transcription

### DIFF
--- a/Deepgram.Tests/Deepgram.Tests.csproj
+++ b/Deepgram.Tests/Deepgram.Tests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="Codenizer.HttpClient.Testable" Version="2.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Deepgram.Tests/Transcription/PrerecordedTranscriptionClientTests.cs
+++ b/Deepgram.Tests/Transcription/PrerecordedTranscriptionClientTests.cs
@@ -1,0 +1,104 @@
+﻿using System.Net;
+using System.Web;
+using Bogus;
+using Codenizer.HttpClient.Testable;
+using Deepgram.Request;
+using Deepgram.Transcription;
+using Newtonsoft.Json;
+
+namespace Deepgram.Tests.Transcription
+{
+    public class PrerecordedTranscriptionClientTests : IDisposable
+    {
+        private readonly TestableMessageHandler _testHandler = new();
+        private readonly Faker _faker = new ();
+        private readonly HttpMessageHandler _defaultHandler;
+
+        public PrerecordedTranscriptionClientTests()
+        {
+            _defaultHandler = Configuration.Instance.ClientHandler;
+            Configuration.Instance.ClientHandler = _testHandler;
+        }
+
+        [Fact]
+        public async Task GetTranscriptionFromUrlWithCallbackAsyncShouldMakeRequestWithCallbackReturnRequestId()
+        {
+            var client = CreateClient();
+            var requestId = Guid.NewGuid().ToString();
+            var callback = _faker.Internet.Url();
+            _testHandler.RespondTo()
+                .Post()
+                .ForUrl("/v1/listen?callback=*")
+                .WithQueryStringParameter("callback")
+                .HavingValue(HttpUtility.UrlEncode(callback))
+                .With(HttpStatusCode.OK)
+                .AndContent("application/json",
+                    JsonConvert.SerializeObject(new PrerecordedTranscriptionRequest() { Id = requestId }));
+
+            var result = await client.GetTranscriptionWithCallbackAsync(new UrlSource(_faker.Internet.Url()),
+                new PrerecordedTranscriptionOptionsWithCallback() { Callback = callback });
+            
+            Assert.Equal(requestId, result.Id);
+        }
+        
+        [Fact]
+        public async Task GetTranscriptionFromUrlWithCallbackAsyncShouldThrowWhenNoCallbackProvided()
+        {
+            var client = CreateClient();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await client.GetTranscriptionWithCallbackAsync(new UrlSource(_faker.Internet.Url()),
+                    new PrerecordedTranscriptionOptionsWithCallback() { Callback = null }));
+    
+            Assert.Matches("Callback is required", exception.Message);
+        }
+        
+        [Fact]
+        public async Task GetTranscriptionFromStreamWithCallbackAsyncShouldMakeRequestWithCallbackReturnRequestId()
+        {
+            var client = CreateClient();
+            var requestId = Guid.NewGuid().ToString();
+            var callback = _faker.Internet.Url();
+            _testHandler.RespondTo()
+                .Post()
+                .ForUrl("/v1/listen?callback=*")
+                .WithQueryStringParameter("callback")
+                .HavingValue(HttpUtility.UrlEncode(callback))
+                .AndContentType("audio/wav")
+                .With(HttpStatusCode.OK)
+                .AndContent("application/json",
+                    JsonConvert.SerializeObject(new PrerecordedTranscriptionRequest() { Id = requestId }));
+            using var stream = new MemoryStream(_faker.Random.Bytes(100));
+
+            var result = await client.GetTranscriptionWithCallbackAsync(new StreamSource(stream, "audio/wav"),
+                new PrerecordedTranscriptionOptionsWithCallback() { Callback = callback });
+            
+            Assert.Equal(requestId, result.Id);
+        }
+        
+        [Fact]
+        public async Task GetTranscriptionFromStreamWithCallbackAsyncShouldThrowWhenNoCallbackProvided()
+        {
+            var client = CreateClient();
+            using var stream = new MemoryStream();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await client.GetTranscriptionWithCallbackAsync(new StreamSource(stream, "audio/wav"),
+                    new PrerecordedTranscriptionOptionsWithCallback() { Callback = null }));
+    
+            Assert.Matches("Callback is required", exception.Message);
+        }
+
+        public void Dispose()
+        {
+            Configuration.Instance.ClientHandler = _defaultHandler;
+            _testHandler.Dispose();
+        }
+
+        private PrerecordedTranscriptionClient CreateClient()
+        {
+            return new PrerecordedTranscriptionClient(new CleanCredentials(_faker.Internet.Password(),
+                _faker.Internet.DomainName(), true));
+        }
+    }
+}

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -39,4 +39,9 @@
     <EditorConfigFiles Remove="D:\Sources\deepgram\deepgram-dotnet-sdk\Deepgram\.editorconfig" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>$(AssemblyName).Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/Deepgram/Transcription/IPrerecordedTranscriptionClient.cs
+++ b/Deepgram/Transcription/IPrerecordedTranscriptionClient.cs
@@ -20,5 +20,21 @@ namespace Deepgram.Transcription
         /// <param name="options">Feature options for the transcription</param>
         /// <returns>Transcription of the provided audio</returns>
         Task<PrerecordedTranscription> GetTranscriptionAsync(StreamSource source, PrerecordedTranscriptionOptions options);
+        
+        /// <summary>
+        /// Submits a request to the Deepgram API to transcribe prerecorded audio with callback url
+        /// </summary>
+        /// <param name="source">Url source to send for transcription</param>
+        /// <param name="options">Feature options for the transcription</param>
+        /// <returns>Transcription request id</returns>
+        Task<PrerecordedTranscriptionRequest> GetTranscriptionWithCallbackAsync(UrlSource source, PrerecordedTranscriptionOptionsWithCallback options);
+        
+        /// <summary>
+        /// Submits a request to the Deepgram API to transcribe prerecorded audio with callback url
+        /// </summary>
+        /// <param name="source">Audio source to send for transcription</param>
+        /// <param name="options">Feature options for the transcription</param>
+        /// <returns>Transcription request id</returns>
+        Task<PrerecordedTranscriptionRequest> GetTranscriptionWithCallbackAsync(StreamSource source, PrerecordedTranscriptionOptionsWithCallback options);
     }
 }

--- a/Deepgram/Transcription/PrerecordedTranscriptionClient.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Net.Http;
-using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Deepgram.Request;
 
@@ -45,6 +44,40 @@ namespace Deepgram.Transcription
                 _credentials,
                 source,
                 options);
+        }
+
+        /// <inheritdoc />
+        public async Task<PrerecordedTranscriptionRequest> GetTranscriptionWithCallbackAsync(UrlSource source, PrerecordedTranscriptionOptionsWithCallback options)
+        {
+            ValidationOptionsWithCallback(options);
+    
+            return await ApiRequest.DoRequestAsync<PrerecordedTranscriptionRequest>(
+                HttpMethod.Post,
+                "/v1/listen",
+                _credentials,
+                options,
+                source);
+        }
+
+        /// <inheritdoc />
+        public async Task<PrerecordedTranscriptionRequest> GetTranscriptionWithCallbackAsync(StreamSource source, PrerecordedTranscriptionOptionsWithCallback options)
+        {
+            ValidationOptionsWithCallback(options);
+
+            return await ApiRequest.DoStreamRequestAsync<PrerecordedTranscriptionRequest>(
+                HttpMethod.Post,
+                "/v1/listen",
+                _credentials,
+                source,
+                options);
+        }
+
+        private void ValidationOptionsWithCallback(PrerecordedTranscriptionOptionsWithCallback options)
+        {
+            if (string.IsNullOrEmpty(options.Callback))
+            {
+                throw new ArgumentException("Callback is required", nameof(options));
+            }
         }
     }
 }

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
@@ -158,13 +158,6 @@ namespace Deepgram.Transcription
         public string[] Replace { get; set; } = null;
 
         /// <summary>
-        /// Callback URL to provide if you would like your submitted audio to be processed asynchronously.
-        /// When passed, Deepgram will immediately respond with a request_id. 
-        /// </summary>
-        [JsonProperty("callback")]
-        public string Callback { get; set; } = null;
-
-        /// <summary>
         /// Keywords to which the model should pay particular attention to boosting or suppressing to help
         /// it understand context.
         /// </summary>

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptionsWithCallback.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptionsWithCallback.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace Deepgram.Transcription
+{
+    public class PrerecordedTranscriptionOptionsWithCallback : PrerecordedTranscriptionOptions
+    {
+        /// <summary>
+        /// Callback URL to provide if you would like your submitted audio to be processed asynchronously.
+        /// When passed, Deepgram will immediately respond with a request_id. 
+        /// </summary>
+        [JsonProperty("callback")]
+        public string Callback { get; set; } = null;
+    }
+}

--- a/Deepgram/Transcription/PrerecordedTranscriptionRequest.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionRequest.cs
@@ -1,0 +1,13 @@
+﻿using Newtonsoft.Json;
+
+namespace Deepgram.Transcription
+{
+    public class PrerecordedTranscriptionRequest
+    {
+        /// <summary>
+        /// Unique identifier for the submitted audio and derived data returned.
+        /// </summary>
+        [JsonProperty("request_id")]
+        public string Id { get; set; }
+    }
+}


### PR DESCRIPTION
Synchronous request for transcription has following response:
![image](https://user-images.githubusercontent.com/1872946/213172535-9bfea38a-d1af-442d-9c3e-888ca7a007b7.png)
And this response is supported by current `PrerecordedTranscription` response model

But if you add `callback` parameter response is completely different  
![image](https://user-images.githubusercontent.com/1872946/213172790-54f9a9fc-b984-458f-89e7-111b81bd045e.png)
And PrerecordedTranscription is null for than case. 

This PR contains breaking change. Callback option removed from `GetTranscriptionAsync` `PrerecordedTranscriptionOptions` options. 
It is now available in `GetTranscriptionWithCallbackAsync` as part of `PrerecordedTranscriptionOptionsWithCallback`

