### PR TITLE
Deprecate NamedEntityRecognition parameter

### DIFF
--- a/Deepgram/Transcription/LiveTranscriptionOptions.cs
+++ b/Deepgram/Transcription/LiveTranscriptionOptions.cs
@@ -65,6 +65,14 @@ namespace Deepgram.Transcription
         public string DiarizationVersion { get; set; } = null;
 
         /// <summary>
+        /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
+        /// between characters identified as part of an alphanumeric string.
+        /// </summary>
+        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
+        [JsonProperty("ner")]
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
+
+        /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]

--- a/Deepgram/Transcription/LiveTranscriptionOptions.cs
+++ b/Deepgram/Transcription/LiveTranscriptionOptions.cs
@@ -65,13 +65,6 @@ namespace Deepgram.Transcription
         public string DiarizationVersion { get; set; } = null;
 
         /// <summary>
-        /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
-        /// between characters identified as part of an alphanumeric string. 
-        /// </summary>
-        [JsonProperty("ner")]
-        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
-
-        /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]

--- a/Deepgram/Transcription/LiveTranscriptionOptions.cs
+++ b/Deepgram/Transcription/LiveTranscriptionOptions.cs
@@ -66,7 +66,7 @@ namespace Deepgram.Transcription
 
         /// <summary>
         /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
-        /// between characters identified as part of an alphanumeric string.
+        /// between characters identified as part of an alphanumeric string. 
         /// </summary>
         [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
         [JsonProperty("ner")]

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
@@ -65,6 +65,14 @@ namespace Deepgram.Transcription
         public string DiarizationVersion { get; set; } = null;
 
         /// <summary>
+        /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
+        /// between characters identified as part of an alphanumeric string.
+        /// </summary>
+        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
+        [JsonProperty("ner")]
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
+
+        /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
@@ -65,13 +65,6 @@ namespace Deepgram.Transcription
         public string DiarizationVersion { get; set; } = null;
 
         /// <summary>
-        /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
-        /// between characters identified as part of an alphanumeric string. 
-        /// </summary>
-        [JsonProperty("ner")]
-        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
-
-        /// <summary>
         /// Indicates whether to transcribe each audio channel independently.
         /// </summary>
         [JsonProperty("multichannel")]

--- a/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
+++ b/Deepgram/Transcription/PrerecordedTranscriptionOptions.cs
@@ -66,7 +66,7 @@ namespace Deepgram.Transcription
 
         /// <summary>
         /// Indicates whether to recognize alphanumeric strings. When set to true, whitespace will be removed
-        /// between characters identified as part of an alphanumeric string.
+        /// between characters identified as part of an alphanumeric string. 
         /// </summary>
         [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
         [JsonProperty("ner")]

--- a/Deepgram/Usage/GetUsageSummaryOptions.cs
+++ b/Deepgram/Usage/GetUsageSummaryOptions.cs
@@ -60,12 +60,6 @@ namespace Deepgram.Usage
         public Nullable<bool> Punctuate { get; set; } = null;
 
         /// <summary>
-        /// Limits results to requests that include the ner feature.
-        /// </summary>
-        [JsonProperty("ner")]
-        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
-
-        /// <summary>
         /// Limits results to requests that include the utterances feature.
         /// </summary>
         [JsonProperty("utterances")]

--- a/Deepgram/Usage/GetUsageSummaryOptions.cs
+++ b/Deepgram/Usage/GetUsageSummaryOptions.cs
@@ -60,6 +60,13 @@ namespace Deepgram.Usage
         public Nullable<bool> Punctuate { get; set; } = null;
 
         /// <summary>
+        /// Limits results to requests that include the ner feature.
+        /// </summary>
+        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
+        [JsonProperty("ner")]
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
+
+        /// <summary>
         /// Limits results to requests that include the utterances feature.
         /// </summary>
         [JsonProperty("utterances")]
@@ -70,13 +77,6 @@ namespace Deepgram.Usage
         /// </summary>
         [JsonProperty("replace")]
         public Nullable<bool> Replace { get; set; } = null;
-
-        /// <summary>
-        /// Limits results to requests that include the ner feature.
-        /// </summary>
-        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
-        [JsonProperty("ner")]
-        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
 
         /// <summary>
         /// Limits results to requests that include the profanity_filter feature.

--- a/Deepgram/Usage/GetUsageSummaryOptions.cs
+++ b/Deepgram/Usage/GetUsageSummaryOptions.cs
@@ -72,6 +72,13 @@ namespace Deepgram.Usage
         public Nullable<bool> Replace { get; set; } = null;
 
         /// <summary>
+        /// Limits results to requests that include the ner feature.
+        /// </summary>
+        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
+        [JsonProperty("ner")]
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
+
+        /// <summary>
         /// Limits results to requests that include the profanity_filter feature.
         /// </summary>
         [JsonProperty("profanity_filter")]

--- a/Deepgram/Usage/UsageRequestResponseConfig.cs
+++ b/Deepgram/Usage/UsageRequestResponseConfig.cs
@@ -66,6 +66,13 @@ namespace Deepgram.Usage
         public string Model { get; set; } = null;
 
         /// <summary>
+        /// Indicates whether named-entity recognition (NER) was requested.
+        /// </summary>
+        [Obsolete("NamedEntityRecognition is deprecated in favor of SmartFormat.")]
+        [JsonProperty("ner")]
+        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
+
+        /// <summary>
         /// Indicates whether numeral conversion was requested.
         /// </summary>
         [JsonProperty("numerals")]

--- a/Deepgram/Usage/UsageRequestResponseConfig.cs
+++ b/Deepgram/Usage/UsageRequestResponseConfig.cs
@@ -66,12 +66,6 @@ namespace Deepgram.Usage
         public string Model { get; set; } = null;
 
         /// <summary>
-        /// Indicates whether named-entity recognition (NER) was requested.
-        /// </summary>
-        [JsonProperty("ner")]
-        public Nullable<bool> NamedEntityRecognition { get; set; } = null;
-
-        /// <summary>
         /// Indicates whether numeral conversion was requested.
         /// </summary>
         [JsonProperty("numerals")]


### PR DESCRIPTION
NamedEntityRecognition (NER) has been deprecated in favor of improved Smart Formatting, so it no longer makes sense to get/set this parameter.

(Note that as of June 2023, NER is still bundled within Smart Formatting for Basic and Enhanced tiers.)

Edit: We will be deprecating rather than removing this parameter. 