### PR TITLE
[release-v3] Temporary Fix for v3 Timeouts

### DIFF
--- a/Deepgram.Tests/UtilitiesTests/HttpClientUtilTests.cs
+++ b/Deepgram.Tests/UtilitiesTests/HttpClientUtilTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using Deepgram.Utilities;
 using Xunit;
 
@@ -21,7 +22,62 @@ namespace Deepgram.Tests.UtilitiesTests
             Assert.IsAssignableFrom<HttpClient>(result);
             Assert.Equal("application/json", result.DefaultRequestHeaders.Accept.ToString());
             Assert.Equal(agent, result.DefaultRequestHeaders.UserAgent.ToString());
+        }
 
+        [Fact]
+        public async Task ExecuteAsync_NotExecutedWithinTimeout_ThrowsExceptionAsync()
+        {
+            // Arrange
+            var endpoint = "https://google.com/";
+            var timeoutShouldFail = TimeSpan.FromMilliseconds(1);
+
+            var httpClientUtil = new HttpClientUtil();
+            httpClientUtil.SetTimeOut(timeoutShouldFail);
+
+            var client = httpClientUtil.HttpClient;
+            bool resultShouldFail = false;
+
+            // Act
+            try
+            {
+                await client.GetAsync(endpoint);
+            }
+            catch (TaskCanceledException)
+            {
+                // we are expecting this to timeout
+                resultShouldFail = true;
+            }
+
+            // Assert
+            Assert.True(resultShouldFail);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_ExecutedWithinTimeout_ThrowsExceptionAsync()
+        {
+            // Arrange
+            var endpoint = "https://google.com/";
+            var timeoutShouldSucceed = TimeSpan.FromMilliseconds(2000);
+
+            var httpClientUtil = new HttpClientUtil();
+            httpClientUtil.SetTimeOut(timeoutShouldSucceed);
+
+            var client = httpClientUtil.HttpClient;
+            bool resultShouldSucceed = false;
+
+            // Act
+            try
+            {
+                await client.GetAsync(endpoint);
+            }
+            catch (TaskCanceledException)
+            {
+                // we should not see the exception thrown
+                resultShouldSucceed = true;
+            }
+
+            // Assert
+            Assert.False(resultShouldSucceed);
         }
     }
 }

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -12,8 +12,11 @@
     <PackageTags>speech-to-text,captions,speech-recognition,deepgram</PackageTags>
     <PackageIcon>dg_logo.png</PackageIcon>
     <Product>Deepgram.NET SDK</Product>
-    <PackageId>Deepgram</PackageId>
-    <Title>Deepgram.NET</Title>
+    <PackageId>Deepgram .NET SDK</PackageId>
+    <Title>Deepgram .NET SDK</Title>
+    <Version>3.4.1</Version>
+    <Authors>Deepgram Contributors</Authors>
+    <Company>Deepgram</Company>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Deepgram/Utilities/HttpClientUtil.cs
+++ b/Deepgram/Utilities/HttpClientUtil.cs
@@ -32,13 +32,6 @@ namespace Deepgram.Utilities
         /// <param name="timeSpan"></param>
         public void SetTimeOut(TimeSpan timeSpan)
         {
-            // If the timeout has a new value, create a new HttpClient
-            if (HttpClient.Timeout != timeSpan)
-            {
-                HttpClient = Create();
-            }
-
-            // Set the timeout
             HttpClient.Timeout = timeSpan;
         }
     }


### PR DESCRIPTION
This supersedes this PR:
https://github.com/deepgram/deepgram-dotnet-sdk/pull/179

I would have used that PR but there were Project Properties that needed to be updated beyond what was provided.

NOTE: This is going on the `release-v3` branch and will tag a release from there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
	- Updated project metadata including package ID, title, version, and authors.

- **Bug Fixes**
	- Implemented a temporary fix in the HTTP client utility to address a timeout control flow issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->