### PR TITLE
Added separate ItemGroup for target frameworks.

### DIFF
--- a/Deepgram.Tests/Fakes/MockHttpMessageHandler.cs
+++ b/Deepgram.Tests/Fakes/MockHttpMessageHandler.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+
+using Newtonsoft.Json;
 
 namespace Deepgram.Tests.Fakes;
 public class MockHttpMessageHandler : HttpMessageHandler

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -28,10 +28,23 @@
     <None Include="D:\Sources\deepgram\deepgram-dotnet-sdk\Deepgram\.editorconfig" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="System.Threading.Channels" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="System.Threading.Channels" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Deepgram/DeepgramClient.cs
+++ b/Deepgram/DeepgramClient.cs
@@ -8,8 +8,6 @@ namespace Deepgram
 {
     public class DeepgramClient : BaseClient
     {
-        private Credentials Credentials;
-
         public IKeyClient Keys { get; protected set; }
         public IProjectClient Projects { get; protected set; }
         public ITranscriptionClient Transcription { get; protected set; }


### PR DESCRIPTION
Regarding #117, submitting changes to break out the ItemGroups in .csproj by target frameworks.

Also, when building the project, I noticed the redundant private Credentials property in DeepgramClient, which was giving a warning.  Removed the private property, so it uses the public one in BaseClient.

Disabled CS1998 warning in mock handler in tests as well.

Saw there were a bunch of warnings about deprecations in tests, but didn't touch those. 