### PR TITLE
Adds support for SpeechStarted

### DIFF
--- a/Deepgram/Interfaces/ILiveTranscriptionClient.cs
+++ b/Deepgram/Interfaces/ILiveTranscriptionClient.cs
@@ -27,6 +27,11 @@ namespace Deepgram.Interfaces
         /// Fires when a transcript is received from the Deepgram API
         /// </summary>
         event EventHandler<TranscriptReceivedEventArgs> TranscriptReceived;
+        
+        /// <summary>
+        /// Fires if vad_events set to true and speech detected
+        /// </summary>
+        event EventHandler<SpeechStartedEventArgs> SpeechStarted;
 
         /// <summary>
         /// Retrieves the connection state of the WebSocket

--- a/Deepgram/Models/LiveTranscriptionOptions.cs
+++ b/Deepgram/Models/LiveTranscriptionOptions.cs
@@ -247,5 +247,8 @@ namespace Deepgram.Models
         /// </summary>
         [JsonProperty("tag")]
         public string[] Tag { get; set; }
+
+        [JsonProperty("vad_events")]
+        public bool VadEvents { get; set; }
     }
 }

--- a/Deepgram/Models/LiveTranscriptionResult.cs
+++ b/Deepgram/Models/LiveTranscriptionResult.cs
@@ -50,5 +50,8 @@ namespace Deepgram.Models
         /// </summary>
         [JsonProperty("tags")]
         public string[] Tags { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
     }
 }

--- a/Deepgram/Models/LiveTranscriptionSpeechStarted.cs
+++ b/Deepgram/Models/LiveTranscriptionSpeechStarted.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Deepgram.Models
+{
+    public class LiveTranscriptionSpeechStarted
+    {
+        /// <summary>
+        /// Timestamp since start of first recognition that speech started.
+        /// </summary>
+        [JsonProperty("timestamp")]
+        public decimal Timestamp { get; set; }
+
+        /// <summary>
+        /// The channel field is interpreted as [A,B], where A is the channel index, and B is the total number of channels. The above example is channel 0 of single-channel audio.
+        /// </summary>
+        [JsonProperty("channel")]
+        public int[] Channel { get; set; }
+
+        /// <summary>
+        /// The type field is always SpeechStarted for this event
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/Deepgram/Models/SpeechStartedEventArgs.cs
+++ b/Deepgram/Models/SpeechStartedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Deepgram.Models
+{
+    public class SpeechStartedEventArgs : EventArgs
+    {
+        public SpeechStartedEventArgs(LiveTranscriptionSpeechStarted speechStarted)
+        {
+            SpeechStarted = speechStarted;
+        }
+
+        public LiveTranscriptionSpeechStarted SpeechStarted { get; set; }
+    }
+}


### PR DESCRIPTION
I needed to use speech started event so I made an update with the event added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced Voice Activity Detection (VAD) events to the live transcription service. Now, when speech is detected, a `SpeechStarted` event will be triggered if VAD events are enabled.
	- Added a new option `VadEvents` to enable or disable VAD events during live transcription.
- **Enhancements**
	- Enhanced live transcription results to include a `Type` property, improving result interpretation.
- **Documentation**
	- Updated documentation to include details on the new `SpeechStarted` event and `VadEvents` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->