### PR TITLE
Fix CI Action on `main` Branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,13 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - release-v*
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - release-v*
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We want to trigger CI on `main` and `release-v*` branches.

Fixes on `main`.