### PR TITLE
Add License Headers to All Source Code

### DIFF
--- a/Deepgram.Tests/Fakes/ConcreteRestClient.cs
+++ b/Deepgram.Tests/Fakes/ConcreteRestClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Authenticate.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.Fakes;
 

--- a/Deepgram.Tests/Fakes/MockHttpClient.cs
+++ b/Deepgram.Tests/Fakes/MockHttpClient.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Tests.Fakes;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Tests.Fakes;
 public static class MockHttpClient
 {
     public static HttpClient CreateHttpClientWithResult<T>(

--- a/Deepgram.Tests/Fakes/MockHttpMessageHandler.cs
+++ b/Deepgram.Tests/Fakes/MockHttpMessageHandler.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Tests.Fakes;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Tests.Fakes;
 public class MockHttpMessageHandler<T>(T response, HttpStatusCode statusCode) : HttpMessageHandler
 {
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/Deepgram.Tests/Fakes/MockHttpMessageHandlerException.cs
+++ b/Deepgram.Tests/Fakes/MockHttpMessageHandlerException.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Tests.Fakes;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Tests.Fakes;
 public class MockHttpMessageHandlerException(Exception exceptionType) : HttpMessageHandler
 {
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/Deepgram.Tests/GlobalSuppressions.cs
+++ b/Deepgram.Tests/GlobalSuppressions.cs
@@ -1,4 +1,8 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/Deepgram.Tests/GlobalUsings.cs
+++ b/Deepgram.Tests/GlobalUsings.cs
@@ -1,4 +1,8 @@
-﻿global using System.Net;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+global using System.Net;
 global using System.Text;
 global using System.Text.Json;
 global using System.Web;

--- a/Deepgram.Tests/TestExtensions/LoggerTestExtensions.cs
+++ b/Deepgram.Tests/TestExtensions/LoggerTestExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Extensions.Logging;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Microsoft.Extensions.Logging;
 
 namespace Deepgram.Tests.TestExtensions;
 

--- a/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
 using Deepgram.Models.Manage.v1;
 using Deepgram.Models.PreRecorded.v1;
 using Deepgram.Models.Authenticate.v1;

--- a/Deepgram.Tests/UnitTests/ClientTests/LiveClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/LiveClientTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Net.WebSockets;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using System.Net.WebSockets;
 using Deepgram.DeepgramEventArgs;
 using Deepgram.Models.Live.v1;
 using Deepgram.Models.Authenticate.v1;

--- a/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
 using Deepgram.Models.Manage;
 using Deepgram.Models.Manage.v1;
 using Deepgram.Models.Authenticate.v1;

--- a/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
 using Deepgram.Models.Manage.v1;
 using Deepgram.Models.OnPrem.v1;
 using Deepgram.Models.Authenticate.v1;

--- a/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
 using Deepgram.Models.PreRecorded.v1;
 using Deepgram.Models.Authenticate.v1;
 

--- a/Deepgram.Tests/UnitTests/ExtensionsTests/HttpClientExtensionTests.cs
+++ b/Deepgram.Tests/UnitTests/ExtensionsTests/HttpClientExtensionTests.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Manage.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.UnitTests.ExtensionsTests;

--- a/Deepgram.Tests/UnitTests/LoggerProviderTests/LogProviderTest.cs
+++ b/Deepgram.Tests/UnitTests/LoggerProviderTests/LogProviderTest.cs
@@ -1,4 +1,7 @@
-﻿
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
 using Deepgram.Logger;
 using Microsoft.Extensions.Logging;
 

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Manage.v1;
 using Deepgram.Models.PreRecorded.v1;
 
 namespace Deepgram.Tests.UnitTests.UtilitiesTests;

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/RequestContentUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/RequestContentUtilTests.cs
@@ -1,4 +1,7 @@
-﻿
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
 using Deepgram.Models.Manage.v1;
 
 namespace Deepgram.Tests.UnitTests.UtilitiesTests;

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/UserAgentTest.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/UserAgentTest.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Tests.UnitTests.UtilitiesTests;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Tests.UnitTests.UtilitiesTests;
 internal class UserAgentTest
 {
     [Test]

--- a/Deepgram.Tests/VoidResponse.cs
+++ b/Deepgram.Tests/VoidResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Tests;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Tests;
 public class VoidResponse
 {
     public Exception? Error { get; set; }

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Abstractions;

--- a/Deepgram/AnalyzeClient.cs
+++ b/Deepgram/AnalyzeClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Analyze.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram;

--- a/Deepgram/Constants/AudioEncoding.cs
+++ b/Deepgram/Constants/AudioEncoding.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Constants;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Constants;
 
 /// <summary> 
 /// Expected encoding of the submitted streaming audio. 

--- a/Deepgram/Constants/Defaults.cs
+++ b/Deepgram/Constants/Defaults.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Constants;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Constants;
 
 public static class Defaults
 {

--- a/Deepgram/Constants/UriSegments.cs
+++ b/Deepgram/Constants/UriSegments.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Constants;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Constants;
 public static class UriSegments
 {
 

--- a/Deepgram/Encapsulations/HttpClientFactory.cs
+++ b/Deepgram/Encapsulations/HttpClientFactory.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Extensions;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Extensions;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Encapsulations;

--- a/Deepgram/Encapsulations/HttpClientWrapper.cs
+++ b/Deepgram/Encapsulations/HttpClientWrapper.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Encapsulations;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Encapsulations;
 
 internal class HttpClientWrapper(HttpClient HttpClient)
 {

--- a/Deepgram/Enums/LiveType.cs
+++ b/Deepgram/Enums/LiveType.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Enums;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Enums;
 public enum LiveType
 {
     Metadata,

--- a/Deepgram/Enums/RequestMethod.cs
+++ b/Deepgram/Enums/RequestMethod.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Enums;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Enums;
 
 public enum RequestMethod
 {

--- a/Deepgram/Enums/WarningType.cs
+++ b/Deepgram/Enums/WarningType.cs
@@ -1,4 +1,8 @@
-﻿using System.Runtime.Serialization;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using System.Runtime.Serialization;
 
 namespace Deepgram.Enums;
 

--- a/Deepgram/EventArgs/ResponseReceivedEventArgs.cs
+++ b/Deepgram/EventArgs/ResponseReceivedEventArgs.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Live.v1;
 
 namespace Deepgram.DeepgramEventArgs;
 

--- a/Deepgram/Extensions/ClientWebSocketExtensions.cs
+++ b/Deepgram/Extensions/ClientWebSocketExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Authenticate.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Extensions;
 public static class ClientWebSocketExtensions

--- a/Deepgram/Extensions/HttpClientExtensions.cs
+++ b/Deepgram/Extensions/HttpClientExtensions.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Authenticate.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Extensions;
 

--- a/Deepgram/GlobalSuppressions.cs
+++ b/Deepgram/GlobalSuppressions.cs
@@ -1,4 +1,8 @@
-﻿// This file is used by Code Analysis to maintain SuppressMessage
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+// This file is used by Code Analysis to maintain SuppressMessage
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.

--- a/Deepgram/GlobalUsings.cs
+++ b/Deepgram/GlobalUsings.cs
@@ -1,4 +1,8 @@
-﻿global using System.Collections.Concurrent;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+global using System.Collections.Concurrent;
 global using System.Net.Http.Headers;
 global using System.Net.WebSockets;
 global using System.Reflection;

--- a/Deepgram/LiveClient.cs
+++ b/Deepgram/LiveClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Extensions;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Extensions;
 using Deepgram.Models.Live.v1;
 using Deepgram.Models.Authenticate.v1;
 

--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Manage.v1;
 
 namespace Deepgram.Logger;
 internal static partial class Log

--- a/Deepgram/Logger/LogProvider.cs
+++ b/Deepgram/Logger/LogProvider.cs
@@ -1,32 +1,35 @@
-﻿namespace Deepgram.Logger
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Logger;
+
+public sealed class LogProvider
 {
-    public sealed class LogProvider
+    internal static readonly ConcurrentDictionary<string, ILogger> _loggers = new();
+    internal static ILoggerFactory? _loggerFactory = NullLoggerFactory.Instance;
+
+    public static void SetLogFactory(ILoggerFactory factory)
     {
-        internal static readonly ConcurrentDictionary<string, ILogger> _loggers = new();
-        internal static ILoggerFactory? _loggerFactory = NullLoggerFactory.Instance;
-
-        public static void SetLogFactory(ILoggerFactory factory)
-        {
-            _loggerFactory?.Dispose();
-            _loggerFactory = factory;
-            _loggers.Clear();
-        }
-
-        public static ILogger GetLogger(string category)
-        {
-            // Try to get the logger from the dictionary
-            if (!_loggers.TryGetValue(category, out var logger))
-            {
-                // If not found, create a new logger and add it to the dictionary
-                logger = _loggerFactory?.CreateLogger(category) ?? NullLogger.Instance;
-                _loggers[category] = logger;
-            }
-            // Return the logger
-            return logger;
-        }
-
-
-
-
+        _loggerFactory?.Dispose();
+        _loggerFactory = factory;
+        _loggers.Clear();
     }
+
+    public static ILogger GetLogger(string category)
+    {
+        // Try to get the logger from the dictionary
+        if (!_loggers.TryGetValue(category, out var logger))
+        {
+            // If not found, create a new logger and add it to the dictionary
+            logger = _loggerFactory?.CreateLogger(category) ?? NullLogger.Instance;
+            _loggers[category] = logger;
+        }
+        // Return the logger
+        return logger;
+    }
+
+
+
+
 }

--- a/Deepgram/ManageClient.cs
+++ b/Deepgram/ManageClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Manage.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram;

--- a/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
+++ b/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public class AnalyzeSchema
 {

--- a/Deepgram/Models/Analyze/v1/AsyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/AsyncResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record AsyncResponse
 {

--- a/Deepgram/Models/Analyze/v1/Average.cs
+++ b/Deepgram/Models/Analyze/v1/Average.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Average
 {

--- a/Deepgram/Models/Analyze/v1/Intent.cs
+++ b/Deepgram/Models/Analyze/v1/Intent.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Intent
 {

--- a/Deepgram/Models/Analyze/v1/IntentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/IntentGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record IntentGroup
 {

--- a/Deepgram/Models/Analyze/v1/IntentsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/IntentsInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record IntentsInfo
 {

--- a/Deepgram/Models/Analyze/v1/Metadata.cs
+++ b/Deepgram/Models/Analyze/v1/Metadata.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Metadata
 {

--- a/Deepgram/Models/Analyze/v1/Results.cs
+++ b/Deepgram/Models/Analyze/v1/Results.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Results
 {

--- a/Deepgram/Models/Analyze/v1/Segment.cs
+++ b/Deepgram/Models/Analyze/v1/Segment.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Segment
 {

--- a/Deepgram/Models/Analyze/v1/SentimentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record SentimentGroup
 {

--- a/Deepgram/Models/Analyze/v1/SentimentInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record SentimentInfo
 {

--- a/Deepgram/Models/Analyze/v1/Summary.cs
+++ b/Deepgram/Models/Analyze/v1/Summary.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Summary
 {

--- a/Deepgram/Models/Analyze/v1/SummaryInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SummaryInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record SummaryInfo
 {

--- a/Deepgram/Models/Analyze/v1/SyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/SyncResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record SyncResponse
 {

--- a/Deepgram/Models/Analyze/v1/Topic.cs
+++ b/Deepgram/Models/Analyze/v1/Topic.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record Topic
 {

--- a/Deepgram/Models/Analyze/v1/TopicGroup.cs
+++ b/Deepgram/Models/Analyze/v1/TopicGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record TopicGroup
 {

--- a/Deepgram/Models/Analyze/v1/TopicsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/TopicsInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public record TopicsInfo
 {

--- a/Deepgram/Models/Analyze/v1/UrlSource.cs
+++ b/Deepgram/Models/Analyze/v1/UrlSource.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Analyze.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Analyze.v1;
 
 public class UrlSource(string url)
 {

--- a/Deepgram/Models/Authenticate/v1/DeepgramClientOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramClientOptions.cs
@@ -1,4 +1,7 @@
-﻿
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
 namespace Deepgram.Models.Authenticate.v1;
 
 /// <summary>

--- a/Deepgram/Models/Live/v1/Alternative.cs
+++ b/Deepgram/Models/Live/v1/Alternative.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record Alternative
 {

--- a/Deepgram/Models/Live/v1/Average.cs
+++ b/Deepgram/Models/Live/v1/Average.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record Average
 {

--- a/Deepgram/Models/Live/v1/Channel.cs
+++ b/Deepgram/Models/Live/v1/Channel.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record Channel
 {

--- a/Deepgram/Models/Live/v1/EventResponse.cs
+++ b/Deepgram/Models/Live/v1/EventResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public class EventResponse
 {

--- a/Deepgram/Models/Live/v1/LiveSchema.cs
+++ b/Deepgram/Models/Live/v1/LiveSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public class LiveSchema
 {

--- a/Deepgram/Models/Live/v1/MessageToSend.cs
+++ b/Deepgram/Models/Live/v1/MessageToSend.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 internal readonly struct MessageToSend(byte[] message, WebSocketMessageType type)
 {

--- a/Deepgram/Models/Live/v1/Metadata.cs
+++ b/Deepgram/Models/Live/v1/Metadata.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record MetaData
 {

--- a/Deepgram/Models/Live/v1/MetadataResponse.cs
+++ b/Deepgram/Models/Live/v1/MetadataResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record MetadataResponse
 {

--- a/Deepgram/Models/Live/v1/ModelInfo.cs
+++ b/Deepgram/Models/Live/v1/ModelInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record ModelInfo
 {

--- a/Deepgram/Models/Live/v1/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Live/v1/SpeechStartedResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record SpeechStartedResponse
 {

--- a/Deepgram/Models/Live/v1/TranscriptionResponse.cs
+++ b/Deepgram/Models/Live/v1/TranscriptionResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 public record TranscriptionResponse
 {
     /// <summary>

--- a/Deepgram/Models/Live/v1/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Live/v1/UtteranceEndResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record UtteranceEndResponse
 {

--- a/Deepgram/Models/Live/v1/Word.cs
+++ b/Deepgram/Models/Live/v1/Word.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Live.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Live.v1;
 
 public record Word
 {

--- a/Deepgram/Models/Manage/v1/BalanceResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalanceResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record BalanceResponse
 {

--- a/Deepgram/Models/Manage/v1/BalancesResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalancesResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record BalancesResponse
 {

--- a/Deepgram/Models/Manage/v1/Callback.cs
+++ b/Deepgram/Models/Manage/v1/Callback.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Callback
 {

--- a/Deepgram/Models/Manage/v1/Config.cs
+++ b/Deepgram/Models/Manage/v1/Config.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Config
 {

--- a/Deepgram/Models/Manage/v1/Details.cs
+++ b/Deepgram/Models/Manage/v1/Details.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Details
 {

--- a/Deepgram/Models/Manage/v1/Invite.cs
+++ b/Deepgram/Models/Manage/v1/Invite.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Invite
 {

--- a/Deepgram/Models/Manage/v1/InviteSchema.cs
+++ b/Deepgram/Models/Manage/v1/InviteSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class InviteSchema(string email, string scope)
 {

--- a/Deepgram/Models/Manage/v1/InvitesResponse.cs
+++ b/Deepgram/Models/Manage/v1/InvitesResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record InvitesResponse
 {

--- a/Deepgram/Models/Manage/v1/Key.cs
+++ b/Deepgram/Models/Manage/v1/Key.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Key
 {

--- a/Deepgram/Models/Manage/v1/KeyResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record KeyResponse : Key
 {

--- a/Deepgram/Models/Manage/v1/KeySchema.cs
+++ b/Deepgram/Models/Manage/v1/KeySchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class KeySchema(string comment, List<string> scopes)
 {

--- a/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record KeyScopeResponse
 {

--- a/Deepgram/Models/Manage/v1/KeysResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeysResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record KeysResponse
 {

--- a/Deepgram/Models/Manage/v1/Member.cs
+++ b/Deepgram/Models/Manage/v1/Member.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Member
 {

--- a/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class MemberScopeSchema(string scope)
 {

--- a/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record MemberScopesResponse
 {

--- a/Deepgram/Models/Manage/v1/MembersResponse.cs
+++ b/Deepgram/Models/Manage/v1/MembersResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record MembersResponse
 {

--- a/Deepgram/Models/Manage/v1/MessageResponse.cs
+++ b/Deepgram/Models/Manage/v1/MessageResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record MessageResponse
 {

--- a/Deepgram/Models/Manage/v1/Model.cs
+++ b/Deepgram/Models/Manage/v1/Model.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Model
 {

--- a/Deepgram/Models/Manage/v1/Project.cs
+++ b/Deepgram/Models/Manage/v1/Project.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Project
 {

--- a/Deepgram/Models/Manage/v1/ProjectResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record ProjectResponse : Project
 {

--- a/Deepgram/Models/Manage/v1/ProjectSchema.cs
+++ b/Deepgram/Models/Manage/v1/ProjectSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class ProjectSchema
 {

--- a/Deepgram/Models/Manage/v1/ProjectsResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectsResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record ProjectsResponse
 {

--- a/Deepgram/Models/Manage/v1/Resolution.cs
+++ b/Deepgram/Models/Manage/v1/Resolution.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Resolution
 {

--- a/Deepgram/Models/Manage/v1/Response.cs
+++ b/Deepgram/Models/Manage/v1/Response.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Response
 {

--- a/Deepgram/Models/Manage/v1/Result.cs
+++ b/Deepgram/Models/Manage/v1/Result.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record UsageSummary
 {

--- a/Deepgram/Models/Manage/v1/Token.cs
+++ b/Deepgram/Models/Manage/v1/Token.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record Token
 {

--- a/Deepgram/Models/Manage/v1/TokenDetails.cs
+++ b/Deepgram/Models/Manage/v1/TokenDetails.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record TokenDetails
 {

--- a/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record UsageFieldsResponse
 {

--- a/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class UsageFieldsSchema
 {

--- a/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record UsageRequestResponse
 {

--- a/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record UsageRequestsResponse
 {

--- a/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class UsageRequestsSchema
 {

--- a/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public record UsageSummaryResponse
 {

--- a/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Manage.v1;
 
 public class UsageSummarySchema
 {

--- a/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.OnPrem.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.OnPrem.v1;
 
 public record CredentialResponse
 {

--- a/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.OnPrem.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.OnPrem.v1;
 
 public record CredentialsResponse
 {

--- a/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.OnPrem.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.OnPrem.v1;
 
 public class CredentialsSchema
 {

--- a/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
+++ b/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.OnPrem.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.OnPrem.v1;
 
 public record DistributionCredentials
 {

--- a/Deepgram/Models/OnPrem/v1/Member.cs
+++ b/Deepgram/Models/OnPrem/v1/Member.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.OnPrem.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.OnPrem.v1;
 
 public record Member
 {

--- a/Deepgram/Models/PreRecorded/v1/Alternative.cs
+++ b/Deepgram/Models/PreRecorded/v1/Alternative.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Alternative
 {

--- a/Deepgram/Models/PreRecorded/v1/AsyncResponse.cs
+++ b/Deepgram/Models/PreRecorded/v1/AsyncResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record AsyncResponse
 {

--- a/Deepgram/Models/PreRecorded/v1/Average.cs
+++ b/Deepgram/Models/PreRecorded/v1/Average.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Average
 {

--- a/Deepgram/Models/PreRecorded/v1/Channel.cs
+++ b/Deepgram/Models/PreRecorded/v1/Channel.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 public record Channel
 {
     /// <summary>

--- a/Deepgram/Models/PreRecorded/v1/Entity.cs
+++ b/Deepgram/Models/PreRecorded/v1/Entity.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Entity
 {

--- a/Deepgram/Models/PreRecorded/v1/Hit.cs
+++ b/Deepgram/Models/PreRecorded/v1/Hit.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Hit
 {

--- a/Deepgram/Models/PreRecorded/v1/Intent.cs
+++ b/Deepgram/Models/PreRecorded/v1/Intent.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Intent
 {

--- a/Deepgram/Models/PreRecorded/v1/IntentGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/IntentGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record IntentGroup
 {

--- a/Deepgram/Models/PreRecorded/v1/IntentSchema.cs
+++ b/Deepgram/Models/PreRecorded/v1/IntentSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public class IntentSchema
 {

--- a/Deepgram/Models/PreRecorded/v1/IntentsInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/IntentsInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record IntentsInfo
 {

--- a/Deepgram/Models/PreRecorded/v1/Metadata.cs
+++ b/Deepgram/Models/PreRecorded/v1/Metadata.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Metadata
 {

--- a/Deepgram/Models/PreRecorded/v1/ModelInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/ModelInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record ModelInfo
 {

--- a/Deepgram/Models/PreRecorded/v1/Paragraph.cs
+++ b/Deepgram/Models/PreRecorded/v1/Paragraph.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Paragraph
 {

--- a/Deepgram/Models/PreRecorded/v1/ParagraphGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/ParagraphGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record ParagraphGroup
 {

--- a/Deepgram/Models/PreRecorded/v1/PrerecordedSchema.cs
+++ b/Deepgram/Models/PreRecorded/v1/PrerecordedSchema.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public class PrerecordedSchema
 {

--- a/Deepgram/Models/PreRecorded/v1/Results.cs
+++ b/Deepgram/Models/PreRecorded/v1/Results.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Results
 {

--- a/Deepgram/Models/PreRecorded/v1/Search.cs
+++ b/Deepgram/Models/PreRecorded/v1/Search.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Search
 {

--- a/Deepgram/Models/PreRecorded/v1/Segment.cs
+++ b/Deepgram/Models/PreRecorded/v1/Segment.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Segment
 {

--- a/Deepgram/Models/PreRecorded/v1/Sentence.cs
+++ b/Deepgram/Models/PreRecorded/v1/Sentence.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Sentence
 {

--- a/Deepgram/Models/PreRecorded/v1/SentimentGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/SentimentGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record SentimentGroup
 {

--- a/Deepgram/Models/PreRecorded/v1/SentimentInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/SentimentInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record SentimentInfo
 {

--- a/Deepgram/Models/PreRecorded/v1/Summary.cs
+++ b/Deepgram/Models/PreRecorded/v1/Summary.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Summary // aka SummaryV2
 {

--- a/Deepgram/Models/PreRecorded/v1/SummaryInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/SummaryInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record SummaryInfo
 {

--- a/Deepgram/Models/PreRecorded/v1/SummaryObsolete.cs
+++ b/Deepgram/Models/PreRecorded/v1/SummaryObsolete.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record SummaryObsolete // aka SummaryV1
 {

--- a/Deepgram/Models/PreRecorded/v1/SyncResponse.cs
+++ b/Deepgram/Models/PreRecorded/v1/SyncResponse.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record SyncResponse
 {

--- a/Deepgram/Models/PreRecorded/v1/Topic.cs
+++ b/Deepgram/Models/PreRecorded/v1/Topic.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Topic
 {

--- a/Deepgram/Models/PreRecorded/v1/TopicGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/TopicGroup.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record TopicGroup
 {

--- a/Deepgram/Models/PreRecorded/v1/TopicsInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/TopicsInfo.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record TopicsInfo
 {

--- a/Deepgram/Models/PreRecorded/v1/Translation.cs
+++ b/Deepgram/Models/PreRecorded/v1/Translation.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Translation
 {

--- a/Deepgram/Models/PreRecorded/v1/UrlSource.cs
+++ b/Deepgram/Models/PreRecorded/v1/UrlSource.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public class UrlSource(string url)
 {

--- a/Deepgram/Models/PreRecorded/v1/Utterance.cs
+++ b/Deepgram/Models/PreRecorded/v1/Utterance.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Utterance
 {

--- a/Deepgram/Models/PreRecorded/v1/Warning.cs
+++ b/Deepgram/Models/PreRecorded/v1/Warning.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Warning
 {

--- a/Deepgram/Models/PreRecorded/v1/Word.cs
+++ b/Deepgram/Models/PreRecorded/v1/Word.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.PreRecorded.v1;
 
 public record Word
 {

--- a/Deepgram/OnPremClient.cs
+++ b/Deepgram/OnPremClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.Manage.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Manage.v1;
 using Deepgram.Models.OnPrem.v1;
 using Deepgram.Models.Authenticate.v1;
 

--- a/Deepgram/PrerecordedClient.cs
+++ b/Deepgram/PrerecordedClient.cs
@@ -1,4 +1,8 @@
-﻿using Deepgram.Models.PreRecorded.v1;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.PreRecorded.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram;

--- a/Deepgram/Utilities/QueryParameterUtil.cs
+++ b/Deepgram/Utilities/QueryParameterUtil.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using System.Collections;
 using Deepgram.Models.PreRecorded.v1;
 
 namespace Deepgram.Utilities;

--- a/Deepgram/Utilities/RequestContentUtil.cs
+++ b/Deepgram/Utilities/RequestContentUtil.cs
@@ -1,4 +1,8 @@
-﻿internal static class RequestContentUtil
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+internal static class RequestContentUtil
 {
     static ILogger logger => LogProvider.GetLogger(nameof(RequestContentUtil));
     static readonly JsonSerializerOptions _jsonSerializerOptions = new()

--- a/Deepgram/Utilities/UserAgentUtil.cs
+++ b/Deepgram/Utilities/UserAgentUtil.cs
@@ -1,4 +1,8 @@
-﻿namespace Deepgram.Utilities;
+﻿// Copyright 2021-2023 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Utilities;
 
 internal static class UserAgentUtil
 {


### PR DESCRIPTION
Addresses Issue: https://github.com/deepgram/deepgram-dotnet-sdk/issues/197

This adds License Headers to all source code files. This PR touches every source code file in the repo. This is intentional at this stage because our CodeRabbit license ends in two days. The hope is that this PR forces CodeRabbit to analyze the entire code base with its line-by-line capabilities which we lose when the PRO trial ends (in 2 days). This should (hopefully) raise every issue it can find. Worst case is that is only looks at code that is changed and it was worth the experiment.

If we do get all line-by-line CodeRabbit suggestions, the intent is to dismiss all the code comments and requests for fixes from CodeRabbit because that is not the intent of this PR (it's only header changes). HOWEVER, doing so will put down in writing all the things we need to fix, update, address, etc in subsequent PRs.

Everything compiles and unit tests all run correctly.
![Screenshot 2024-02-07 at 08 34 41](https://github.com/deepgram/deepgram-dotnet-sdk/assets/12752197/d5996f3a-6902-4149-99e3-173d246bda74)
