### PR TITLE
retarget the packages to only target net6 net7

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ["3.1.x", "5.0.x", "6.0.x", "7.0.x"]
+        dotnet-version: ["6.0.x", "7.0.x"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ["3.1.x", "5.0.x", "6.0.x", "7.0.x"]
+        dotnet-version: ["6.0.x", "7.0.x"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <ImplicitUsings>disable</ImplicitUsings>
     <Description>.NET SDK for the Deepgram API</Description>
     <Copyright>2021 Deepgram</Copyright>


### PR DESCRIPTION
So the current main repo is what was the v3 branch?

looking through it the look at the deepgram seems to have been retargeted to --

netcoreapp3.1;net5.0;net6.0;net7.0;netstandard2.0

it was reworked to just target-- 
net6.0;net7.0

the other framework were targeted in the V2-support and why I went back to add the feature to that branch.
also, I noticed in the CI.yml was also targeting other versions and not just [6.0,7.0]

that may be why you are getting the error in https://github.com/deepgram/deepgram-dotnet-sdk/issues/115