### PR TITLE
Formatting of Extra Property

### DIFF
--- a/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -81,6 +81,27 @@ public class QueryParameterUtilTests
         result.Should().Contain(expected);
     }
 
+    public void GetParameters_Should_Return_String_When_Passing_Dictonary_Parameter()
+    {
+        //Arrange
+        var prerecordedOptions = new PrerecordedSchema()
+        {
+            Extra = new Dictionary<string, string>
+            {
+                {"KeyOne","ValueOne" },
+                {"KeyTwo","ValueTwo" }
+            }
+        };
+        var expected = $"extra={HttpUtility.UrlEncode("KeyOne:ValueOne")}&extra={HttpUtility.UrlEncode("KeyTwo:ValueTwo")}";
+
+        //Act
+        var result = QueryParameterUtil.GetParameters(prerecordedOptions);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Should().Contain(expected);
+    }
+
     [Test]
     public void GetParameters_Should_Return_String_When_Passing_Decimal_Parameter()
     {

--- a/Deepgram/Utilities/QueryParameterUtil.cs
+++ b/Deepgram/Utilities/QueryParameterUtil.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using Deepgram.Models.PreRecorded.v1;
 
 namespace Deepgram.Utilities;
@@ -39,7 +39,18 @@ internal static class QueryParameterUtil
                 case DateTime time:
                     sb.Append($"{name}={HttpUtility.UrlEncode(time.ToString("yyyy-MM-dd"))}&");
                     break;
-
+                //specific case for the Extra Parameter dictionary to format the querystring correctly
+                //no case changing of the key or values as theses are unknowns and the casing may have 
+                //significance to the user
+                case Dictionary<string, string> dict:
+                    if (name == "extra")
+                    {
+                        foreach (var kvp in dict)
+                        {
+                            sb.Append($"{name}={HttpUtility.UrlEncode($"{kvp.Key}:{kvp.Value}")}&");
+                        }
+                    }
+                    break;
                 default:
                     sb.Append($"{name}={HttpUtility.UrlEncode(pValue.ToString().ToLower())}&");
                     break;


### PR DESCRIPTION
to address git hub issues
https://github.com/deepgram/deepgram-dotnet-sdk/issues/200 
https://github.com/deepgram/deepgram-dotnet-sdk/issues/201

implementation to properly format the Extra Property of the LiveSchema and PrerecordedSchema for the QueryString of request. The implementation in the QueryParameterUtil class, in the URL Encode methods switch statement. the format does NOT change the casing of the keys or value's as the casing may have significance to the user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the app's ability to handle complex queries by introducing support for dictionary parameters in the query string formatting process.
- **Tests**
	- Added unit tests to ensure reliable query string formatting when using dictionary parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->