### PR TITLE
Enable Developer Builds to Get Published to `Deepgram.Unstable.SDK.Builds`

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -1,0 +1,50 @@
+name: Development Releases
+
+on:
+    push:
+      branches:
+        - "!not_activated_on_branches!*"
+      tags:
+        - "[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: ["6.0.x", "7.0.x","8.0.x"]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.target_commitish }}
+      - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Install dependencies
+        run: dotnet restore Deepgram.DevBuild.sln
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      - name: Build
+        run: dotnet build Deepgram.DevBuild.sln --configuration Release --no-restore
+      - name: Pack
+        run: |
+          dotnet pack Deepgram.DevBuild.sln --configuration Release --no-restore --output ./dist -p:Version=${{ steps.get_version.outputs.VERSION }}
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist
+  publish:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: "dist"
+      - name: Publish packages
+        run: dotnet nuget push ./dist/**.nupkg --source nuget.org --api-key ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore Deepgram.sln
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore Deepgram.sln
       - name: Run tests
         run: dotnet test Deepgram.sln
   build:
@@ -34,6 +34,6 @@ jobs:
         with:
           dotnet-version: "8.x.x"
       - name: Install dependencies
-        run: dotnet restore
+        run: dotnet restore Deepgram.sln
       - name: Build
         run: dotnet build Deepgram.sln --configuration Release --no-restore

--- a/Deepgram.DevBuild.sln
+++ b/Deepgram.DevBuild.sln
@@ -1,0 +1,29 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Deepgram", "Deepgram\Deepgram.csproj", "{1F72D53C-2EF5-4556-A0E6-18D57BF9648B}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1F72D53C-2EF5-4556-A0E6-18D57BF9648B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1F72D53C-2EF5-4556-A0E6-18D57BF9648B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1F72D53C-2EF5-4556-A0E6-18D57BF9648B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1F72D53C-2EF5-4556-A0E6-18D57BF9648B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED1EF53E-BA86-44FA-B1C0-484B3864E459}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED1EF53E-BA86-44FA-B1C0-484B3864E459}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED1EF53E-BA86-44FA-B1C0-484B3864E459}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED1EF53E-BA86-44FA-B1C0-484B3864E459}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8D4ABC6D-7126-4EE2-9303-43A954616B2A}
+	EndGlobalSection
+EndGlobal

--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>   
   </PropertyGroup>
   
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(SolutionFileName)' == 'Deepgram.sln'">
     <!-- Properties related to NuGet packaging: -->
     <IsPackable>true</IsPackable>
     <Company>Deepgram</Company>
@@ -16,7 +16,28 @@
     <Description>SDK for communicating with the Deepgram APIs </Description>
     <Summary>SDK for communicating with the Deepgram APIs </Summary>
     <Authors>Deepgram .NET SDK Contributors</Authors>
-    <Copyright>2021 Deepgram</Copyright>
+    <Copyright>2021-2024 Deepgram</Copyright>
+    <PackageIcon>dg_logo.png</PackageIcon>
+    <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://developers.deepgram.com/sdks-tools/sdks/dotnet-sdk/</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/deepgram-devs/deepgram-dotnet-sdk</RepositoryUrl>
+    <PackageTags>speech-to-text,captions,speech-recognition,deepgram,dotnet</PackageTags>
+    <EnableNETAnalyzers>True</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(SolutionFileName)' == 'Deepgram.DevBuild.sln'">
+    <!-- Properties related to NuGet packaging: -->
+    <IsPackable>true</IsPackable>
+    <Company>Deepgram</Company>
+    <PackageId>Deepgram.Unstable.SDK.Builds</PackageId>
+    <Title>Deepgram - UNSTABLE DEVELOPER BUILDS</Title>
+    <Description>UNSTABLE DEVELOPER BUILDS - Deepgram .NET SDK</Description>
+    <Summary>UNSTABLE DEVELOPER BUILDS - .NET SDK for communicating with the Deepgram APIs</Summary>
+    <Authors>Deepgram .NET SDK Contributors</Authors>
+    <Copyright>2021-2024 Deepgram</Copyright>
     <PackageIcon>dg_logo.png</PackageIcon>
     <PackageRequireLicenseAcceptance>False</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
It looks like the official Deepgram .NET SDK package on Nuget doesn't have any developer, alpha, beta, or rc builds unless you go waaaay back to `1.0.0-beta2`:
https://www.nuget.org/packages/Deepgram

I want the ability to create Unstable test builds but without polluting the "official" `Deepgram` packages above. This creates a separate package in Nuget independent of the official one which will be called `Deepgram.Unstable.SDK.Builds` with descriptions and warnings for individuals not to install this. See in the configuration below:
```
    <PackageId>Deepgram.Unstable.SDK.Builds</PackageId>
    <Title>Deepgram - UNSTABLE DEVELOPER BUILDS</Title>
    <Description>UNSTABLE DEVELOPER BUILDS - Deepgram .NET SDK</Description>
    <Summary>UNSTABLE DEVELOPER BUILDS - .NET SDK for communicating with the Deepgram APIs</Summary>
```

To build this particular release, you will use the `Deepgram.DevBuild.sln` solution file in the CD-dev.yml workflow.

A test `Deepgram.Unstable.SDK.Builds` build exists here:
![Screenshot 2024-02-14 at 12 37 41](https://github.com/deepgram/deepgram-dotnet-sdk/assets/12752197/5714f8df-2d5d-4649-957d-63d1edde245a)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Continuous Deployment (CD) workflow for development releases, optimizing the build and deployment process across different .NET Core SDK versions.
	- Created a new Visual Studio solution (`Deepgram-DEV.sln`) tailored for development, supporting multiple target frameworks and enhanced package metadata for NuGet distribution.

- **Enhancements**
	- Updated the CD pipeline to explicitly specify the solution file for dependency restoration, improving build reliability.

- **Documentation**
	- Updated copyright information to reflect the current year, ensuring compliance and up-to-date documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->