### PR TITLE
Fix DefaultTimeouts on REST and WS Operations

### DIFF
--- a/Deepgram/Abstractions/Constants.cs
+++ b/Deepgram/Abstractions/Constants.cs
@@ -12,6 +12,6 @@ public static class Constants
     // For Speak Headers
     public const int OneSecond = 1000;
     public const int OneMinute = 60 * OneSecond;
-    public const int DefaultRESTTimeout = 5 * OneMinute;
+    public const int DefaultRESTTimeout = 30 * OneSecond;
 }
 

--- a/Deepgram/Clients/Live/v1/Client.cs
+++ b/Deepgram/Clients/Live/v1/Client.cs
@@ -707,7 +707,7 @@ public class Client : Attribute, IDisposable
         if (cancelToken == null)
         {
             Log.Information("Stop", "Using default disconnect cancellation token");
-            cancelToken = new CancellationTokenSource(Constants.DefaultConnectTimeout);
+            cancelToken = new CancellationTokenSource(Constants.DefaultDisconnectTimeout);
         }
 
         try

--- a/Deepgram/Clients/Live/v1/Constants.cs
+++ b/Deepgram/Clients/Live/v1/Constants.cs
@@ -14,5 +14,6 @@ public static class Constants
 
     // Default timeout for connect/disconnect
     public const int DefaultConnectTimeout = 5000;
+    public const int DefaultDisconnectTimeout = 5000;
 }
 


### PR DESCRIPTION
This just fixes the default timeout on REST operations to 30 seconds and WS connect/disconnect to 5 seconds.