### PR TITLE
Client unit tests

### DIFF
--- a/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
+++ b/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Deepgram.Clients;
 using Deepgram.Interfaces;
 using Deepgram.Tests.Fakes;
 using Deepgram.Utilities;
@@ -29,10 +30,10 @@ namespace Deepgram.Tests.ClientTests
 
             //Assert
             Assert.NotNull(result);
-            Assert.IsAssignableFrom<IKeyClient>(result.Keys);
-            Assert.IsAssignableFrom<IProjectClient>(result.Projects);
-            Assert.IsAssignableFrom<ITranscriptionClient>(result.Transcription);
-            Assert.IsAssignableFrom<IUsageClient>(result.Usage);
+            Assert.IsAssignableFrom<KeyClient>(result.Keys);
+            Assert.IsAssignableFrom<ProjectClient>(result.Projects);
+            Assert.IsAssignableFrom<TranscriptionClient>(result.Transcription);
+            Assert.IsAssignableFrom<UsageClient>(result.Usage);
         }
 
         [Fact]

--- a/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
+++ b/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Deepgram.Interfaces;
+using Deepgram.Utilities;
+using Xunit;
+
+namespace Deepgram.Tests.ClientTests
+{
+    public class DeepClientTests
+    {
+        [Fact]
+        public void Should_Throw_Exception_When_No_Apikey_Present()
+        {
+            //Act
+            var ex = Assert.Throws<ArgumentException>(() => _ = new DeepgramClient());
+
+            //Assert
+            Assert.IsAssignableFrom<ArgumentException>(ex);
+            Assert.Equal("Deepgram API Key must be provided in constructor", ex.Message);
+        }
+
+
+        [Fact]
+        public void Should_Initialize_Clients()
+        {
+
+            //Act
+            var result = new DeepgramClient(FakeModels.Credentials);
+
+            //Assert
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<IKeyClient>(result.Keys);
+            Assert.IsAssignableFrom<IProjectClient>(result.Projects);
+            Assert.IsAssignableFrom<ITranscriptionClient>(result.Transcription);
+            Assert.IsAssignableFrom<IUsageClient>(result.Usage);
+        }
+
+        [Fact]
+        public void Should_Initialize_LiveTranscriptionClient()
+        {
+            //Arrange
+
+            var SUT = new DeepgramClient(FakeModels.Credentials);
+            //Act
+
+            var result = SUT.CreateLiveTranscriptionClient();
+
+            //Assert
+            Assert.NotNull(result);
+            Assert.IsAssignableFrom<ILiveTranscriptionClient>(result);
+
+        }
+
+
+        [Theory]
+        [InlineData(2)]
+        [InlineData(10)]
+        [InlineData(20)]
+        [InlineData(30)]
+        public void Should_Set_TimeOut_On_HttpClient(double timeSpan)
+        {
+
+            //Arrange
+            var SUT = new DeepgramClient(FakeModels.Credentials);
+
+            //Act
+            SUT.SetHttpClientTimeout(TimeSpan.FromSeconds(timeSpan));
+            var httpClient = HttpClientUtil.HttpClient;
+
+            //Assert
+            Assert.NotNull(httpClient);
+            Assert.Equal(timeSpan, httpClient.Timeout.TotalSeconds);
+        }
+
+
+    }
+}

--- a/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
+++ b/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Deepgram.Interfaces;
+using Deepgram.Tests.Fakes;
 using Deepgram.Utilities;
 using Xunit;
 

--- a/Deepgram.Tests/ClientTests/KeyClientTests.cs
+++ b/Deepgram.Tests/ClientTests/KeyClientTests.cs
@@ -1,0 +1,13 @@
+﻿using Xunit;
+
+namespace Deepgram.Tests.ClientTests
+{
+    public class KeyClientTests
+    {
+        [Fact]
+        public async void Should()
+        {
+
+        }
+    }
+}

--- a/Deepgram.Tests/FakeHttpMessageHandler.cs
+++ b/Deepgram.Tests/FakeHttpMessageHandler.cs
@@ -34,7 +34,7 @@ namespace Deepgram.Tests
         {
             var httpClient = new HttpClient(CreateMessageHandlerWithResult(result, code).Object)
             {
-                BaseAddress = new Uri("https://api-client-under-test.com"),
+                BaseAddress = new Uri(FakeModels.FullUrl),
             };
 
             return httpClient;

--- a/Deepgram.Tests/FakeModels.cs
+++ b/Deepgram.Tests/FakeModels.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using Deepgram.Models;
+
+namespace Deepgram.Tests
+{
+    public static class FakeModels
+    {
+        public static Credentials Credentials => new Credentials()
+        {
+            ApiKey = ApiKey,
+            ApiUrl = CleanedUrl,
+            RequireSSL = true
+        };
+        public static string ApiKey = Guid.NewGuid().ToString();
+        public static string FullUrl = "http://test.com";
+        public static string CleanedUrl = "test.com";
+        public static string UriSegment = "test";
+
+        public static PrerecordedTranscriptionOptions PrerecordedTranscriptionOptions = new PrerecordedTranscriptionOptions
+        {
+            Keywords = new[] { "key", "word" },
+            Punctuate = true,
+            Utterances = true,
+            Redaction = new[] { "pci", "ssn" },
+            UtteranceSplit = (decimal)2.223,
+            Paragraphs = true,
+            Model = "Model"
+        };
+
+        public static ListAllRequestsOptions ListAllRequestsOptions = new ListAllRequestsOptions()
+        {
+            Limit = 10,
+            StartDateTime = new DateTime(2023, 5, 23)
+        };
+
+        public static UrlSource UrlSource = new UrlSource("https://test.com");
+
+        public static UpdateScopeOptions UpdateScopeOptions = new UpdateScopeOptions() { Scope = "owner" };
+
+        public static Project Project = new Project()
+        {
+            Company = "testCompany",
+            Id = "testId",
+            Name = "test"
+        };
+
+        public static StreamSource StreamSource = new StreamSource(new MemoryStream(new byte[] { 0b1, 0b10, 0b11, 0b100 }), "text/plain");
+
+    }
+}

--- a/Deepgram.Tests/Fakes/FakeHttpMessageHandler.cs
+++ b/Deepgram.Tests/Fakes/FakeHttpMessageHandler.cs
@@ -7,7 +7,7 @@ using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
 
-namespace Deepgram.Tests
+namespace Deepgram.Tests.Fakes
 {
     public static class FakeHttpMessageHandler
     {

--- a/Deepgram.Tests/Fakes/FakeModels.cs
+++ b/Deepgram.Tests/Fakes/FakeModels.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using Deepgram.Models;
 
-namespace Deepgram.Tests
+namespace Deepgram.Tests.Fakes
 {
     public static class FakeModels
     {

--- a/Deepgram.Tests/RequestTests/ApiRequestTests.cs
+++ b/Deepgram.Tests/RequestTests/ApiRequestTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using Deepgram.Models;
 using Deepgram.Request;
+using Deepgram.Tests.Fakes;
 using Xunit;
 
 namespace Deepgram.Tests.RequestTests

--- a/Deepgram.Tests/RequestTests/ApiRequestTests.cs
+++ b/Deepgram.Tests/RequestTests/ApiRequestTests.cs
@@ -12,7 +12,7 @@ namespace Deepgram.Tests.RequestTests
         public async void Should_Return_A_Valid_Object_When_Deserialized()
         {
             //Arrange
-            var responseObject = new Project() { Company = "testCompany", Id = "fakeId", Name = "fakeName" };
+            var responseObject = FakeModels.Project;
             var client = FakeHttpMessageHandler.CreateHttpClientWithResult(responseObject);
             var SUT = new ApiRequest(client);
 

--- a/Deepgram.Tests/RequestTests/RequestMessageBuilderTests.cs
+++ b/Deepgram.Tests/RequestTests/RequestMessageBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http;
 using Deepgram.Models;
 using Deepgram.Request;
+using Deepgram.Tests.Fakes;
 using Xunit;
 
 namespace Deepgram.Tests.RequestTests

--- a/Deepgram.Tests/RequestTests/RequestMessageBuilderTests.cs
+++ b/Deepgram.Tests/RequestTests/RequestMessageBuilderTests.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 using Deepgram.Models;
 using Deepgram.Request;
 using Xunit;
@@ -9,30 +8,22 @@ namespace Deepgram.Tests.RequestTests
     public class RequestMessageBuilderTests
     {
         Credentials Credentials;
-        string Segment;
+
         public RequestMessageBuilderTests()
         {
-            Credentials = new Credentials()
-            {
-                ApiKey = "apikey",
-                ApiUrl = "apiurl.com"
-            };
-
-            Segment = "test";
+            Credentials = FakeModels.Credentials;
         }
-
-
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
         public void CreateHttpRequestMessage_Should_Return_HttpRequestMessage_When_HttpMethod_Is_Get_No_QueryParameters(bool requireSSL)
         {
-            //Arrange
+            //Arrange            
             Credentials.RequireSSL = requireSSL;
 
             //Act
-            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Get, Segment, Credentials);
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Get, FakeModels.UriSegment, Credentials);
 
             //Assert
             Assert.NotNull(result);
@@ -48,12 +39,9 @@ namespace Deepgram.Tests.RequestTests
         {
             //Arrange
             Credentials.RequireSSL = requireSSL;
-            var queryParameters = new LiveTranscriptionOptions()
-            {
-                Keywords = new[] { "key", "word" }
-            };
+
             //Act
-            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Get, Segment, Credentials, null, queryParameters);
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Get, FakeModels.UriSegment, Credentials, null, FakeModels.PrerecordedTranscriptionOptions);
 
             //Assert
             Assert.NotNull(result);
@@ -69,15 +57,9 @@ namespace Deepgram.Tests.RequestTests
         {
             //Arrange
             Credentials.RequireSSL = requireSSL;
-            var urlSource = new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav");
-            var queryParameters = new PrerecordedTranscriptionOptions()
-            {
-                Punctuate = true,
-                Utterances = true,
-                Redaction = new[] { "pci", "ssn" }
-            };
+
             //Act
-            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Post, Segment, Credentials, urlSource, queryParameters);
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Post, FakeModels.UriSegment, Credentials, FakeModels.UrlSource, FakeModels.PrerecordedTranscriptionOptions);
 
             //Assert
             Assert.NotNull(result);
@@ -97,9 +79,9 @@ namespace Deepgram.Tests.RequestTests
         {
             //Arrange
             Credentials.RequireSSL = requireSSL;
-            var body = new UpdateScopeOptions() { Scope = "owner" };
+
             //Act
-            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Put, Segment, Credentials, body, null);
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Put, FakeModels.UriSegment, Credentials, FakeModels.UpdateScopeOptions, null);
 
             //Assert
             Assert.NotNull(result);
@@ -119,21 +101,12 @@ namespace Deepgram.Tests.RequestTests
         {
             //Arrange
             Credentials.RequireSSL = requireSSL;
-            var body = new Project()
-            {
-                Company = "testCompany",
-                Id = "testId",
-                Name = "test"
-            };
             //Act
 
 #if NETSTANDARD2_0
-                   var result = RequestMessageBuilder.CreateHttpRequestMessage(new HttpMethod("PATCH"), Segment, Credentials, body, null);
-
-
-#else
-            //Act
-            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Patch, Segment, Credentials, body, null);
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(new HttpMethod("PATCH"), FakeModels.UriSegment, Credentials, FakeModels.Project, null);
+#else            
+            var result = RequestMessageBuilder.CreateHttpRequestMessage(HttpMethod.Patch, FakeModels.UriSegment, Credentials, FakeModels.Project, null);
 #endif
 
 
@@ -143,7 +116,7 @@ namespace Deepgram.Tests.RequestTests
             var content = result.Content;
             Assert.NotNull(result.Content);
 #if NETSTANDARD2_0
-  Assert.Equal(new HttpMethod("PATCH"), result.Method);
+            Assert.Equal(new HttpMethod("PATCH"), result.Method);
 #else
             Assert.Equal(HttpMethod.Patch, result.Method);
 
@@ -161,13 +134,8 @@ namespace Deepgram.Tests.RequestTests
             //Arrange
             Credentials.RequireSSL = requireSSL;
 
-            var stream = new MemoryStream(new byte[] { 0b1, 0b10, 0b11, 0b100 });
-
-            var streamSource = new StreamSource(stream, "text/plain");
-
-
             //Act
-            var result = RequestMessageBuilder.CreateStreamHttpRequestMessage(HttpMethod.Post, Segment, Credentials, streamSource);
+            var result = RequestMessageBuilder.CreateStreamHttpRequestMessage(HttpMethod.Post, FakeModels.UriSegment, Credentials, FakeModels.StreamSource);
 
             //Assert
             Assert.NotNull(result);

--- a/Deepgram.Tests/SummarizeTest.cs
+++ b/Deepgram.Tests/SummarizeTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Deepgram.Clients;
+﻿using Deepgram.Clients;
 using Deepgram.Models;
 using Deepgram.Request;
 using Deepgram.Tests.Fakes;
@@ -22,25 +21,17 @@ namespace Deepgram.Tests
 
             var client = FakeHttpMessageHandler.CreateHttpClientWithResult(responseObject);
 
-            var creds = new Credentials()
-            {
-                ApiKey = Guid.NewGuid().ToString(),
-                ApiUrl = "test.com",
-                RequireSSL = true,
-            };
-
-            var fakeSource = new UrlSource("https://test.com");
-
             var fakeOptions = new PrerecordedTranscriptionOptions()
             {
                 Summarize = "v2"
             };
 
-            var SUT = new PrerecordedTranscriptionClient(creds);
+            var SUT = new PrerecordedTranscriptionClient(FakeModels.Credentials);
             SUT._apiRequest = new ApiRequest(client);
 
+
             //Act
-            var result = await SUT.GetTranscriptionAsync(fakeSource, fakeOptions);
+            var result = await SUT.GetTranscriptionAsync(FakeModels.UrlSource, fakeOptions);
 
             //Assert         
             Assert.NotNull(result);
@@ -74,25 +65,17 @@ namespace Deepgram.Tests
 
             var client = FakeHttpMessageHandler.CreateHttpClientWithResult(responseObject);
 
-            var creds = new Credentials()
-            {
-                ApiKey = Guid.NewGuid().ToString(),
-                ApiUrl = "test.com",
-                RequireSSL = true,
-            };
-
-            var fakeSource = new UrlSource("https://test.com");
-
             var fakeOptions = new PrerecordedTranscriptionOptions()
             {
                 Summarize = value
             };
 
-            var SUT = new PrerecordedTranscriptionClient(creds);
+            var SUT = new PrerecordedTranscriptionClient(FakeModels.Credentials);
             SUT._apiRequest = new ApiRequest(client);
 
+
             //Act
-            var result = await SUT.GetTranscriptionAsync(fakeSource, fakeOptions);
+            var result = await SUT.GetTranscriptionAsync(FakeModels.UrlSource, fakeOptions);
 
             //Assert         
             Assert.NotNull(result);

--- a/Deepgram.Tests/SummarizeTest.cs
+++ b/Deepgram.Tests/SummarizeTest.cs
@@ -2,6 +2,7 @@
 using Deepgram.Clients;
 using Deepgram.Models;
 using Deepgram.Request;
+using Deepgram.Tests.Fakes;
 using Xunit;
 
 namespace Deepgram.Tests

--- a/Deepgram.Tests/UtilitiesTests/CredentialsUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/CredentialsUtilTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Deepgram.Tests.Fakes;
+using System;
 using Deepgram.Utilities;
 using Xunit;
 

--- a/Deepgram.Tests/UtilitiesTests/CredentialsUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/CredentialsUtilTests.cs
@@ -10,7 +10,7 @@ namespace Deepgram.Tests.UtilitiesTests
         public void CheckApiKey_Should_Return_Same_APIKey_That_Passed_As_Parameter()
         {
             //Act
-            var fakeKey = Guid.NewGuid().ToString();
+            var fakeKey = FakeModels.ApiKey;
             var result = CredentialsUtil.CheckApiKey(fakeKey);
 
             //Assert
@@ -23,7 +23,6 @@ namespace Deepgram.Tests.UtilitiesTests
         public void CheckApiKey_Should_Throw_ArgumentException_If_No_ApiKey_Found()
         {
             //Act
-
             var result = Assert.Throws<ArgumentException>(() => CredentialsUtil.CheckApiKey(null));
 
             //Assert
@@ -34,9 +33,8 @@ namespace Deepgram.Tests.UtilitiesTests
         [Fact]
         public void CheckApiUrl_Should_Return_TrimmedApiUrl_That_Passed_As_Parameter()
         {
-            //Act
-            var fakeUrl = "http://test.com";
-            var result = CredentialsUtil.CleanApiUrl(fakeUrl);
+            //Act            
+            var result = CredentialsUtil.CleanApiUrl(FakeModels.FullUrl);
 
             //Assert
             Assert.NotNull(result);
@@ -50,7 +48,6 @@ namespace Deepgram.Tests.UtilitiesTests
         public void CheckApiUrl_Should_Return_DefaultApiUrl_If_NO_ApiUrl_Present_In_Parameters()
         {
             //Act
-
             var result = CredentialsUtil.CleanApiUrl(null);
 
             //Assert
@@ -68,7 +65,6 @@ namespace Deepgram.Tests.UtilitiesTests
         public void CheckApiUrl_Should_Return_RequireSSL_That_Passed_As_Parameter(bool? requireSSL)
         {
             //Act
-
             var result = CredentialsUtil.CleanRequireSSL(requireSSL);
 
             //Assert

--- a/Deepgram.Tests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Deepgram.Models;
+﻿using Deepgram.Models;
 using Deepgram.Utilities;
 using Xunit;
 
@@ -11,11 +10,7 @@ namespace Deepgram.Tests.UtilitiesTests
         public void GetParameters_Should_Return_String_When_Passing_String_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new LiveTranscriptionOptions()
-            {
-                Model = "Model"
-            };
+            var obj = FakeModels.PrerecordedTranscriptionOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
@@ -28,29 +23,21 @@ namespace Deepgram.Tests.UtilitiesTests
         public void GetParameters_Should_Return_String_When_Passing_Int_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new LiveTranscriptionOptions()
-            {
-                Channels = 1,
-            };
+            var obj = FakeModels.ListAllRequestsOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
 
             //Assert
             Assert.NotNull(result);
-            Assert.Contains($"{nameof(obj.Channels).ToLower()}={obj.Channels}", result);
+            Assert.Contains($"{nameof(obj.Limit).ToLower()}={obj.Limit}", result);
         }
 
         [Fact]
         public void GetParameters_Should_Return_String_When_Passing_Array_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new LiveTranscriptionOptions()
-            {
-                Keywords = new[] { "key", "word" }
-            };
+            var obj = FakeModels.PrerecordedTranscriptionOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
@@ -58,18 +45,14 @@ namespace Deepgram.Tests.UtilitiesTests
             //Assert
             Assert.NotNull(result);
             Assert.Contains($"{nameof(obj.Keywords).ToLower()}={obj.Keywords[0].ToLower()}", result);
-            Assert.Contains($"{nameof(obj.Keywords).ToLower()}={obj.Keywords[1].ToLower()}", result);
+
         }
 
         [Fact]
         public void GetParameters_Should_Return_String_When_Passing_Decimal_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new PrerecordedTranscriptionOptions()
-            {
-                UtteranceSplit = (decimal)2.223
-            };
+            var obj = FakeModels.PrerecordedTranscriptionOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
@@ -83,11 +66,7 @@ namespace Deepgram.Tests.UtilitiesTests
         public void GetParameters_Should_Return_String_When_Passing_Boolean_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new PrerecordedTranscriptionOptions()
-            {
-                Paragraphs = true
-            };
+            var obj = FakeModels.PrerecordedTranscriptionOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
@@ -101,30 +80,21 @@ namespace Deepgram.Tests.UtilitiesTests
         public void GetParameters_Should_Return_String_When_Passing_DateTime_Parameter()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-
-            var obj = new DateTimeObject()
-            {
-                Time = new DateTime(2023, 5, 23)
-            };
+            var obj = FakeModels.ListAllRequestsOptions;
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
 
             //Assert
             Assert.NotNull(result);
-            Assert.Contains($"{nameof(obj.Time).ToLower()}=2023-05-23", result);
+            Assert.Contains($"start=2023-05-23", result);
         }
 
         [Fact]
         public void GetParameters_Should_Return_Empty_String_When_Parameter_Has_No_Values()
         {
             //Arrange 
-            //only creating a limited object so to test each value is being processed
-            var obj = new LiveTranscriptionOptions()
-            {
-                Version = null
-            };
+            var obj = new LiveTranscriptionOptions();
 
             //Act
             var result = QueryParameterUtil.GetParameters(obj);
@@ -132,13 +102,6 @@ namespace Deepgram.Tests.UtilitiesTests
             //Assert
             Assert.NotNull(result);
             Assert.Equal(string.Empty, result);
-
         }
-
-        public class DateTimeObject
-        {
-            public DateTime Time { get; set; }
-        }
-
     }
 }

--- a/Deepgram.Tests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -1,4 +1,5 @@
 ﻿using Deepgram.Models;
+using Deepgram.Tests.Fakes;
 using Deepgram.Utilities;
 using Xunit;
 

--- a/Deepgram.Tests/UtilitiesTests/UriUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/UriUtilTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Deepgram.Tests.Fakes;
+using System;
 using System.Collections.Generic;
 using Deepgram.Utilities;
 using Xunit;

--- a/Deepgram.Tests/UtilitiesTests/UriUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/UriUtilTests.cs
@@ -16,8 +16,8 @@ namespace Deepgram.Tests.UtilitiesTests
         public void ResolveUri_Should_Return_Uri_Without_Parameters(string protocol)
         {
             //Arrange
-            var apiUrl = "test.com";
-            var uriSegment = "segment";
+            var apiUrl = FakeModels.CleanedUrl;
+            var uriSegment = FakeModels.UriSegment;
 
             //Act
             var result = UriUtil.ResolveUri(apiUrl, uriSegment, protocol);
@@ -40,8 +40,8 @@ namespace Deepgram.Tests.UtilitiesTests
         public void ResolveUri_Should_Return_Uri_With_Parameters(string protocol)
         {
             //Arrange
-            var apiUrl = "test.com";
-            var uriSegment = "segment";
+            var apiUrl = FakeModels.CleanedUrl;
+            var uriSegment = FakeModels.UriSegment;
             var parameters = new Dictionary<string, string>
         {
             { "key", "value" }

--- a/Deepgram/Clients/BaseClient.cs
+++ b/Deepgram/Clients/BaseClient.cs
@@ -1,16 +1,18 @@
-﻿using Deepgram.Models;
+﻿using Deepgram.Interfaces;
+using Deepgram.Models;
 using Deepgram.Request;
 using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal abstract class BaseClient
+    public abstract class BaseClient
     {
         internal Credentials _credentials;
-        internal ApiRequest _apiRequest;
+        internal IApiRequest _apiRequest;
 
         public BaseClient(Credentials credentials)
         {
+            _credentials = credentials;
             _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
         }
 

--- a/Deepgram/Clients/BaseClient.cs
+++ b/Deepgram/Clients/BaseClient.cs
@@ -1,0 +1,18 @@
+﻿using Deepgram.Models;
+using Deepgram.Request;
+using Deepgram.Utilities;
+
+namespace Deepgram.Clients
+{
+    internal abstract class BaseClient
+    {
+        internal Credentials _credentials;
+        internal ApiRequest _apiRequest;
+
+        public BaseClient(Credentials credentials)
+        {
+            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
+        }
+
+    }
+}

--- a/Deepgram/Clients/BillingClient.cs
+++ b/Deepgram/Clients/BillingClient.cs
@@ -1,22 +1,13 @@
 ﻿using System.Net.Http;
 using System.Threading.Tasks;
-using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal class BillingClient : IBillingClient
+    public class BillingClient : BaseClient
     {
-        private Credentials _credentials;
-        private ApiRequest _apiRequest;
-        public BillingClient(Credentials credentials)
-        {
-            _credentials = credentials;
-
-            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
-        }
+        public BillingClient(Credentials credentials) : base(credentials) { }
 
         /// <summary>
         /// Generates a list of outstanding balances for the specified project. To see balances, the authenticated account must be a project owner or administrator

--- a/Deepgram/Clients/KeyClient.cs
+++ b/Deepgram/Clients/KeyClient.cs
@@ -3,12 +3,13 @@ using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-
 namespace Deepgram.Clients
 {
-    internal class KeyClient : BaseClient, IKeyClient
+    public class KeyClient : BaseClient, IKeyClient
     {
-        public KeyClient(Credentials credentials) : base(credentials) { }
+        public KeyClient(Credentials credentials) : base(credentials)
+        {
+        }
 
 
         /// <summary>

--- a/Deepgram/Clients/KeyClient.cs
+++ b/Deepgram/Clients/KeyClient.cs
@@ -3,19 +3,12 @@ using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal class KeyClient : IKeyClient
+    internal class KeyClient : BaseClient, IKeyClient
     {
-        private Credentials _credentials;
-        private ApiRequest _apiRequest;
-        public KeyClient(Credentials credentials)
-        {
-            _credentials = credentials;
-            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
-        }
+        public KeyClient(Credentials credentials) : base(credentials) { }
 
 
         /// <summary>

--- a/Deepgram/Clients/PrerecordedTranscriptionClient.cs
+++ b/Deepgram/Clients/PrerecordedTranscriptionClient.cs
@@ -6,10 +6,9 @@ using Deepgram.Request;
 
 namespace Deepgram.Clients
 {
-    internal class PrerecordedTranscriptionClient : BaseClient, IPrerecordedTranscriptionClient
+    public class PrerecordedTranscriptionClient : BaseClient, IPrerecordedTranscriptionClient
     {
         public PrerecordedTranscriptionClient(Credentials credentials) : base(credentials) { }
-
         /// <summary>
         /// Submits a request to the Deepgram API to transcribe prerecorded audio
         /// </summary>

--- a/Deepgram/Clients/PrerecordedTranscriptionClient.cs
+++ b/Deepgram/Clients/PrerecordedTranscriptionClient.cs
@@ -3,19 +3,12 @@ using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal class PrerecordedTranscriptionClient : IPrerecordedTranscriptionClient
+    internal class PrerecordedTranscriptionClient : BaseClient, IPrerecordedTranscriptionClient
     {
-        private Credentials _credentials;
-        internal ApiRequest _apiRequest;
-        public PrerecordedTranscriptionClient(Credentials credentials)
-        {
-            _credentials = credentials;
-            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
-        }
+        public PrerecordedTranscriptionClient(Credentials credentials) : base(credentials) { }
 
         /// <summary>
         /// Submits a request to the Deepgram API to transcribe prerecorded audio

--- a/Deepgram/Clients/ProjectClient.cs
+++ b/Deepgram/Clients/ProjectClient.cs
@@ -6,10 +6,9 @@ using Deepgram.Request;
 
 namespace Deepgram.Clients
 {
-    internal class ProjectClient : BaseClient, IProjectClient
+    public class ProjectClient : BaseClient, IProjectClient
     {
         public ProjectClient(Credentials credentials) : base(credentials) { }
-
         /// <summary>
         /// Returns all Deepgram projects
         /// </summary>

--- a/Deepgram/Clients/ProjectClient.cs
+++ b/Deepgram/Clients/ProjectClient.cs
@@ -3,20 +3,12 @@ using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal class ProjectClient : IProjectClient
+    internal class ProjectClient : BaseClient, IProjectClient
     {
-
-        private Credentials _credentials;
-        private ApiRequest _apiRequest;
-        public ProjectClient(Credentials credentials)
-        {
-            _credentials = credentials;
-            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
-        }
+        public ProjectClient(Credentials credentials) : base(credentials) { }
 
         /// <summary>
         /// Returns all Deepgram projects

--- a/Deepgram/Clients/TranscriptionClient.cs
+++ b/Deepgram/Clients/TranscriptionClient.cs
@@ -3,9 +3,10 @@ using Deepgram.Models;
 
 namespace Deepgram.Clients
 {
-    internal class TranscriptionClient : ITranscriptionClient
+    public class TranscriptionClient : ITranscriptionClient
     {
         public IPrerecordedTranscriptionClient Prerecorded { get; private set; }
+
         public TranscriptionClient(Credentials credentials)
         {
             Prerecorded = new PrerecordedTranscriptionClient(credentials);

--- a/Deepgram/Clients/UsageClient.cs
+++ b/Deepgram/Clients/UsageClient.cs
@@ -3,21 +3,12 @@ using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
 using Deepgram.Request;
-using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
-    internal class UsageClient : IUsageClient
+    internal class UsageClient : BaseClient, IUsageClient
     {
-        private Credentials _credentials;
-        private ApiRequest _apiRequest;
-
-        public UsageClient(Credentials credentials)
-        {
-            _credentials = credentials;
-            _apiRequest = new ApiRequest(HttpClientUtil.HttpClient);
-
-        }
+        public UsageClient(Credentials credentials) : base(credentials) { }
 
         /// <summary>
         /// Generates a list of requests sent to the Deepgram API for the specified project over a given time range. 

--- a/Deepgram/Clients/UsageClient.cs
+++ b/Deepgram/Clients/UsageClient.cs
@@ -6,8 +6,9 @@ using Deepgram.Request;
 
 namespace Deepgram.Clients
 {
-    internal class UsageClient : BaseClient, IUsageClient
+    public class UsageClient : BaseClient, IUsageClient
     {
+
         public UsageClient(Credentials credentials) : base(credentials) { }
 
         /// <summary>

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -43,9 +43,4 @@
       <_Parameter1>Deepgram.Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
-  <ItemGroup>
-    <AssemblyAttribute Include="System.Runtime.CompilerServices.PrivatesVisibleTo">
-      <_Parameter1>Deepgram.Tests</_Parameter1>
-    </AssemblyAttribute>
-  </ItemGroup>
 </Project>

--- a/Deepgram/Interfaces/IApiRequest.cs
+++ b/Deepgram/Interfaces/IApiRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Deepgram.Interfaces
+{
+    public interface IApiRequest
+    {
+        Task<T> SendHttpRequestAsync<T>(HttpRequestMessage request);
+    }
+}

--- a/Deepgram/Request/ApiRequest.cs
+++ b/Deepgram/Request/ApiRequest.cs
@@ -1,13 +1,14 @@
 ﻿using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Deepgram.Interfaces;
 using Deepgram.Models;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Deepgram.Request
 {
-    public class ApiRequest
+    public class ApiRequest : IApiRequest
     {
         readonly HttpClient _httpClient;
         public ApiRequest(HttpClient httpClient)
@@ -16,7 +17,7 @@ namespace Deepgram.Request
         }
 
 
-        internal async Task<T> SendHttpRequestAsync<T>(HttpRequestMessage request)
+        public async Task<T> SendHttpRequestAsync<T>(HttpRequestMessage request)
         {
 
             var response = await _httpClient.SendAsync(request);

--- a/Deepgram/Request/RequestMessageBuilder.cs
+++ b/Deepgram/Request/RequestMessageBuilder.cs
@@ -9,9 +9,18 @@ using Newtonsoft.Json;
 
 namespace Deepgram.Request
 {
-    internal static class RequestMessageBuilder
+    internal class RequestMessageBuilder
     {
-        internal static HttpRequestMessage CreateHttpRequestMessage(HttpMethod method, string uri, Credentials credentials, object body = null, object queryParameters = null)
+        /// <summary>
+        /// Creates a Http Request Message for the Api calls
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="uri"></param>
+        /// <param name="credentials"></param>
+        /// <param name="body"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
+        public static HttpRequestMessage CreateHttpRequestMessage(HttpMethod method, string uri, Credentials credentials, object body = null, object queryParameters = null)
         {
             var req = ConfigureHttpRequestMessage(method, uri, credentials, queryParameters);
 
@@ -28,6 +37,16 @@ namespace Deepgram.Request
 
         }
 
+
+        /// <summary>
+        /// Create a HttpRequestMessage when a stream is the body source
+        /// </summary>
+        /// <param name="method"></param>
+        /// <param name="uri"></param>
+        /// <param name="credentials"></param>
+        /// <param name="streamSource"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
         internal static HttpRequestMessage CreateStreamHttpRequestMessage(HttpMethod method, string uri, Credentials credentials, StreamSource streamSource, object queryParameters = null)
         {
             var req = ConfigureHttpRequestMessage(method, uri, credentials, queryParameters);
@@ -59,5 +78,8 @@ namespace Deepgram.Request
             req.Headers.Authorization = new AuthenticationHeaderValue("token", credentials.ApiKey);
             return req;
         }
+
+
+
     }
 }

--- a/Deepgram/Utilities/CredentialsUtil.cs
+++ b/Deepgram/Utilities/CredentialsUtil.cs
@@ -6,6 +6,11 @@ namespace Deepgram.Utilities
 {
     public class CredentialsUtil
     {
+        /// <summary>
+        /// Method for cleaning the passed in Credentials
+        /// </summary>
+        /// <param name="credentials"></param>
+        /// <returns></returns>
         public static Credentials Clean(Credentials credentials = null)
         {
             //if no credentials are passed in the constructor create a empty credentials
@@ -19,6 +24,13 @@ namespace Deepgram.Utilities
                 CleanRequireSSL(credentials.RequireSSL));
 
         }
+
+        /// <summary>
+        /// Checks the required apikey is present 
+        /// </summary>
+        /// <param name="apiKey"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException"></exception>
         internal static string CheckApiKey(string apiKey = null)
         {
             if (string.IsNullOrEmpty(apiKey))
@@ -27,12 +39,27 @@ namespace Deepgram.Utilities
             return apiKey;
         }
 
+        /// <summary>
+        /// sets the cleaned ApiUri if passed in or sets default
+        /// </summary>
+        /// <param name="apiUrl"></param>
+        /// <returns></returns>
         internal static string CleanApiUrl(string apiUrl = null) =>
             string.IsNullOrEmpty(apiUrl) ? Constants.DEFAULT_URI : TrimApiUrl(apiUrl);
 
+        /// <summary>
+        /// removes http:// or https:// from the uri
+        /// </summary>
+        /// <param name="apiUrl"></param>
+        /// <returns></returns>
         internal static string TrimApiUrl(string apiUrl) =>
             apiUrl.Contains("://") ? apiUrl.Substring(apiUrl.IndexOf("://") + 3) : apiUrl;
 
+        /// <summary>
+        /// covnerts value to boolean if passed in or sets default
+        /// </summary>
+        /// <param name="requireSSL"></param>
+        /// <returns></returns>
         internal static bool CleanRequireSSL(bool? requireSSL = null) =>
             !requireSSL.HasValue ? true : Convert.ToBoolean(requireSSL);
 

--- a/Deepgram/Utilities/HttpClientUtil.cs
+++ b/Deepgram/Utilities/HttpClientUtil.cs
@@ -9,6 +9,11 @@ namespace Deepgram.Utilities
         // Global client used in all instance when needed
         internal static HttpClient HttpClient = Create();
         static HttpClientUtil() { }
+
+        /// <summary>
+        /// Create a Httpclient set common headers
+        /// </summary>
+        /// <returns></returns>
         private static HttpClient Create()
         {
             var httpClient = new HttpClient();
@@ -18,6 +23,10 @@ namespace Deepgram.Utilities
             return httpClient;
         }
 
+        /// <summary>
+        /// sets timeout on the httpclient
+        /// </summary>
+        /// <param name="timeSpan"></param>
         public static void SetTimeOut(TimeSpan timeSpan) =>
           HttpClient.Timeout = timeSpan;
 

--- a/Deepgram/Utilities/UriUtil.cs
+++ b/Deepgram/Utilities/UriUtil.cs
@@ -4,6 +4,14 @@ namespace Deepgram.Utilities
 {
     internal static class UriUtil
     {
+        /// <summary>
+        /// create the Uri require for calling the api
+        /// </summary>
+        /// <param name="apiUrl"></param>
+        /// <param name="uriSegment"></param>
+        /// <param name="protocol"></param>
+        /// <param name="queryParameters"></param>
+        /// <returns></returns>
         internal static Uri ResolveUri(string apiUrl, string uriSegment, string protocol, object queryParameters = null)
         {
             var startUri = $@"{protocol}://{apiUrl}/v1/{uriSegment}";

--- a/Deepgram/Utilities/UserAgentUtil.cs
+++ b/Deepgram/Utilities/UserAgentUtil.cs
@@ -4,6 +4,10 @@ namespace Deepgram.Utilities
 {
     internal static class UserAgentUtil
     {
+        /// <summary>
+        /// determines the useragent for the httpclient
+        /// </summary>
+        /// <returns></returns>
         public static string GetUserAgent()
         {
 


### PR DESCRIPTION
resolve the error in tests failing last pull

General tidy-up of the test coed to make it more consistent -

introduces a baseclient as all the clients were doing the same thing in the constructor and storing the same variables  putting the into a abstract base class keep all that code in one place and easier to change
