### PR TITLE
Fix Update ClientOptions Based on HTTP and WS

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
@@ -18,7 +18,10 @@ public class AbstractRestfulClientTests
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _clientOptions = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _clientOptions = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
     }
 
     [Test]

--- a/Deepgram.Tests/UnitTests/ClientTests/AnalyzeClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AnalyzeClientTests.cs
@@ -17,7 +17,10 @@ public class AnalyzeClientTests
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _options = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _options = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
     }
 
     [Test]

--- a/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/ManageClientTest.cs
@@ -19,7 +19,10 @@ public class ManageClientTest
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _options = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _options = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
         _projectId = new Faker().Random.Guid().ToString();
     }
 

--- a/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
@@ -17,7 +17,10 @@ public class OnPremClientTests
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _options = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _options = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
         _projectId = new Faker().Random.Guid().ToString();
     }
 

--- a/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
@@ -17,7 +17,10 @@ public class PreRecordedClientTests
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _options = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _options = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
     }
 
     [Test]

--- a/Deepgram.Tests/UnitTests/ClientTests/SpeakClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/SpeakClientTests.cs
@@ -17,7 +17,10 @@ public class SpeakClientTests
     public void Setup()
     {
         _apiKey = new Faker().Random.Guid().ToString();
-        _options = new DeepgramHttpClientOptions(_apiKey, null, null, true);
+        _options = new DeepgramHttpClientOptions(_apiKey)
+        {
+            OnPrem = true,
+        };
     }
 
     //[Test]

--- a/Deepgram.Tests/UnitTests/HttpExtensionsTests/HttpClientExtensionTests.cs
+++ b/Deepgram.Tests/UnitTests/HttpExtensionsTests/HttpClientExtensionTests.cs
@@ -70,7 +70,7 @@ public class HttpClientTests
     {
         // Input and Output 
         var _apiKey = new Faker().Random.Guid().ToString();
-        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, null, null, null, FakeHeaders());
+        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, null, null, FakeHeaders());
 
         // Fake Clients
         var httpClient = MockHttpClient.CreateHttpClientWithResult(new MessageResponse(), HttpStatusCode.OK);
@@ -95,7 +95,7 @@ public class HttpClientTests
         var expectedBaseAddress = $"https://{_customUrl}/v1";
         var customBaseAddress = $"https://{_customUrl}";
         var _apiKey = new Faker().Random.Guid().ToString();
-        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, customBaseAddress, null, null, FakeHeaders());
+        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, customBaseAddress, null, FakeHeaders());
 
         // Fake Clients
         var httpClient = MockHttpClient.CreateHttpClientWithResult(new MessageResponse(), HttpStatusCode.OK);
@@ -122,7 +122,7 @@ public class HttpClientTests
         var expectedBaseAddress = $"https://{_customUrl}/v1";
         var customBaseAddress = $"https://{_customUrl}";
         var _apiKey = new Faker().Random.Guid().ToString();
-        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, customBaseAddress, null, null, FakeHeaders());
+        var _clientOptions = new DeepgramHttpClientOptions(_apiKey, customBaseAddress, null, FakeHeaders());
 
         // Fake Clients
         var httpClient = MockHttpClient.CreateHttpClientWithResult(new MessageResponse(), HttpStatusCode.OK, expectedBaseAddress);

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -34,7 +34,6 @@ public abstract class AbstractRestClient
 
         Log.Debug("AbstractRestClient", $"APIVersion: {options.APIVersion}");
         Log.Debug("AbstractRestClient", $"BaseAddress: {options.BaseAddress}");
-        Log.Debug("AbstractRestClient", $"KeepAlive: {options.KeepAlive}");
         Log.Debug("AbstractRestClient", $"options: {options.OnPrem}");
         Log.Verbose("AbstractRestClient", "LEAVE");
     }

--- a/Deepgram/Models/Authenticate/v1/DeepgramHttpClientOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramHttpClientOptions.cs
@@ -38,14 +38,6 @@ public class DeepgramHttpClientOptions
     /*****************************/
 
     /*****************************/
-    // Live
-    /*****************************/
-    /// <summary>
-    /// Enable sending KeepAlives for Streaming
-    /// </summary>
-    public bool KeepAlive { get; set; } = false;
-
-    /*****************************/
     // OnPrem
     /*****************************/
     /// <summary>
@@ -62,26 +54,25 @@ public class DeepgramHttpClientOptions
     /*****************************/
 
     /*****************************/
+    // Speak
+    /*****************************/
+
+    /*****************************/
     // Constructor
     /*****************************/
-    public DeepgramHttpClientOptions(string? apiKey = null, string? baseAddress = null, bool? keepAlive = null, bool? onPrem = null, Dictionary<string, string>? headers = null, string? apiVersion = null)
+    public DeepgramHttpClientOptions(string? apiKey = null, string? baseAddress = null, bool? onPrem = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("DeepgramHttpClientOptions", "ENTER");
         Log.Debug("DeepgramHttpClientOptions", apiKey == null ? "API KEY is null" : "API KEY provided");
         Log.Debug("DeepgramHttpClientOptions", baseAddress == null ? "BaseAddress is null" : "BaseAddress provided");
-        Log.Debug("DeepgramHttpClientOptions", keepAlive == null ? "KeepAlive is null" : "KeepAlive provided");
         Log.Debug("DeepgramHttpClientOptions", onPrem == null ? "OnPrem is null" : "OnPrem provided");
         Log.Debug("DeepgramHttpClientOptions", headers == null ? "Headers is null" : "Headers provided");
-        Log.Debug("DeepgramHttpClientOptions", apiVersion == null ? "API Version is null" : "API Version provided");
 
         ApiKey = apiKey ?? "";
         BaseAddress = baseAddress ?? Defaults.DEFAULT_URI;
-        KeepAlive = keepAlive ?? false;
         OnPrem = onPrem ?? false;
         Headers = headers ?? new Dictionary<string, string>();
-        APIVersion = apiVersion ?? Defaults.DEFAULT_API_VERSION;
 
-        Log.Information("DeepgramHttpClientOptions", $"KeepAlive: {KeepAlive}");
         Log.Information("DeepgramHttpClientOptions", $"OnPrem: {OnPrem}");
         Log.Information("DeepgramHttpClientOptions", $"APIVersion: {APIVersion}");
 

--- a/Deepgram/Models/Authenticate/v1/DeepgramWsClientOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramWsClientOptions.cs
@@ -34,10 +34,6 @@ public class DeepgramWsClientOptions
     public Dictionary<string, string> Headers { get; set; }
 
     /*****************************/
-    // Prerecorded
-    /*****************************/
-
-    /*****************************/
     // Live
     /*****************************/
     /// <summary>
@@ -54,17 +50,13 @@ public class DeepgramWsClientOptions
     public bool OnPrem { get; set; } = false;
 
     /*****************************/
-    // Manage
-    /*****************************/
-
-    /*****************************/
-    // Analyze
+    // Speak
     /*****************************/
 
     /*****************************/
     // Constructor
     /*****************************/
-    public DeepgramWsClientOptions(string? apiKey = null, string? baseAddress = null, bool? keepAlive = null, bool? onPrem = null, Dictionary<string, string>? headers = null, string? apiVersion = null)
+    public DeepgramWsClientOptions(string? apiKey = null, string? baseAddress = null, bool? keepAlive = null, bool? onPrem = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("DeepgramWsClientOptions", "ENTER");
         Log.Debug("DeepgramWsClientOptions", apiKey == null ? "API KEY is null" : "API KEY provided");
@@ -72,14 +64,12 @@ public class DeepgramWsClientOptions
         Log.Debug("DeepgramWsClientOptions", keepAlive == null ? "KeepAlive is null" : "KeepAlive provided");
         Log.Debug("DeepgramWsClientOptions", onPrem == null ? "OnPrem is null" : "OnPrem provided");
         Log.Debug("DeepgramWsClientOptions", headers == null ? "Headers is null" : "Headers provided");
-        Log.Debug("DeepgramWsClientOptions", apiVersion == null ? "API Version is null" : "API Version provided");
 
         ApiKey = apiKey ?? "";
         BaseAddress = baseAddress ?? Defaults.DEFAULT_URI;
         KeepAlive = keepAlive ?? false;
         OnPrem = onPrem ?? false;
         Headers = headers ?? new Dictionary<string, string>();
-        APIVersion = apiVersion ?? Defaults.DEFAULT_API_VERSION;
 
         Log.Information("DeepgramWsClientOptions", $"KeepAlive: {KeepAlive}");
         Log.Information("DeepgramWsClientOptions", $"OnPrem: {OnPrem}");

--- a/examples/prerecorded/file/Program.cs
+++ b/examples/prerecorded/file/Program.cs
@@ -44,6 +44,7 @@ namespace PreRecorded
                 });
 
             Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
 
             // Teardown Library


### PR DESCRIPTION
I have been thinking about this a lot and I think separating out HTTP vs WS is probably the better thing to do for ClientOptions. As an example, the KeepAlive (currently) has no meaning for HTTP (yes, I know HTTP does actually support keeping a connection open). Just seems like this is the best way to avoid "overloaded" meanings on this because the object is entirely different.

Other changes:
- Only expose the most common options in each of the constructors as to avoid calling constructors with `Constructor(null, null, null, null, something)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced initialization of client options across various tests for consistency, specifically for on-premise configurations.
- **Bug Fixes**
	- Fixed custom headers setup in HTTP client configuration by adjusting initialization in unit tests.
- **Chores**
	- Removed unused `KeepAlive` property and associated logic from client options to streamline HTTP client setup.
- **New Features**
	- Improved user interaction in the prerecorded file example by adding a prompt to exit the program.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->