### PR TITLE
chore: add precommit to check conventional commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]


### PR DESCRIPTION

To finish setup: 
1. Install precommit (https://pre-commit.com/). Run `pip install pre-commit` (For macOS, brew install pre-commit)
2. Run `pre-commit install --hook-type commit-msg` 