### PR TITLE
Fixing HttpException when using Float url parameters with fractional values

### DIFF
--- a/Deepgram/Utilities/QueryParameterUtil.cs
+++ b/Deepgram/Utilities/QueryParameterUtil.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Web;
 using Newtonsoft.Json;
@@ -34,6 +35,10 @@ namespace Deepgram.Utilities
                         else if (prop.Value.Type == JTokenType.Date)
                         {
                             paramList.Add(new KeyValuePair<string, string>(prop.Name, HttpUtility.UrlEncode(((DateTime)prop.Value).ToString("yyyy-MM-dd"))));
+                        }
+                        else if (prop.Value.Type == JTokenType.Float)
+                        {
+                            paramList.Add(new KeyValuePair<string, string>(prop.Name, ((JValue)prop.Value).ToString(CultureInfo.InvariantCulture)));
                         }
                         else
                         {


### PR DESCRIPTION
### This fixes #177 ("Specifiying UtteranceSplit parameter with a fractional value causes HttpException")

When calling `DeepgramClient.Transcription.Prerecorded.GetTranscriptionAsync(...)` with a `PrerecordedTranscriptionOptions` parameter that contains a `PrerecordedTranscriptionOptions.UtteranceSplit` value which has a fractiuonal value (i.e. 1.2, 2.5) causes HttpException. Values like 2.0, 1.0 do not cause exception.

The issue is the way the float value is being serialized in `Deepgram.Utilities.QueryParameterUtil.GetParameters(...)`

A parameter value of **2.2**
is serialized into this url parameter: utt_split=**2%2c2**

I added a "Float" type branch in `Deepgram.Utilities.QueryParameterUtil.GetParameters(...)` which does not url encode the float value and stringifies it with an invariant culture.