### PR TITLE
Issues/116 crash on multiple set time out calls

### DIFF
--- a/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
+++ b/Deepgram.Tests/ClientTests/DeepgramClientTest.cs
@@ -54,13 +54,13 @@ namespace Deepgram.Tests.ClientTests
         [InlineData(30)]
         public void Should_Set_TimeOut_On_HttpClient(double timeSpan)
         {
-
             //Arrange
-            var SUT = new DeepgramClient(new CredentialsFaker().Generate());
+            var httpClientUtil = new HttpClientUtil();
+            var SUT = new DeepgramClient(new CredentialsFaker().Generate(), httpClientUtil);
 
             //Act
             SUT.SetHttpClientTimeout(TimeSpan.FromSeconds(timeSpan));
-            var httpClient = HttpClientUtil.HttpClient;
+            var httpClient = httpClientUtil.HttpClient;
 
             //Assert
             Assert.NotNull(httpClient);

--- a/Deepgram.Tests/UtilitiesTests/HttpClientUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/HttpClientUtilTests.cs
@@ -9,12 +9,12 @@ namespace Deepgram.Tests.UtilitiesTests
         [Fact]
         public void GetUserAgent_Should_Return_HttpClient_With_Accept_And_UserAgent_Headers_Set()
         {
-            //Arrange 
+            //Arrange
+            var httpClientUtil = new HttpClientUtil();
             var agent = UserAgentUtil.GetUserAgent();
 
             //Act
-            var result = HttpClientUtil.HttpClient;
-
+            var result = httpClientUtil.HttpClient;
 
             //Assert
             Assert.NotNull(result);

--- a/Deepgram/Clients/BaseClient.cs
+++ b/Deepgram/Clients/BaseClient.cs
@@ -11,8 +11,12 @@ namespace Deepgram.Clients
         public IApiRequest ApiRequest { get; set; }
         public IRequestMessageBuilder RequestMessageBuilder { get; set; }
 
-        public BaseClient(Credentials credentials)
+        protected HttpClientUtil HttpClientUtil { get; }
+
+        public BaseClient(Credentials credentials, HttpClientUtil httpClientUtil)
         {
+            HttpClientUtil = httpClientUtil;
+
             Credentials = credentials;
             ApiRequest = new ApiRequest(HttpClientUtil.HttpClient);
             RequestMessageBuilder = new RequestMessageBuilder();

--- a/Deepgram/Clients/BillingClient.cs
+++ b/Deepgram/Clients/BillingClient.cs
@@ -2,12 +2,14 @@
 using System.Threading.Tasks;
 using Deepgram.Models;
 using Deepgram.Request;
+using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
     public class BillingClient : BaseClient
     {
-        public BillingClient(Credentials credentials) : base(credentials) { }
+        public BillingClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil) { }
 
         /// <summary>
         /// Generates a list of outstanding balances for the specified project. To see balances, the authenticated account must be a project owner or administrator

--- a/Deepgram/Clients/KeyClient.cs
+++ b/Deepgram/Clients/KeyClient.cs
@@ -2,14 +2,14 @@
 using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
+using Deepgram.Utilities;
+
 namespace Deepgram.Clients
 {
     public class KeyClient : BaseClient, IKeyClient
     {
-        public KeyClient(Credentials credentials) : base(credentials)
-        {
-        }
-
+        public KeyClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil) { }
 
         /// <summary>
         /// Returns all Deepgram API keys associated with the project provided

--- a/Deepgram/Clients/PrerecordedTranscriptionClient.cs
+++ b/Deepgram/Clients/PrerecordedTranscriptionClient.cs
@@ -3,12 +3,15 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
+using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
     public class PrerecordedTranscriptionClient : BaseClient, IPrerecordedTranscriptionClient
     {
-        public PrerecordedTranscriptionClient(Credentials credentials) : base(credentials) { }
+        public PrerecordedTranscriptionClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil) { }
+
         /// <inheritdoc />
         public async Task<PrerecordedTranscription> GetTranscriptionAsync(UrlSource source, PrerecordedTranscriptionOptions options)
         {

--- a/Deepgram/Clients/ProjectClient.cs
+++ b/Deepgram/Clients/ProjectClient.cs
@@ -2,12 +2,15 @@
 using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
+using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
     public class ProjectClient : BaseClient, IProjectClient
     {
-        public ProjectClient(Credentials credentials) : base(credentials) { }
+        public ProjectClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil) { }
+
         /// <summary>
         /// Returns all Deepgram projects
         /// </summary>

--- a/Deepgram/Clients/TranscriptionClient.cs
+++ b/Deepgram/Clients/TranscriptionClient.cs
@@ -1,5 +1,6 @@
 ﻿using Deepgram.Interfaces;
 using Deepgram.Models;
+using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
@@ -7,9 +8,9 @@ namespace Deepgram.Clients
     {
         public IPrerecordedTranscriptionClient Prerecorded { get; protected set; }
 
-        public TranscriptionClient(Credentials credentials)
+        public TranscriptionClient(Credentials credentials, HttpClientUtil httpClientUtil)
         {
-            Prerecorded = new PrerecordedTranscriptionClient(credentials);
+            Prerecorded = new PrerecordedTranscriptionClient(credentials, httpClientUtil);
         }
 
 

--- a/Deepgram/Clients/UsageClient.cs
+++ b/Deepgram/Clients/UsageClient.cs
@@ -2,13 +2,15 @@
 using System.Threading.Tasks;
 using Deepgram.Interfaces;
 using Deepgram.Models;
+using Deepgram.Utilities;
 
 namespace Deepgram.Clients
 {
     public class UsageClient : BaseClient, IUsageClient
     {
 
-        public UsageClient(Credentials credentials) : base(credentials) { }
+        public UsageClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil) { }
 
         /// <summary>
         /// Generates a list of requests sent to the Deepgram API for the specified project over a given time range. 

--- a/Deepgram/DeepgramClient.cs
+++ b/Deepgram/DeepgramClient.cs
@@ -6,7 +6,7 @@ using Deepgram.Utilities;
 
 namespace Deepgram
 {
-    public class DeepgramClient
+    public class DeepgramClient : BaseClient
     {
         private Credentials Credentials;
 
@@ -17,7 +17,16 @@ namespace Deepgram
         public ILiveTranscriptionClient CreateLiveTranscriptionClient() => new LiveTranscriptionClient(Credentials);
         public DeepgramClient() : this(null) { }
 
-        public DeepgramClient(Credentials credentials)
+        public DeepgramClient(Credentials credentials) : this(credentials, new HttpClientUtil()) { }
+
+        /// <summary>
+        /// Only directly called by unit tests,
+        /// but indirectly called by the other constructors.
+        /// </summary>
+        /// <param name="credentials">Credentials to pass for access to the deepgram services</param>
+        /// <param name="httpClientUtil">The instance to get the HttpClient from</param>
+        internal DeepgramClient(Credentials credentials, HttpClientUtil httpClientUtil)
+            : base(credentials, httpClientUtil)
         {
             Initialize(credentials);
         }
@@ -37,11 +46,10 @@ namespace Deepgram
 
         protected void InitializeClients()
         {
-
-            Keys = new KeyClient(Credentials);
-            Projects = new ProjectClient(Credentials);
-            Transcription = new TranscriptionClient(Credentials);
-            Usage = new UsageClient(Credentials);
+            Keys = new KeyClient(Credentials, HttpClientUtil);
+            Projects = new ProjectClient(Credentials, HttpClientUtil);
+            Transcription = new TranscriptionClient(Credentials, HttpClientUtil);
+            Usage = new UsageClient(Credentials, HttpClientUtil);
         }
     }
 }

--- a/Deepgram/Utilities/HttpClientUtil.cs
+++ b/Deepgram/Utilities/HttpClientUtil.cs
@@ -6,15 +6,18 @@ namespace Deepgram.Utilities
 {
     public class HttpClientUtil
     {
-        // Global client used in all instance when needed
-        internal static HttpClient HttpClient = Create();
-        static HttpClientUtil() { }
+        // Client used in instance when needed
+        internal HttpClient HttpClient { get; private set; }
+
+        internal HttpClientUtil() {
+            HttpClient = Create();
+        }
 
         /// <summary>
         /// Create a Httpclient set common headers
         /// </summary>
         /// <returns></returns>
-        private static HttpClient Create()
+        private HttpClient Create()
         {
             var httpClient = new HttpClient();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
@@ -27,7 +30,7 @@ namespace Deepgram.Utilities
         /// sets timeout on the httpclient
         /// </summary>
         /// <param name="timeSpan"></param>
-        public static void SetTimeOut(TimeSpan timeSpan)
+        public void SetTimeOut(TimeSpan timeSpan)
         {
             // If the timeout has a new value, create a new HttpClient
             if (HttpClient.Timeout != timeSpan)
@@ -38,7 +41,5 @@ namespace Deepgram.Utilities
             // Set the timeout
             HttpClient.Timeout = timeSpan;
         }
-
-
     }
 }

--- a/Deepgram/Utilities/HttpClientUtil.cs
+++ b/Deepgram/Utilities/HttpClientUtil.cs
@@ -27,8 +27,17 @@ namespace Deepgram.Utilities
         /// sets timeout on the httpclient
         /// </summary>
         /// <param name="timeSpan"></param>
-        public static void SetTimeOut(TimeSpan timeSpan) =>
-          HttpClient.Timeout = timeSpan;
+        public static void SetTimeOut(TimeSpan timeSpan)
+        {
+            // If the timeout has a new value, create a new HttpClient
+            if (HttpClient.Timeout != timeSpan)
+            {
+                HttpClient = Create();
+            }
+
+            // Set the timeout
+            HttpClient.Timeout = timeSpan;
+        }
 
 
     }


### PR DESCRIPTION
Fixes #116.

Fixes the issue where a static and shared HttpClient was passed around all instances of DeepgramClient, no matter if it was still in memory or not(as the HttpClient was still around anyways). This resulted in any calls to SetTimeout after the first request had been sent from ANY DeepgramClient to fail with an exception.

This also sets up recreation of the HttpClient used inside of the DeepgramClient instance when the timeout changes, so that it can be reset to something else, on a per client basis.

---

Basically, this makes each DeepgramClient instance independent from each other, and makes it possible to modify the timeout even after the client has been used to send & recieve the first requests.