### PR TITLE
Deepgram options assignment

### DIFF
--- a/Deepgram/LiveClient.cs
+++ b/Deepgram/LiveClient.cs
@@ -9,6 +9,7 @@ public class LiveClient : IDisposable
 {
     public LiveClient(string apiKey, DeepgramClientOptions? deepgramClientOptions = null)
     {
+        if (string.IsNullOrEmpty(apiKey)) throw new ArgumentNullException(nameof(apiKey), "ApiKey is required");
         _apiKey = apiKey;
         _deepgramClientOptions = deepgramClientOptions is not null ? deepgramClientOptions : new DeepgramClientOptions();
     }

--- a/Deepgram/LiveClient.cs
+++ b/Deepgram/LiveClient.cs
@@ -1,6 +1,6 @@
 ﻿using Deepgram.Extensions;
-using Deepgram.Models.Live.v1;
 using Deepgram.Models.Authenticate.v1;
+using Deepgram.Models.Live.v1;
 
 namespace Deepgram;
 
@@ -10,10 +10,7 @@ public class LiveClient : IDisposable
     public LiveClient(string apiKey, DeepgramClientOptions? deepgramClientOptions = null)
     {
         _apiKey = apiKey;
-        if (deepgramClientOptions is null)
-        {
-            _deepgramClientOptions = new DeepgramClientOptions();
-        }
+        _deepgramClientOptions = deepgramClientOptions is not null ? deepgramClientOptions : new DeepgramClientOptions();
     }
     #region Fields
 


### PR DESCRIPTION
Deepgramclient options was not being assigned to field when if it was passed it to the constructor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved clarity in the initialization of client options in the Live Client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->