### PR TITLE
Rewrite/feature/setup and registration

### DIFF
--- a/Deepgram.Tests/Fakes/ConcreteRestClient.cs
+++ b/Deepgram.Tests/Fakes/ConcreteRestClient.cs
@@ -1,6 +1,6 @@
 ﻿namespace Deepgram.Tests.Fakes;
 
-public class ConcreteRestClient(string? apiKey, IHttpClientFactory httpClientFactory, DeepgramClientOptions? deepgramClientOptions = null)
-    : AbstractRestClient(apiKey, httpClientFactory, deepgramClientOptions)
+public class ConcreteRestClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
+    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
 {
 }

--- a/Deepgram.Tests/Fakes/ConcreteRestClient.cs
+++ b/Deepgram.Tests/Fakes/ConcreteRestClient.cs
@@ -1,6 +1,6 @@
 ﻿namespace Deepgram.Tests.Fakes;
 
-public class ConcreteRestClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
-    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
+public class ConcreteRestClient(DeepgramClientOptions deepgramClientOptions, IHttpClientFactory httpClientFactory)
+    : AbstractRestClient(deepgramClientOptions, httpClientFactory)
 {
 }

--- a/Deepgram.Tests/Fakes/MockHttpClient.cs
+++ b/Deepgram.Tests/Fakes/MockHttpClient.cs
@@ -2,26 +2,21 @@
 public static class MockHttpClient
 {
     public static HttpClient CreateHttpClientWithResult<T>(
-       T result, HttpStatusCode code = HttpStatusCode.OK, string? url = $"https://{Constants.DEFAULT_URI}")
+       T result, HttpStatusCode code = HttpStatusCode.OK, string url = $"https://{Constants.DEFAULT_URI}")
     {
 
-        var httpClient = new HttpClient(new MockHttpMessageHandler<T>(result, code))
+        return new HttpClient(new MockHttpMessageHandler<T>(result, code))
         {
-            BaseAddress = new Uri(url!)
+            BaseAddress = new Uri(url)
         };
-
-        return httpClient;
     }
 
     public static HttpClient CreateHttpClientWithException<T>(
        T result, HttpStatusCode code = HttpStatusCode.OK)
     {
-
-        var httpClient = new HttpClient(new MockHttpMessageHandler<T>(result, code))
+        return new HttpClient(new MockHttpMessageHandler<T>(result, code))
         {
             BaseAddress = new Uri($"https://{Constants.DEFAULT_URI}")
         };
-
-        return httpClient;
     }
 }

--- a/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
@@ -20,7 +20,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<GetProjectsResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act
         var result = await client.GetAsync<GetProjectsResponse>(Constants.PROJECTS);
@@ -41,7 +41,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<GetProjectsResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
         // Act & Assert
         client.Invoking(y => y.GetAsync<GetProjectsResponse>(Constants.PROJECTS))
              .Should().ThrowAsync<HttpRequestException>();
@@ -58,7 +58,7 @@ public class AbstractRestfulClientTests
         expectedResponse.ProjectId = "1";
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
         // Act
         var result = await client.GetAsync<GetProjectResponse>($"{Constants.PROJECTS}/1");
 
@@ -79,7 +79,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<CreateProjectKeyResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
         // Act
         var result = await client.PostAsync<CreateProjectKeyResponse>(Constants.PROJECTS, new StringContent(string.Empty));
 
@@ -99,7 +99,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<SyncPrerecordedResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
         // Act
         var result = await client.PostAsync<SyncPrerecordedResponse>(Constants.PROJECTS, new StringContent(string.Empty));
 
@@ -118,7 +118,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<SyncPrerecordedResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act & Assert      
 
@@ -132,7 +132,7 @@ public class AbstractRestfulClientTests
         // Arrange   
         var httpClient = MockHttpClient.CreateHttpClientWithResult(new VoidResponse(), HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act & Assert
         client.Invoking(y => y.Delete($"{Constants.PROJECTS}/1"))
@@ -146,7 +146,7 @@ public class AbstractRestfulClientTests
         // Arrange    
         var httpClient = MockHttpClient.CreateHttpClientWithException(new MessageResponse(), HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act & Assert
         _ = client.Invoking(y => y.Delete(Constants.PROJECTS))
@@ -160,7 +160,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act
         var result = await client.DeleteAsync<MessageResponse>($"{Constants.PROJECTS}/1");
@@ -181,7 +181,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithException(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act & Assert
         client.Invoking(y => y.DeleteAsync<MessageResponse>(Constants.PROJECTS))
@@ -196,7 +196,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act
         var result = await client.PatchAsync<MessageResponse>($"{Constants.PROJECTS}/1", new StringContent(string.Empty));
@@ -217,7 +217,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithException(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         //Act & Assert
         client.Invoking(y => y.PatchAsync<MessageResponse>(Constants.PROJECTS, new StringContent(string.Empty)))
@@ -231,7 +231,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
 
         // Act
         var result = await client.PutAsync<MessageResponse>($"{Constants.PROJECTS}/1", new StringContent(string.Empty));
@@ -251,7 +251,7 @@ public class AbstractRestfulClientTests
         // Arrange       
         var httpClient = MockHttpClient.CreateHttpClientWithException(new MessageResponse(), HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
+        var client = new ConcreteRestClient(_clientOptions, _httpClientFactory);
         // Act & Assert
         client.Invoking(y => y.PutAsync<MessageResponse>(Constants.PROJECTS, new StringContent(string.Empty)))
              .Should().ThrowAsync<HttpRequestException>();

--- a/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
@@ -3,12 +3,13 @@
 public class AbstractRestfulClientTests
 {
     IHttpClientFactory _httpClientFactory;
-    string _apiKey;
+    DeepgramClientOptions _clientOptions;
 
     [SetUp]
     public void Setup()
     {
-        _apiKey = new Faker().Random.Guid().ToString();
+
+        _clientOptions = new DeepgramClientOptions(new Faker().Random.Guid().ToString());
         _httpClientFactory = Substitute.For<IHttpClientFactory>();
     }
 
@@ -19,7 +20,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<GetProjectsResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act
         var result = await client.GetAsync<GetProjectsResponse>(Constants.PROJECTS);
@@ -40,7 +41,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<GetProjectsResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
         // Act & Assert
         client.Invoking(y => y.GetAsync<GetProjectsResponse>(Constants.PROJECTS))
              .Should().ThrowAsync<HttpRequestException>();
@@ -57,7 +58,7 @@ public class AbstractRestfulClientTests
         expectedResponse.ProjectId = "1";
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
         // Act
         var result = await client.GetAsync<GetProjectResponse>($"{Constants.PROJECTS}/1");
 
@@ -78,7 +79,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<CreateProjectKeyResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
         // Act
         var result = await client.PostAsync<CreateProjectKeyResponse>(Constants.PROJECTS, new StringContent(string.Empty));
 
@@ -98,7 +99,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<SyncPrerecordedResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
         // Act
         var result = await client.PostAsync<SyncPrerecordedResponse>(Constants.PROJECTS, new StringContent(string.Empty));
 
@@ -117,7 +118,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<SyncPrerecordedResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act & Assert      
 
@@ -131,7 +132,7 @@ public class AbstractRestfulClientTests
         // Arrange   
         var httpClient = MockHttpClient.CreateHttpClientWithResult(new VoidResponse(), HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act & Assert
         client.Invoking(y => y.Delete($"{Constants.PROJECTS}/1"))
@@ -145,7 +146,7 @@ public class AbstractRestfulClientTests
         // Arrange    
         var httpClient = MockHttpClient.CreateHttpClientWithException(new MessageResponse(), HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act & Assert
         _ = client.Invoking(y => y.Delete(Constants.PROJECTS))
@@ -159,7 +160,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory) { };
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act
         var result = await client.DeleteAsync<MessageResponse>($"{Constants.PROJECTS}/1");
@@ -180,7 +181,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithException(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act & Assert
         client.Invoking(y => y.DeleteAsync<MessageResponse>(Constants.PROJECTS))
@@ -195,7 +196,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory) { };
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act
         var result = await client.PatchAsync<MessageResponse>($"{Constants.PROJECTS}/1", new StringContent(string.Empty));
@@ -216,7 +217,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithException(expectedResponse, HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         //Act & Assert
         client.Invoking(y => y.PatchAsync<MessageResponse>(Constants.PROJECTS, new StringContent(string.Empty)))
@@ -230,7 +231,7 @@ public class AbstractRestfulClientTests
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse, HttpStatusCode.OK);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory) { };
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
 
         // Act
         var result = await client.PutAsync<MessageResponse>($"{Constants.PROJECTS}/1", new StringContent(string.Empty));
@@ -250,7 +251,7 @@ public class AbstractRestfulClientTests
         // Arrange       
         var httpClient = MockHttpClient.CreateHttpClientWithException(new MessageResponse(), HttpStatusCode.BadRequest);
         _httpClientFactory.CreateClient(Constants.HTTPCLIENT_NAME).Returns(httpClient);
-        var client = new ConcreteRestClient(_apiKey, _httpClientFactory);
+        var client = new ConcreteRestClient(_httpClientFactory, _clientOptions);
         // Act & Assert
         client.Invoking(y => y.PutAsync<MessageResponse>(Constants.PROJECTS, new StringContent(string.Empty)))
              .Should().ThrowAsync<HttpRequestException>();

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/BaseAddressUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/BaseAddressUtilTests.cs
@@ -7,7 +7,7 @@ public class BaseAddressUtilTests
     [SetUp]
     public void SetUp()
     {
-        _deepgramClientOptions = new DeepgramClientOptions();
+        _deepgramClientOptions = new DeepgramClientOptions("fakeApiKey");
         _customAddressPart = "acme.com";
     }
 

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/HttpClientUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/HttpClientUtilTests.cs
@@ -11,7 +11,7 @@ public class HttpClientUtilTests
     {
         _apiKey = Guid.NewGuid().ToString();
         _httpClientFactory = Substitute.For<IHttpClientFactory>();
-        _clientOptions = new DeepgramClientOptions();
+        _clientOptions = new DeepgramClientOptions("fakeKey");
     }
 
 

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -28,10 +28,9 @@
         /// <summary>
         /// Constructor that take a IHttpClientFactory
         /// </summary>
-        /// <param name="apiKey">ApiKey used for Authentication Header and is required</param>
-        /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
-        /// <param name="deepgramClientOptions"><see cref="_deepgramClientOptions"/> for HttpClient Configuration</param>
-        internal AbstractRestClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
+        /// <param name="deepgramClientOptions"><see cref="_deepgramClientOptions"/>Options for the Deepgram client</param>
+        /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/>Factory to use to create instances of HttpClient for making Rest calls</param>
+        internal AbstractRestClient(DeepgramClientOptions deepgramClientOptions, IHttpClientFactory httpClientFactory)
         {
             _clientName = this.GetType().Name;
             _deepgramClientOptions = deepgramClientOptions;

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -31,13 +31,12 @@
         /// <param name="apiKey">ApiKey used for Authentication Header and is required</param>
         /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
         /// <param name="deepgramClientOptions"><see cref="_deepgramClientOptions"/> for HttpClient Configuration</param>
-        internal AbstractRestClient(string? apiKey, IHttpClientFactory httpClientFactory, DeepgramClientOptions? deepgramClientOptions = null)
+        internal AbstractRestClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
         {
             _clientName = this.GetType().Name;
-            var validatedKey = ApiKeyUtil.Validate(apiKey, _clientName);
-            _deepgramClientOptions = deepgramClientOptions is null ? new DeepgramClientOptions() : deepgramClientOptions;
+            _deepgramClientOptions = deepgramClientOptions;
             _deepgramClientOptions = BaseAddressUtil.GetHttps(_deepgramClientOptions);
-            _httpClient = HttpClientUtil.Configure(validatedKey, _deepgramClientOptions, httpClientFactory);
+            _httpClient = HttpClientUtil.Configure(_deepgramClientOptions.ApiKey, _deepgramClientOptions, httpClientFactory);
         }
 
         /// <summary>

--- a/Deepgram/DeepgramEventArgs/ConnectionErrorEventArgs.cs
+++ b/Deepgram/DeepgramEventArgs/ConnectionErrorEventArgs.cs
@@ -1,6 +1,10 @@
-﻿namespace Deepgram.DeepgramEventArgs
+﻿namespace Deepgram.DeepgramEventArgs;
+
+public class ConnectionErrorEventArgs : EventArgs
 {
-    public class ConnectionErrorEventArgs(Exception ex) : EventArgs
+    public Exception Exception { get; set; }
+    public ConnectionErrorEventArgs(Exception ex)
     {
+        Exception = ex;
     }
 }

--- a/Deepgram/LiveClient.cs
+++ b/Deepgram/LiveClient.cs
@@ -6,7 +6,6 @@ public class LiveClient
     readonly string _clientType;
     internal ILogger logger => LogProvider.GetLogger(_clientType);
     internal DeepgramClientOptions _deepgramClientOptions;
-    internal string _apiKey;
     internal ClientWebSocket? _clientWebSocket;
     internal CancellationTokenSource? _tokenSource = new();
     internal bool _disposed;
@@ -35,12 +34,10 @@ public class LiveClient
     public event EventHandler<TranscriptReceivedEventArgs>? TranscriptReceived;
     #endregion
 
-    public LiveClient(string? apiKey, DeepgramClientOptions? deepgramClientOptions = null)
+    public LiveClient(DeepgramClientOptions deepgramClientOptions)
     {
         _clientType = this.GetType().Name;
-        _deepgramClientOptions = deepgramClientOptions is null ? new DeepgramClientOptions() : deepgramClientOptions;
-        _deepgramClientOptions = BaseAddressUtil.GetWss(_deepgramClientOptions);
-        _apiKey = ApiKeyUtil.Validate(apiKey, _clientType);
+        _deepgramClientOptions = BaseAddressUtil.GetWss(deepgramClientOptions);
     }
 
 
@@ -53,7 +50,7 @@ public class LiveClient
     {
         _clientWebSocket?.Dispose();
         _clientWebSocket = new ClientWebSocket();
-        _clientWebSocket = WssClientUtil.SetHeaders(_apiKey, _deepgramClientOptions, _clientWebSocket);
+        _clientWebSocket = WssClientUtil.SetHeaders(_deepgramClientOptions.ApiKey, _deepgramClientOptions, _clientWebSocket);
         _tokenSource = new CancellationTokenSource();
 
 

--- a/Deepgram/ManageClient.cs
+++ b/Deepgram/ManageClient.cs
@@ -6,8 +6,8 @@
 /// <param name="apiKey">ApiKey used for Authentication Header and is required</param>
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class ManageClient(string? apiKey, IHttpClientFactory httpClientFactory, DeepgramClientOptions? deepgramClientOptions = null)
-    : AbstractRestClient(apiKey, httpClientFactory, deepgramClientOptions)
+public class ManageClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
+    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.PROJECTS}";
 

--- a/Deepgram/ManageClient.cs
+++ b/Deepgram/ManageClient.cs
@@ -3,11 +3,10 @@
 /// <summary>
 ///  Client containing methods for interacting with API's to manage project(s)
 /// </summary>
-/// <param name="apiKey">ApiKey used for Authentication Header and is required</param>
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class ManageClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
-    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
+public class ManageClient(DeepgramClientOptions deepgramClientOptions, IHttpClientFactory httpClientFactory)
+    : AbstractRestClient(deepgramClientOptions, httpClientFactory)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.PROJECTS}";
 

--- a/Deepgram/Models/Options/DeepgramClientOptions.cs
+++ b/Deepgram/Models/Options/DeepgramClientOptions.cs
@@ -11,4 +11,15 @@ public class DeepgramClientOptions
     /// no need to attach the protocol it will be added internally
     /// </summary>
     public string BaseAddress { get; set; } = Constants.DEFAULT_URI;
+
+    internal string ApiKey { get; }
+
+    /// <summary>
+    /// Creates a new Deepgram client options
+    /// </summary>
+    /// <param name="apiKey">The key to authenticate with deepgram</param>
+    public DeepgramClientOptions(string apiKey)
+    {
+        ApiKey = apiKey;
+    }
 }

--- a/Deepgram/Models/Options/DeepgramClientOptions.cs
+++ b/Deepgram/Models/Options/DeepgramClientOptions.cs
@@ -20,6 +20,12 @@ public class DeepgramClientOptions
     /// <param name="apiKey">The key to authenticate with deepgram</param>
     public DeepgramClientOptions(string apiKey)
     {
+        if( string.IsNullOrWhiteSpace(apiKey))
+        {
+            Log.ApiKeyNotPresent(LogProvider.GetLogger(nameof(DeepgramClientOptions)), nameof(DeepgramClientOptions));
+            throw new ArgumentNullException(nameof(apiKey));
+        }
+
         ApiKey = apiKey;
     }
 }

--- a/Deepgram/OnPremClient.cs
+++ b/Deepgram/OnPremClient.cs
@@ -3,11 +3,10 @@
 /// <summary>
 /// Constructor that take a IHttpClientFactory
 /// </summary>
-/// <param name="apiKey">ApiKey used for Authentication Header and is required</param> 
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class OnPremClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
-    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
+public class OnPremClient(DeepgramClientOptions deepgramClientOptions, IHttpClientFactory httpClientFactory)
+    : AbstractRestClient(deepgramClientOptions, httpClientFactory)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.PROJECTS}";
     /// <summary>

--- a/Deepgram/OnPremClient.cs
+++ b/Deepgram/OnPremClient.cs
@@ -6,8 +6,8 @@
 /// <param name="apiKey">ApiKey used for Authentication Header and is required</param> 
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class OnPremClient(string? apiKey, IHttpClientFactory httpClientFactory, DeepgramClientOptions? deepgramClientOptions = null)
-    : AbstractRestClient(apiKey, httpClientFactory, deepgramClientOptions)
+public class OnPremClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
+    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.PROJECTS}";
     /// <summary>

--- a/Deepgram/PrerecordedClient.cs
+++ b/Deepgram/PrerecordedClient.cs
@@ -3,11 +3,10 @@
 /// <summary>
 /// Constructor that take a IHttpClientFactory
 /// </summary>
-/// <param name="apiKey">ApiKey used for Authentication Header and is required</param> 
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class PrerecordedClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
-    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
+public class PrerecordedClient(DeepgramClientOptions deepgramClientOptions, IHttpClientFactory httpClientFactory)
+    : AbstractRestClient(deepgramClientOptions, httpClientFactory)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.LISTEN}";
     #region NoneCallBacks

--- a/Deepgram/PrerecordedClient.cs
+++ b/Deepgram/PrerecordedClient.cs
@@ -6,8 +6,8 @@
 /// <param name="apiKey">ApiKey used for Authentication Header and is required</param> 
 /// <param name="httpClientFactory"><see cref="IHttpClientFactory"/> for creating instances of HttpClient for making Rest calls</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class PrerecordedClient(string? apiKey, IHttpClientFactory httpClientFactory, DeepgramClientOptions? deepgramClientOptions = null)
-    : AbstractRestClient(apiKey, httpClientFactory, deepgramClientOptions)
+public class PrerecordedClient(IHttpClientFactory httpClientFactory, DeepgramClientOptions deepgramClientOptions)
+    : AbstractRestClient(httpClientFactory, deepgramClientOptions)
 {
     readonly string _urlPrefix = $"/{Constants.API_VERSION}/{Constants.LISTEN}";
     #region NoneCallBacks

--- a/Deepgram/ServiceCollectionExtensions.cs
+++ b/Deepgram/ServiceCollectionExtensions.cs
@@ -2,8 +2,15 @@
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddDeepgram(this IServiceCollection services)
+    /// <summary>
+    /// Adds the Deepgram services to the service collection
+    /// </summary>
+    /// <param name="options">The options to use with the registered deepgram services</param>
+    public static IServiceCollection AddDeepgram(this IServiceCollection services, DeepgramClientOptions options)
     {
+        // Register options
+        services.AddSingleton(options);
+
         services.AddTransient<LiveClient>();
         services.AddTransient<PrerecordedClient>();
         services.AddTransient<LiveClient>();
@@ -15,5 +22,18 @@ public static class ServiceCollectionExtensions
             policyBuilder.WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), 5)));
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds the Deepgram services to the service collection with the default options
+    /// </summary>
+    /// <param name="apiKey">The API key to use to authenticate with Deepgram</param>
+    /// <returns></returns>
+    public static IServiceCollection AddDeepgram(this IServiceCollection services, string apiKey)
+    {
+        var deepgramOptions = new DeepgramClientOptions(apiKey)
+        { 
+        };
+        return services.AddDeepgram(deepgramOptions);
     }
 }

--- a/Deepgram/ServiceCollectionExtensions.cs
+++ b/Deepgram/ServiceCollectionExtensions.cs
@@ -4,6 +4,12 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddDeepgram(this IServiceCollection services)
     {
+        services.AddTransient<LiveClient>();
+        services.AddTransient<PrerecordedClient>();
+        services.AddTransient<LiveClient>();
+
+        services.AddTransient<ManageClient>();
+
         services.AddHttpClient(Constants.HTTPCLIENT_NAME)
             .AddTransientHttpErrorPolicy(policyBuilder =>
             policyBuilder.WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), 5)));

--- a/examples/prerecorded/Prerecorded.csproj
+++ b/examples/prerecorded/Prerecorded.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/examples/prerecorded/Prerecorded.csproj
+++ b/examples/prerecorded/Prerecorded.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Deepgram\Deepgram.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <Using Include="Deepgram" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\Deepgram\Deepgram.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Using Include="Deepgram" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+	</ItemGroup>
 
 </Project>

--- a/examples/prerecorded/Program.cs
+++ b/examples/prerecorded/Program.cs
@@ -1,35 +1,39 @@
-using Deepgram.Clients;
 using Deepgram.Models;
+using Deepgram.Models.Options;
 using Newtonsoft.Json;
 
-namespace SampleApp
+namespace SampleApp;
+public static class Program
 {
-    class Program
+    private const string API_KEY = "YOUR_DEEPGRAM_API_KEY";
+
+    public static async Task Main()
     {
-        const string API_KEY = "YOUR_DEEPGRAM_API_KEY";
+        var httpClientFactory = new HttpClientFactory(); // Brute force. Don't do this, use dependency injection.
+        var options = new DeepgramClientOptions("apiKey");
+        var deepgramClient = new PrerecordedClient(httpClientFactory, options);
 
-        static async Task Main(string[] args)
-        {   
-            var credentials = new Credentials(API_KEY);
-            var deepgramClient = new DeepgramClient(credentials);
-
-            // UNCOMMENT IF USING LOCAL FILE:
-            // using (FileStream fs = File.OpenRead("YOUR_FILE_LOCATION"))
+        var response = await deepgramClient.TranscribeUrlAsync(
+            new UrlSource()
             {
-                var response = await deepgramClient.Transcription.Prerecorded.GetTranscriptionAsync(
-                    // UNCOMMENT IF USING LOCAL FILE:
-                    // new Deepgram.Transcription.StreamSource(
-                    //     fs,
-                    //     "audio/wav"),
-                    new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-                    new PrerecordedTranscriptionOptions()
-                    {
-                        Punctuate = true,
-                        Utterances = true,
-                    });
+                Url = "https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"
+            },
+            new Deepgram.Models.Schemas.PrerecordedSchema()
+            {
+                Punctuate = true,
+                Utterances = true,
+            });
 
-                Console.WriteLine(JsonConvert.SerializeObject(response));
-            }
+        Console.WriteLine(JsonConvert.SerializeObject(response));
+    }
+
+    // Brute force. Don't do this, use dependency injection.
+    private class HttpClientFactory : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name)
+        {
+            return new HttpClient();
         }
     }
 }
+


### PR DESCRIPTION
# Tasks completed
---
## Deepgram SDK
- Setting up registration into servicecollection via the AddDeepgram extension method.
- Moving ApiKey into Options. There is a "default" AddDeepgram that only takes the apikey string and will add standard options, and one that takes the full options object.
- Changing the use of CancellationToken in liveclient to use a passed token, if one is available. Otherwise it will use the local source.
- Fixing some warnings being thrown in the project.

---
## Deepgram Prerecorded sample
- Updating the prerecorded sample to the correct format for the API.
- Upping the .net version for the prerecorded sample to net8.

**NOTE: Sample has not been run and checked to work, only to compile on a "should work" level.**