### PR TITLE
Fix Invalid Characters in Project Settings

### DIFF
--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -11,11 +11,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>speech-to-text,captions,speech-recognition,deepgram</PackageTags>
     <PackageIcon>dg_logo.png</PackageIcon>
-    <Product>Deepgram.NET SDK</Product>
-    <PackageId>Deepgram .NET SDK</PackageId>
+    <Product>Deepgram .NET SDK</Product>
+    <PackageId>Deepgram</PackageId>
     <Title>Deepgram .NET SDK</Title>
-    <Version>3.4.1</Version>
-    <Authors>Deepgram Contributors</Authors>
+    <Authors>Deepgram .NET SDK Contributors</Authors>
     <Company>Deepgram</Company>
   </PropertyGroup>
 


### PR DESCRIPTION
Just like the title says! It did not like the `.` and ` ` in the product name and the `v` in version `v3.4.1` (should be just `3.4.1`:
```
Invalid NuGet version string: 'v3.4.1'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package metadata including the package ID and authors list for better clarity and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->