### PR TITLE
Implement Analyze Unit Tests and Fix Analyze Func Names

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/AnalyzeClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AnalyzeClientTests.cs
@@ -1,0 +1,426 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Encapsulations;
+using Deepgram.Models.Analyze.v1;
+using Deepgram.Models.Authenticate.v1;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+public class AnalyzeClientTests
+{
+    DeepgramClientOptions _options;
+    string _apiKey;
+
+    [SetUp]
+    public void Setup()
+    {
+        _options = new DeepgramClientOptions();
+        _apiKey = new Faker().Random.Guid().ToString();
+    }
+
+    [Test]
+    public async Task AnalyzeUrl_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<SyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        analyzeSchema.CallBack = null;
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = new AutoFaker<UrlSource>().Generate();
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+
+        analyzeClient.When(x => x.PostAsync<SyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeUrl(source, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>());
+
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<SyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeUrl_Should_Throw_ArgumentException_If_CallBack_Not_Null()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<SyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = new AutoFaker<UrlSource>().Generate();
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<SyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>()).Returns(expectedResponse);
+
+        // Act and Assert
+        await analyzeClient.Invoking(y => y.AnalyzeUrl(source, analyzeSchema))
+            .Should().ThrowAsync<ArgumentException>();
+
+        await analyzeClient.DidNotReceive().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>());
+    }
+
+    [Test]
+    public async Task AnalyzeUrlCallBack_Should_Call_PostAsync_Returning_SyncResponse_With_CallBack_Parameter()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var source = new AutoFaker<UrlSource>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        // analyzeSchema is not null here as we first need to get the querystring with the callBack included
+        var stringedQuery = QueryParameterUtil.GetParameters(analyzeSchema);
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>()).Returns(expectedResponse);
+        var callBackParameter = analyzeSchema.CallBack;
+        //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
+        analyzeSchema.CallBack = null;
+
+
+        // Act
+        var result = await analyzeClient.AnalyzeUrlCallBack(source, callBackParameter, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeUrlCallBack_Should_Call_PostAsync_Returning_SyncResponse_With_CallBack_Property()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var source = new AutoFaker<UrlSource>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedQuery = QueryParameterUtil.GetParameters(analyzeSchema);
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeUrlCallBack(source, null, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeUrlCallBack_Should_Throw_ArgumentException_With_CallBack_Property_And_CallBack_Parameter_Set()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var source = new AutoFaker<UrlSource>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedQuery = QueryParameterUtil.GetParameters(analyzeSchema);
+
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>()).Returns(expectedResponse);
+        var callBackParameter = analyzeSchema.CallBack;
+
+        // Act Assert
+        await analyzeClient.Invoking(y => y.AnalyzeUrlCallBack(source, callBackParameter, analyzeSchema))
+            .Should().ThrowAsync<ArgumentException>();
+
+        await analyzeClient.DidNotReceive().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>());
+    }
+
+    [Test]
+    public async Task AnalyzeUrlCallBack_Should_Throw_ArgumentException_With_No_CallBack_Set()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var source = new AutoFaker<UrlSource>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        analyzeSchema.CallBack = null;
+        var stringedQuery = QueryParameterUtil.GetParameters(analyzeSchema);
+
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<StringContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>()).Returns(expectedResponse);
+
+
+        // Act Assert
+        await analyzeClient.Invoking(y => y.AnalyzeUrlCallBack(source, null, analyzeSchema))
+            .Should().ThrowAsync<ArgumentException>();
+
+        await analyzeClient.DidNotReceive().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedQuery}", Arg.Any<StringContent>());
+    }
+
+    [Test]
+    public async Task AnalyzeFile_With_Stream_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<SyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        analyzeSchema.CallBack = null;
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeStream(GetFakeByteArray());
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<SyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeFile(source, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<SyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFile_With_Bytes_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<SyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        analyzeSchema.CallBack = null;
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeByteArray();
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<SyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeFile(source, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<SyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<SyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Stream_With_CallBack_Property_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeStream(GetFakeByteArray());
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeFileCallBack(source, null, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Bytes_With_CallBack_Property_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeByteArray();
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        // Act
+        var result = await analyzeClient.AnalyzeFileCallBack(source, null, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Stream_With_CallBack_Parameter_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        // analyzeSchema is not null here as we first need to get the querystring with the callBack included
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeStream(GetFakeByteArray());
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        var callBack = analyzeSchema.CallBack;
+
+        //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
+        analyzeSchema.CallBack = null;
+
+        // Act
+        var result = await analyzeClient.AnalyzeFileCallBack(source, callBack, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Bytes_With_CallBack_Parameter_Should_Call_PostAsync_Returning_SyncResponse()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        // analyzeSchema is not null here as we first need to get the querystring with the callBack included
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeByteArray();
+
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+
+        var callBack = analyzeSchema.CallBack;
+
+        //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
+        analyzeSchema.CallBack = null;
+
+        // Act
+        var result = await analyzeClient.AnalyzeFileCallBack(source, callBack, analyzeSchema);
+
+        // Assert
+        await analyzeClient.Received().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>());
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().BeAssignableTo<AsyncResponse>();
+            result.Should().BeEquivalentTo(expectedResponse);
+        }
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Stream_Throw_ArgumentException_With_CallBack_Property_And_CallBack_Parameter_Set()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeStream(GetFakeByteArray());
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+        var callBack = analyzeSchema.CallBack;
+
+
+        // Act  Assert
+        await analyzeClient.Invoking(y => y.AnalyzeFileCallBack(source, callBack, analyzeSchema))
+           .Should().ThrowAsync<ArgumentException>();
+
+        await analyzeClient.DidNotReceive().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>());
+
+
+    }
+
+    [Test]
+    public async Task AnalyzeFileCallBack_With_Bytes_Should_Throw_ArgumentException_With_No_CallBack_Set()
+    {
+        //Arrange 
+        var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
+        var analyzeSchema = new AutoFaker<AnalyzeSchema>().Generate();
+        // analyzeSchema is not null here as we first need to get the querystring with the callBack included
+        var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
+        var source = GetFakeByteArray();
+
+        var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
+        var analyzeClient = Substitute.For<AnalyzeClient>(_apiKey, _options);
+        analyzeClient._httpClientWrapper = new HttpClientWrapper(httpClient);
+        analyzeClient.When(x => x.PostAsync<AsyncResponse>(Arg.Any<string>(), Arg.Any<HttpContent>())).DoNotCallBase();
+        analyzeClient.PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<HttpContent>()).Returns(expectedResponse);
+        analyzeSchema.CallBack = null;
+
+        // Act  Assert
+        await analyzeClient.Invoking(y => y.AnalyzeFileCallBack(source, null, analyzeSchema))
+           .Should().ThrowAsync<ArgumentException>();
+
+        await analyzeClient.DidNotReceive().PostAsync<AsyncResponse>($"{UriSegments.ANALYZE}?{stringedOptions}", Arg.Any<StringContent>());
+    }
+
+    private static Stream GetFakeStream(byte[] source)
+    {
+        var stream = new MemoryStream();
+        stream.Write(source, 0, source.Length);
+        return stream;
+    }
+
+    private static byte[] GetFakeByteArray() => new Faker().Random.Bytes(10);
+
+}

--- a/Deepgram.Tests/UnitTests/ClientTests/LiveClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/LiveClientTests.cs
@@ -8,6 +8,7 @@ using Deepgram.Models.Live.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
+
 public class LiveClientTests
 {
     DeepgramClientOptions _options;

--- a/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 using Deepgram.Encapsulations;
-using Deepgram.Models.Manage;
 using Deepgram.Models.Manage.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
+
 public class ManageClientTest
 {
     DeepgramClientOptions _options;
@@ -22,10 +22,6 @@ public class ManageClientTest
     }
 
     #region Projects
-
-
-
-
     [Test]
     public async Task GetProjects_Should_Call_GetAsync_Returning_ProjectsResponse()
     {

--- a/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
@@ -8,6 +8,7 @@ using Deepgram.Models.OnPrem.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
+
 public class OnPremClientTests
 {
     DeepgramClientOptions _options;
@@ -20,9 +21,6 @@ public class OnPremClientTests
         _projectId = new Faker().Random.Guid().ToString();
         _apiKey = new Faker().Random.Guid().ToString();
     }
-
-
-
 
     [Test]
     public async Task ListCredentials_Should_Call_GetAsync_Returning_CredentialsResponse()

--- a/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
@@ -7,6 +7,7 @@ using Deepgram.Models.PreRecorded.v1;
 using Deepgram.Models.Authenticate.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
+
 public class PrerecordedClientTests
 {
     DeepgramClientOptions _options;

--- a/Deepgram/AnalyzeClient.cs
+++ b/Deepgram/AnalyzeClient.cs
@@ -12,33 +12,33 @@ namespace Deepgram;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramClientOptions"/> for HttpClient Configuration</param>
-public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOptions = null)
+public class AnalyzeClient(string apiKey, DeepgramClientOptions? deepgramClientOptions = null)
     : AbstractRestClient(apiKey, deepgramClientOptions)
 {
     #region NoneCallBacks
     /// <summary>
-    ///  Transcribe a file by providing a url 
+    ///  Analyze a file by providing a url 
     /// </summary>
-    /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"></param>
+    /// <param name="source">Url to the file that is to be analyzed <see cref="UrlSource"></param>
     /// <param name="analyzeSchema">Options for the transcription <see cref="AnalyzeSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeUrl(UrlSource source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<SyncResponse> AnalyzeUrl(UrlSource source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyNoCallBack(nameof(TranscribeUrl), analyzeSchema);
+        VerifyNoCallBack(nameof(AnalyzeUrl), analyzeSchema);
         var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
         return await PostAsync<SyncResponse>(
             $"{UriSegments.ANALYZE}?{stringedOptions}",
             RequestContentUtil.CreatePayload(source), cancellationToken);
     }
     /// <summary>
-    /// Transcribes a file using the provided byte array
+    /// Analyzes a file using the provided byte array
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>
     /// <param name="analyzeSchema">Options for the transcription <see cref="AnalyzeSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeFile(byte[] source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<SyncResponse> AnalyzeFile(byte[] source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyNoCallBack(nameof(TranscribeFile), analyzeSchema);
+        VerifyNoCallBack(nameof(AnalyzeFile), analyzeSchema);
         var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
         var stream = new MemoryStream();
         stream.Write(source, 0, source.Length);
@@ -48,14 +48,14 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
     }
 
     /// <summary>
-    /// Transcribes a file using the provided stream
+    /// Analyzes a file using the provided stream
     /// </summary>
     /// <param name="source">file is the form of a stream <see cref="Stream"/></param>
     /// <param name="analyzeSchema">Options for the transcription <see cref="AnalyzeSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeFile(Stream source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<SyncResponse> AnalyzeFile(Stream source, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyNoCallBack(nameof(TranscribeFile), analyzeSchema);
+        VerifyNoCallBack(nameof(AnalyzeFile), analyzeSchema);
         var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
         return await PostAsync<SyncResponse>(
             $"{UriSegments.ANALYZE}?{stringedOptions}",
@@ -66,15 +66,15 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
 
     #region  CallBack Methods
     /// <summary>
-    /// Transcribes a file using the provided byte array and providing a CallBack
+    /// Analyzes a file using the provided byte array and providing a CallBack
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>  
     /// <param name="callBack">CallBack url</param>    
     /// <param name="analyzeSchema">Options for the transcription<see cref="AnalyzeSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeFileCallBack(byte[] source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<AsyncResponse> AnalyzeFileCallBack(byte[] source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyOneCallBackSet(nameof(TranscribeFileCallBack), callBack, analyzeSchema);
+        VerifyOneCallBackSet(nameof(AnalyzeFileCallBack), callBack, analyzeSchema);
 
         if (callBack != null)
             analyzeSchema.CallBack = callBack;
@@ -87,15 +87,15 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
     }
 
     /// <summary>
-    /// Transcribes a file using the provided stream and providing a CallBack
+    /// Analyzes a file using the provided stream and providing a CallBack
     /// </summary>
     /// <param name="source">file is the form of a stream <see cref="Stream"></param>  
     /// <param name="callBack">CallBack url</param>    
     /// <param name="analyzeSchema">Options for the transcription<see cref="AnalyzeSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeFileCallBack(Stream source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<AsyncResponse> AnalyzeFileCallBack(Stream source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyOneCallBackSet(nameof(TranscribeFileCallBack), callBack, analyzeSchema);
+        VerifyOneCallBackSet(nameof(AnalyzeFileCallBack), callBack, analyzeSchema);
         if (callBack != null)
             analyzeSchema.CallBack = callBack;
         var stringedOptions = QueryParameterUtil.GetParameters(analyzeSchema);
@@ -105,15 +105,15 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
     }
 
     /// <summary>
-    /// Transcribe a file by providing a url and a CallBack
+    /// Analyze a file by providing a url and a CallBack
     /// </summary>
-    /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"/></param>
+    /// <param name="source">Url to the file that is to be analyzed <see cref="UrlSource"/></param>
     /// <param name="callBack">CallBack url</param>    
     /// <param name="analyzeSchema">Options for the transcription<see cref="AnalyzeSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeUrlCallBack(UrlSource source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
+    public async Task<AsyncResponse> AnalyzeUrlCallBack(UrlSource source, string? callBack, AnalyzeSchema? analyzeSchema, CancellationToken cancellationToken = default)
     {
-        VerifyOneCallBackSet(nameof(TranscribeUrlCallBack), callBack, analyzeSchema);
+        VerifyOneCallBackSet(nameof(AnalyzeUrlCallBack), callBack, analyzeSchema);
 
         if (callBack != null)
             analyzeSchema.CallBack = callBack;
@@ -128,7 +128,7 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
     private void VerifyNoCallBack(string method, AnalyzeSchema? analyzeSchema)
     {
         if (analyzeSchema != null && analyzeSchema.CallBack != null)
-            throw new ArgumentException($"CallBack cannot be provided as schema option to a synchronous transcription when calling {method}. Use {nameof(TranscribeFileCallBack)} or {nameof(TranscribeUrlCallBack)}");
+            throw new ArgumentException($"CallBack cannot be provided as schema option to a synchronous transcription when calling {method}. Use {nameof(AnalyzeFileCallBack)} or {nameof(AnalyzeUrlCallBack)}");
     }
 
     private void VerifyOneCallBackSet(string callingMethod, string? callBack, AnalyzeSchema? analyzeSchema)
@@ -136,7 +136,7 @@ public class ReadClient(string apiKey, DeepgramClientOptions? deepgramClientOpti
 
         if (analyzeSchema.CallBack == null && callBack == null)
         { //check if no CallBack set in either callBack parameter or AnalyzeSchema
-            var ex = new ArgumentException($"Either provide a CallBack url or set AnalyzeSchema.CallBack.  If no CallBack needed either {nameof(TranscribeUrl)} or {nameof(TranscribeFile)}");
+            var ex = new ArgumentException($"Either provide a CallBack url or set AnalyzeSchema.CallBack.  If no CallBack needed either {nameof(AnalyzeUrl)} or {nameof(AnalyzeFile)}");
             Log.Exception(_logger, $"While calling {callingMethod} no callback set", ex);
             throw ex;
         }


### PR DESCRIPTION
Addresses Issue: https://github.com/deepgram/deepgram-dotnet-sdk/issues/220

Changes:
- Renames `ReadClient` -> `AnalyzeClient`. I had renamed the file but didn't rename the class.
- Renamed `TranscribeUrl` -> `AnalyzeUrl` and `TranscribeFile` -> `AnalyzeFile` to match other SDKs. Forgot to rename these when I copied the Prerecorded class.
- Implements Unit Tests for `AnalyzeClient` based on `PrerecordedClient` implementation
- Misc Clean Up (will be introducing a linter for this soon)

Unit tests all pass!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced unit tests for the `AnalyzeClient` class, covering various scenarios for analyzing URLs and files.
- **Refactor**
	- Improved code cleanliness in unit test files by adjusting whitespace and removing redundant lines.
- **New Features**
	- Updated the `AnalyzeClient` class functionality from transcribing to analyzing files, including renaming relevant methods to reflect this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->