### PR TITLE
Rename Manage Functions to Match Simplier Model Names

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
@@ -22,10 +22,6 @@ public class ManageClientTest
     }
 
     #region Projects
-
-
-
-
     [Test]
     public async Task GetProjects_Should_Call_GetAsync_Returning_ProjectsResponse()
     {
@@ -154,7 +150,7 @@ public class ManageClientTest
 
     #region ProjectKeys
     [Test]
-    public async Task GetProjectKeys_Should_Call_GetAsync_Returning_KeysResponse()
+    public async Task GetKeys_Should_Call_GetAsync_Returning_KeysResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<KeysResponse>().Generate();
@@ -166,7 +162,7 @@ public class ManageClientTest
         manageClient.GetAsync<KeysResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys").Returns(expectedResponse);
 
         //Act
-        var result = await manageClient.GetProjectKeys(_projectId);
+        var result = await manageClient.GetKeys(_projectId);
 
         //Assert
         await manageClient.Received().GetAsync<KeysResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys");
@@ -179,7 +175,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectKey_Should_Call_GetAsync_Returning_KeyResponse()
+    public async Task GetKey_Should_Call_GetAsync_Returning_KeyResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<KeyScopeResponse>().Generate();
@@ -193,7 +189,7 @@ public class ManageClientTest
 
 
         //Act
-        var result = await manageClient.GetProjectKey(_projectId, keyId);
+        var result = await manageClient.GetKey(_projectId, keyId);
         await manageClient.Received().GetAsync<KeyScopeResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys/{keyId}");
 
         //Assert
@@ -206,7 +202,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task CreateProjectKey_Should_Call_PostAsync_Returning_KeyResponse_Without_Expiration_TimeToLive_Set()
+    public async Task CreateKey_Should_Call_PostAsync_Returning_KeyResponse_Without_Expiration_TimeToLive_Set()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<KeyResponse>().Generate();
@@ -223,7 +219,7 @@ public class ManageClientTest
 
 
         //Act
-        var result = await manageClient.CreateProjectKey(_projectId, createKeySchema);
+        var result = await manageClient.CreateKey(_projectId, createKeySchema);
 
         //Assert
         await manageClient.Received().PostAsync<KeyResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys", Arg.Any<StringContent>());
@@ -237,7 +233,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task CreateProjectKey_Should_Call_PostAsync_Returning_KeyResponse_With_Expiration_Set()
+    public async Task CreateKey_Should_Call_PostAsync_Returning_KeyResponse_With_Expiration_Set()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<KeyResponse>().Generate();
@@ -253,7 +249,7 @@ public class ManageClientTest
 
 
         //Act
-        var result = await manageClient.CreateProjectKey(_projectId, createKeySchema);
+        var result = await manageClient.CreateKey(_projectId, createKeySchema);
 
         //Assert
         await manageClient.Received().PostAsync<KeyResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys", Arg.Any<StringContent>());
@@ -267,7 +263,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task CreateProjectKey_Should_Return_KeyResponse_Without_TimeToLive_Set()
+    public async Task CreateKey_Should_Return_KeyResponse_Without_TimeToLive_Set()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<KeyResponse>().Generate();
@@ -281,7 +277,7 @@ public class ManageClientTest
         manageClient.PostAsync<KeyResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys", Arg.Any<StringContent>()).Returns(expectedResponse);
 
         //Act
-        var result = await manageClient.CreateProjectKey(_projectId, createKeySchema);
+        var result = await manageClient.CreateKey(_projectId, createKeySchema);
 
         //Assert
         await manageClient.Received().PostAsync<KeyResponse>($"{UriSegments.PROJECTS}/{_projectId}/keys", Arg.Any<StringContent>());
@@ -295,7 +291,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task CreateProjectKey_Should_Throw_ArgumentException_When_Both_Expiration_And_TimeToLive_Set()
+    public async Task CreateKey_Should_Throw_ArgumentException_When_Both_Expiration_And_TimeToLive_Set()
     {
         //Arrange 
         var createKeySchema = new AutoFaker<KeySchema>().Generate();
@@ -303,12 +299,12 @@ public class ManageClientTest
         var manageClient = new ManageClient(_apiKey, _options) { _httpClientWrapper = new HttpClientWrapper(new HttpClient()) };
 
         //Act & Assert
-        await manageClient.Invoking(y => y.CreateProjectKey(UriSegments.PROJECTS, createKeySchema))
+        await manageClient.Invoking(y => y.CreateKey(UriSegments.PROJECTS, createKeySchema))
              .Should().ThrowAsync<ArgumentException>();
     }
 
     [Test]
-    public async Task DeleteProjectKey_Should_Call_DeleteAsync()
+    public async Task DeleteKey_Should_Call_DeleteAsync()
     {
         //Arrange
         var keyId = new Faker().Random.Guid().ToString();
@@ -320,7 +316,7 @@ public class ManageClientTest
         manageClient.DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/keys/{keyId}").Returns(Task.CompletedTask);
 
         // Act
-        await manageClient.DeleteProjectKey(_projectId, keyId);
+        await manageClient.DeleteKey(_projectId, keyId);
 
         // Assert
         await manageClient.Received().DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/keys/{keyId}");
@@ -331,7 +327,7 @@ public class ManageClientTest
     #region ProjectInvites
 
     [Test]
-    public async Task GetProjectInvites_Should_Call_GetAsync_Returning_InvitesResponse()
+    public async Task GetInvites_Should_Call_GetAsync_Returning_InvitesResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<InvitesResponse>().Generate();
@@ -343,7 +339,7 @@ public class ManageClientTest
         manageClient.GetAsync<InvitesResponse>($"{UriSegments.PROJECTS}/{_projectId}/invites").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectInvites(_projectId);
+        var result = await manageClient.GetInvites(_projectId);
 
         // Assert
         await manageClient.Received().GetAsync<InvitesResponse>($"{UriSegments.PROJECTS}/{_projectId}/invites");
@@ -356,7 +352,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task SendProjectInvite_Should_Call_PostAsync_Returning_MessageResponse()
+    public async Task SendInvite_Should_Call_PostAsync_Returning_MessageResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
@@ -369,7 +365,7 @@ public class ManageClientTest
         manageClient.PostAsync<MessageResponse>($"{UriSegments.PROJECTS}/{_projectId}/invites", Arg.Any<StringContent>()).Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.SendProjectInvite(_projectId, inviteSchema);
+        var result = await manageClient.SendInvite(_projectId, inviteSchema);
 
         // Assert
         await manageClient.Received().PostAsync<MessageResponse>($"{UriSegments.PROJECTS}/{_projectId}/invites", Arg.Any<StringContent>());
@@ -382,7 +378,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task DeleteProjectInvite_Should_Call_DeleteAsync()
+    public async Task DeleteInvite_Should_Call_DeleteAsync()
     {
         //Arrange        
         var email = new Faker().Internet.Email();
@@ -394,7 +390,7 @@ public class ManageClientTest
         manageClient.DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/invites/{email}").Returns(Task.CompletedTask);
 
         // Act
-        await manageClient.DeleteProjectInvite(_projectId, email);
+        await manageClient.DeleteInvite(_projectId, email);
 
         // Assert
         await manageClient.Received().DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/invites/{email}");
@@ -404,7 +400,7 @@ public class ManageClientTest
 
     #region Members
     [Test]
-    public async Task GetProjectMembers_Should_Call_GetAsync_Returning_MembersResponse()
+    public async Task GetMembers_Should_Call_GetAsync_Returning_MembersResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<MembersResponse>().Generate();
@@ -416,7 +412,7 @@ public class ManageClientTest
         manageClient.GetAsync<MembersResponse>($"{UriSegments.PROJECTS}/{_projectId}/members").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectMembers(_projectId);
+        var result = await manageClient.GetMembers(_projectId);
 
         // Assert
         await manageClient.Received().GetAsync<MembersResponse>($"{UriSegments.PROJECTS}/{_projectId}/members");
@@ -429,7 +425,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectMemberScopes_Should_Call_GetAsync_Returning_MemberScopesResponse()
+    public async Task GetMemberScopes_Should_Call_GetAsync_Returning_MemberScopesResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<MemberScopesResponse>().Generate();
@@ -443,7 +439,7 @@ public class ManageClientTest
         manageClient.GetAsync<MemberScopesResponse>($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}/scopes").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectMemberScopes(_projectId, memberId);
+        var result = await manageClient.GetMemberScopes(_projectId, memberId);
 
         // Assert
         await manageClient.Received().GetAsync<MemberScopesResponse>($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}/scopes");
@@ -456,7 +452,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task UpdateProjectMemberScope_Should_Call_PutAsync_Returning_MessageResponse()
+    public async Task UpdateMemberScope_Should_Call_PutAsync_Returning_MessageResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
@@ -470,7 +466,7 @@ public class ManageClientTest
         manageClient.PutAsync<MessageResponse>($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}/scopes", Arg.Any<StringContent>()).Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.UpdateProjectMemberScope(_projectId, memberId, memberScopeSchema);
+        var result = await manageClient.UpdateMemberScope(_projectId, memberId, memberScopeSchema);
 
         // Assert
         await manageClient.Received().PutAsync<MessageResponse>($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}/scopes", Arg.Any<StringContent>());
@@ -483,7 +479,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task RemoveProjectMember_Should_Call_DeleteAsync()
+    public async Task RemoveMember_Should_Call_DeleteAsync()
     {
         //Arrange         
         var memberId = new Faker().Random.Guid().ToString();
@@ -495,7 +491,7 @@ public class ManageClientTest
         manageClient.DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}").Returns(Task.CompletedTask);
 
         // Act
-        await manageClient.RemoveProjectMember(_projectId, memberId);
+        await manageClient.RemoveMember(_projectId, memberId);
 
         // Assert
         await manageClient.Received().DeleteAsync($"{UriSegments.PROJECTS}/{_projectId}/members/{memberId}");
@@ -505,7 +501,7 @@ public class ManageClientTest
 
     #region Usage
     [Test]
-    public async Task GetProjectUsageRequests_Should_Call_GetAsync_Returning_UsageRequestsResponse()
+    public async Task GetUsageRequests_Should_Call_GetAsync_Returning_UsageRequestsResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<UsageRequestsResponse>().Generate();
@@ -519,7 +515,7 @@ public class ManageClientTest
         manageClient.GetAsync<UsageRequestsResponse>($"{UriSegments.PROJECTS}/{_projectId}/requests?{stringedOptions}").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectUsageRequests(_projectId, UsageRequestsSchema);
+        var result = await manageClient.GetUsageRequests(_projectId, UsageRequestsSchema);
 
         // Assert
         await manageClient.Received().GetAsync<UsageRequestsResponse>($"{UriSegments.PROJECTS}/{_projectId}/requests?{stringedOptions}");
@@ -533,7 +529,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectsUsageRequest_Should_Call_GetAsync_Returning_UsageRequestResponse()
+    public async Task GetsUsageRequest_Should_Call_GetAsync_Returning_UsageRequestResponse()
     {
         //Arrange 
         var requestId = new Faker().Random.Guid().ToString();
@@ -546,7 +542,7 @@ public class ManageClientTest
         manageClient.GetAsync<UsageRequestResponse>($"{UriSegments.PROJECTS}/{_projectId}/requests/{requestId}").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectUsageRequest(_projectId, requestId);
+        var result = await manageClient.GetUsageRequest(_projectId, requestId);
 
         // Assert
         await manageClient.Received().GetAsync<UsageRequestResponse>($"{UriSegments.PROJECTS}/{_projectId}/requests/{requestId}");
@@ -559,7 +555,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectsUsageSummary_Should_Call_GetAsync_Returning_UsageSummaryResponse()
+    public async Task GetsUsageSummary_Should_Call_GetAsync_Returning_UsageSummaryResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<UsageSummaryResponse>().Generate();
@@ -573,7 +569,7 @@ public class ManageClientTest
         manageClient.GetAsync<UsageSummaryResponse>($"{UriSegments.PROJECTS}/{_projectId}/usage?{stringedOptions}").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectUsageSummary(_projectId, getProjectUsageSummarySchema);
+        var result = await manageClient.GetUsageSummary(_projectId, getProjectUsageSummarySchema);
 
         // Assert
         await manageClient.Received().GetAsync<UsageSummaryResponse>($"{UriSegments.PROJECTS}/{_projectId}/usage?{stringedOptions}");
@@ -587,7 +583,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectUsageFields_Should_GetAsync_Returning_UsageSummaryResponse()
+    public async Task GetUsageFields_Should_GetAsync_Returning_UsageSummaryResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<UsageFieldsResponse>().Generate();
@@ -601,7 +597,7 @@ public class ManageClientTest
         manageClient.GetAsync<UsageFieldsResponse>($"{UriSegments.PROJECTS}/{_projectId}/usage/fields?{stringedOptions}").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectUsageFields(_projectId, getProjectUsageFieldsSchema);
+        var result = await manageClient.GetUsageFields(_projectId, getProjectUsageFieldsSchema);
 
         // Assert
         await manageClient.Received().GetAsync<UsageFieldsResponse>($"{UriSegments.PROJECTS}/{_projectId}/usage/fields?{stringedOptions}");
@@ -619,7 +615,7 @@ public class ManageClientTest
     #region Balances
 
     [Test]
-    public async Task GetProjectBalances_Should_Call_GetAsync_Returning_BalancesResponse()
+    public async Task GetBalances_Should_Call_GetAsync_Returning_BalancesResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<BalancesResponse>().Generate();
@@ -631,7 +627,7 @@ public class ManageClientTest
         manageClient.GetAsync<BalancesResponse>($"{UriSegments.PROJECTS}/{_projectId}/balances").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectBalances(_projectId);
+        var result = await manageClient.GetBalances(_projectId);
 
         // Assert
         await manageClient.Received().GetAsync<BalancesResponse>($"{UriSegments.PROJECTS}/{_projectId}/balances");
@@ -644,7 +640,7 @@ public class ManageClientTest
     }
 
     [Test]
-    public async Task GetProjectBalance_Should_Call_GetAsync_Returning_BalanceResponse()
+    public async Task GetBalance_Should_Call_GetAsync_Returning_BalanceResponse()
     {
         //Arrange 
         var expectedResponse = new AutoFaker<BalanceResponse>().Generate();
@@ -656,7 +652,7 @@ public class ManageClientTest
         manageClient.GetAsync<BalanceResponse>($"{UriSegments.PROJECTS}/{_projectId}/balances/{balanceId}").Returns(expectedResponse);
 
         // Act
-        var result = await manageClient.GetProjectBalance(_projectId, balanceId);
+        var result = await manageClient.GetBalance(_projectId, balanceId);
 
         // Assert
         await manageClient.Received().GetAsync<BalanceResponse>($"{UriSegments.PROJECTS}/{_projectId}/balances/{balanceId}");

--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -49,5 +49,5 @@ internal static partial class Log
     EventId = 0018,
     Level = LogLevel.Error,
     Message = "Error creating project key both ExpirationDate and TimeToLiveInSeconds are set: `{createProjectKeySchema}`")]
-    internal static partial void CreateProjectKeyError(this ILogger logger, KeySchema createProjectKeySchema);
+    internal static partial void CreateKeyError(this ILogger logger, KeySchema createProjectKeySchema);
 }

--- a/Deepgram/ManageClient.cs
+++ b/Deepgram/ManageClient.cs
@@ -68,7 +68,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// </summary>
     /// <param name="projectId">Id of project</param>
     /// <returns><see cref="KeysResponse"/></returns>
-    public async Task<KeysResponse> GetProjectKeys(string projectId, CancellationToken cancellationToken = default) =>
+    public async Task<KeysResponse> GetKeys(string projectId, CancellationToken cancellationToken = default) =>
         await GetAsync<KeysResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.KEYS}", cancellationToken);
 
     /// <summary>
@@ -77,7 +77,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="keyId">Id of key</param>
     /// <returns><see cref="KeyScopeResponse"/></returns>
-    public async Task<KeyScopeResponse> GetProjectKey(string projectId, string keyId, CancellationToken cancellationToken = default) =>
+    public async Task<KeyScopeResponse> GetKey(string projectId, string keyId, CancellationToken cancellationToken = default) =>
         await GetAsync<KeyScopeResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.KEYS}/{keyId}", cancellationToken);
 
     /// <summary>
@@ -86,11 +86,11 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="createProjectKeySchema"><see cref="KeySchema"/> for the key to be created</param>
     /// <returns><see cref="KeyResponse"/></returns>
-    public async Task<KeyResponse> CreateProjectKey(string projectId, KeySchema createProjectKeySchema, CancellationToken cancellationToken = default)
+    public async Task<KeyResponse> CreateKey(string projectId, KeySchema createProjectKeySchema, CancellationToken cancellationToken = default)
     {
         if (createProjectKeySchema.ExpirationDate is not null && createProjectKeySchema.TimeToLiveInSeconds is not null)
         {
-            Log.CreateProjectKeyError(_logger, createProjectKeySchema);
+            Log.CreateKeyError(_logger, createProjectKeySchema);
             throw new ArgumentException("Both ExpirationDate and TimeToLiveInSeconds is set. set either one but not both");
         }
 
@@ -106,7 +106,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="keyId">Id of key</param>
     // Nothing being returned
-    public async Task DeleteProjectKey(string projectId, string keyId, CancellationToken cancellationToken = default) =>
+    public async Task DeleteKey(string projectId, string keyId, CancellationToken cancellationToken = default) =>
         await DeleteAsync($"{UriSegments.PROJECTS}/{projectId}/keys/{keyId}", cancellationToken);
 
     #endregion
@@ -117,7 +117,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// </summary>
     /// <param name="projectId">Id of project</param>
     /// <returns><see cref="InvitesResponse"/></returns>
-    public async Task<InvitesResponse> GetProjectInvites(string projectId, CancellationToken cancellationToken = default) =>
+    public async Task<InvitesResponse> GetInvites(string projectId, CancellationToken cancellationToken = default) =>
         await GetAsync<InvitesResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.INVITES}", cancellationToken);
 
     /// <summary>
@@ -126,7 +126,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="email">email of the invite to be removed</param>
     //no response expected
-    public async Task DeleteProjectInvite(string projectId, string email, CancellationToken cancellationToken = default) =>
+    public async Task DeleteInvite(string projectId, string email, CancellationToken cancellationToken = default) =>
         await DeleteAsync($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.INVITES}/{email}", cancellationToken);
 
     /// <summary>
@@ -135,7 +135,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="inviteSchema"><see cref="InviteSchema"/> for a invite to project</param>
     /// <returns><see cref="MessageResponse"/></returns>
-    public async Task<MessageResponse> SendProjectInvite(string projectId, InviteSchema inviteSchema, CancellationToken cancellationToken = default) =>
+    public async Task<MessageResponse> SendInvite(string projectId, InviteSchema inviteSchema, CancellationToken cancellationToken = default) =>
         await PostAsync<MessageResponse>(
             $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.INVITES}",
             RequestContentUtil.CreatePayload(inviteSchema), cancellationToken);
@@ -147,7 +147,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// </summary>
     /// <param name="projectId">Id of project</param>
     /// <returns><see cref="MembersResponse"/></returns>
-    public async Task<MembersResponse> GetProjectMembers(string projectId, CancellationToken cancellationToken = default) =>
+    public async Task<MembersResponse> GetMembers(string projectId, CancellationToken cancellationToken = default) =>
         await GetAsync<MembersResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}", cancellationToken);
 
     /// <summary>
@@ -156,7 +156,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="memberId">Id of member</param>
     /// <returns><see cref="MemberScopesResponse"/></returns>
-    public async Task<MemberScopesResponse> GetProjectMemberScopes(string projectId, string memberId, CancellationToken cancellationToken = default) =>
+    public async Task<MemberScopesResponse> GetMemberScopes(string projectId, string memberId, CancellationToken cancellationToken = default) =>
         await GetAsync<MemberScopesResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}/{memberId}/{UriSegments.SCOPES}", cancellationToken);
 
     /// <summary>
@@ -166,7 +166,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="memberId">Id of member</param>
     /// <param name="memberScopeSchema">updates scope options for member<see cref="MemberScopeSchema"/></param>
     /// <returns><see cref="MessageResponse"/></returns>  
-    public async Task<MessageResponse> UpdateProjectMemberScope(string projectId, string memberId, MemberScopeSchema memberScopeSchema, CancellationToken cancellationToken = default) =>
+    public async Task<MessageResponse> UpdateMemberScope(string projectId, string memberId, MemberScopeSchema memberScopeSchema, CancellationToken cancellationToken = default) =>
         await PutAsync<MessageResponse>(
             $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}/{memberId}/{UriSegments.SCOPES}",
             RequestContentUtil.CreatePayload(memberScopeSchema), cancellationToken);
@@ -177,7 +177,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="memberId">Id of member</param>   
     //No response expected
-    public async Task RemoveProjectMember(string projectId, string memberId, CancellationToken cancellationToken = default) =>
+    public async Task RemoveMember(string projectId, string memberId, CancellationToken cancellationToken = default) =>
         await DeleteAsync($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}/{memberId}", cancellationToken);
     #endregion
 
@@ -189,7 +189,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="UsageRequestsSchema">Project usage request options<see cref="UsageRequestsSchema"/>  </param>
     /// <returns><see cref="UsageRequestsResponse"/></returns>
-    public async Task<UsageRequestsResponse> GetProjectUsageRequests(string projectId, UsageRequestsSchema UsageRequestsSchema, CancellationToken cancellationToken = default)
+    public async Task<UsageRequestsResponse> GetUsageRequests(string projectId, UsageRequestsSchema UsageRequestsSchema, CancellationToken cancellationToken = default)
     {
         var stringedOptions = QueryParameterUtil.GetParameters(UsageRequestsSchema);
         return await GetAsync<UsageRequestsResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.REQUESTS}?{stringedOptions}", cancellationToken);
@@ -201,7 +201,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="requestId">Id of request</param>
     /// <returns><see cref="UsageRequestResponse"/></returns>
-    public async Task<UsageRequestResponse> GetProjectUsageRequest(string projectId, string requestId, CancellationToken cancellationToken = default) =>
+    public async Task<UsageRequestResponse> GetUsageRequest(string projectId, string requestId, CancellationToken cancellationToken = default) =>
         await GetAsync<UsageRequestResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.REQUESTS}/{requestId}", cancellationToken);
 
     /// <summary>
@@ -210,7 +210,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="getProjectUsageSummarySchema">Usage summary options<see cref="UsageSummarySchema"/> </param>
     /// <returns><see cref="UsageSummaryResponse"/></returns>
-    public async Task<UsageSummaryResponse> GetProjectUsageSummary(string projectId, UsageSummarySchema getProjectUsageSummarySchema, CancellationToken cancellationToken = default)
+    public async Task<UsageSummaryResponse> GetUsageSummary(string projectId, UsageSummarySchema getProjectUsageSummarySchema, CancellationToken cancellationToken = default)
     {
         var stringedOptions = QueryParameterUtil.GetParameters(getProjectUsageSummarySchema);
         return await GetAsync<UsageSummaryResponse>(
@@ -223,7 +223,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="getProjectUsageFieldsSchema">Project usage request field options<see cref="UsageFieldsSchema"/></param>
     /// <returns><see cref="UsageFieldsResponse"/></returns>
-    public async Task<UsageFieldsResponse> GetProjectUsageFields(string projectId, UsageFieldsSchema getProjectUsageFieldsSchema, CancellationToken cancellationToken = default)
+    public async Task<UsageFieldsResponse> GetUsageFields(string projectId, UsageFieldsSchema getProjectUsageFieldsSchema, CancellationToken cancellationToken = default)
     {
         var stringedOptions = QueryParameterUtil.GetParameters(getProjectUsageFieldsSchema);
         return await GetAsync<UsageFieldsResponse>(
@@ -238,7 +238,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// </summary>
     /// <param name="projectId">Id of project</param>
     /// <returns><see cref="BalancesResponse"/></returns>
-    public async Task<BalancesResponse> GetProjectBalances(string projectId, CancellationToken cancellationToken = default) =>
+    public async Task<BalancesResponse> GetBalances(string projectId, CancellationToken cancellationToken = default) =>
         await GetAsync<BalancesResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.BALANCES}", cancellationToken);
 
     /// <summary>
@@ -247,7 +247,7 @@ public class ManageClient(string apiKey, DeepgramClientOptions? deepgramClientOp
     /// <param name="projectId">Id of project</param>
     /// <param name="balanceId">Id of balance</param>
     /// <returns><see cref="BalanceResponse"/></returns>
-    public async Task<BalanceResponse> GetProjectBalance(string projectId, string balanceId, CancellationToken cancellationToken = default) =>
+    public async Task<BalanceResponse> GetBalance(string projectId, string balanceId, CancellationToken cancellationToken = default) =>
         await GetAsync<BalanceResponse>($"{UriSegments.PROJECTS}/{projectId}/{UriSegments.BALANCES}/{balanceId}", cancellationToken);
     #endregion
 }


### PR DESCRIPTION
It looks like the Manage function names also needed to be changed to the more minimalist form. This matches the recent changes with the model names in this PR https://github.com/deepgram/deepgram-dotnet-sdk/pull/190. Effectively, this removes "GetProject" from every function name (ie. `GetProjectUsageRequest()` -> `GetUsageRequest()`) to make it easier to call functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified naming for project management functions for better clarity and consistency.
- **Tests**
	- Updated unit tests to align with the renamed functions in project management.
- **Bug Fixes**
	- Adjusted error logging method name for consistency with other naming updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->