### PR TITLE
HotFix for SetTimeout() having no effect

### DIFF
--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -14,6 +14,9 @@
     <Product>Deepgram.NET SDK</Product>
     <PackageId>Deepgram</PackageId>
     <Title>Deepgram.NET</Title>
+    <Version>3.4.1-beta</Version>
+    <Authors>deepgram</Authors>
+    <Company />
   </PropertyGroup>
 
   <ItemGroup>

--- a/Deepgram/Utilities/HttpClientUtil.cs
+++ b/Deepgram/Utilities/HttpClientUtil.cs
@@ -35,7 +35,7 @@ namespace Deepgram.Utilities
             // If the timeout has a new value, create a new HttpClient
             if (HttpClient.Timeout != timeSpan)
             {
-                HttpClient = Create();
+                // HttpClient = Create(); // temporary bug fix until SDK v4 is released
             }
 
             // Set the timeout


### PR DESCRIPTION
### This fixes #127 ("A customer reported that it's not possible to set the HTTP Timeout at all now.")

See [this comment](https://github.com/deepgram/deepgram-dotnet-sdk/issues/127#issuecomment-1779085524) for the idea to this pull request.

**Problem:**
deepgram.SetHttpClientTimeout(...) has no effect.

**Hotfix:**
removed .HttpClient.Create() in HttpClientUtil.SetTimeOut(TimeSpan timeSpan)
