### PR TITLE
Bonked `rc.1` + ImplementHTTP Webcast Example + Model Params When Null

### DIFF
--- a/Deepgram.Dev.sln
+++ b/Deepgram.Dev.sln
@@ -139,6 +139,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TriggerCancel", "tests\expe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExerciseTimeout", "tests\expected_failures\websocket\exercise_timeout\ExerciseTimeout.csproj", "{8C5A02D8-E18B-4060-A567-A4AACC49B2F6}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "http", "http", "{5DFC6330-8303-4045-B186-32B396391D31}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Streaming", "examples\streaming\http\Streaming.csproj", "{61B42F6B-521C-4A07-B592-54975F4AE2E6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -261,6 +265,10 @@ Global
 		{8C5A02D8-E18B-4060-A567-A4AACC49B2F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8C5A02D8-E18B-4060-A567-A4AACC49B2F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8C5A02D8-E18B-4060-A567-A4AACC49B2F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61B42F6B-521C-4A07-B592-54975F4AE2E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61B42F6B-521C-4A07-B592-54975F4AE2E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61B42F6B-521C-4A07-B592-54975F4AE2E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61B42F6B-521C-4A07-B592-54975F4AE2E6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -329,6 +337,8 @@ Global
 		{DF383769-5F1F-4692-854F-2E923F3D0F09} = {D100AACD-E5FB-45E5-980B-B19C091440B2}
 		{F736604C-A245-411E-BECE-028FBD98166E} = {80E7546A-4CED-4644-8900-983422CDE73C}
 		{8C5A02D8-E18B-4060-A567-A4AACC49B2F6} = {3AC17A9C-30BB-4298-8E5A-4FAE73189821}
+		{5DFC6330-8303-4045-B186-32B396391D31} = {132EEE99-6194-477A-9416-D7EF173C17FD}
+		{61B42F6B-521C-4A07-B592-54975F4AE2E6} = {5DFC6330-8303-4045-B186-32B396391D31}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D4ABC6D-7126-4EE2-9303-43A954616B2A}

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -106,7 +106,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.GetAsync<S, T>", "ENTER");
         Log.Debug("GetAsync<S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("GetAsync<S, T>", $"parameter: {parameter}");
         Log.Debug("GetAsync<S, T>", $"addons: {addons}");
 
         try
@@ -173,7 +172,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.PostRetrieveLocalFileAsync<R, S, T>", "ENTER");
         Log.Debug("PostRetrieveLocalFileAsync<R, S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("PostRetrieveLocalFileAsync<R, S, T>", $"parameter: {parameter}");
         Log.Debug("PostRetrieveLocalFileAsync<R, S, T>", $"keys: {keys}");
         Log.Debug("PostRetrieveLocalFileAsync<R, S, T>", $"addons: {addons}");
 
@@ -290,7 +288,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.PostAsync<S, T>", "ENTER");
         Log.Debug("PostAsync<S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("PostAsync<S, T>", $"parameter: {parameter}");
         Log.Debug("PostAsync<S, T>", $"addons: {addons}");
 
         try
@@ -350,8 +347,7 @@ public abstract class AbstractRestClient
         Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("AbstractRestClient.PostAsync<R, S, T>", "ENTER");
-        Log.Debug("PostAsync<R, S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("PostAsync<R, S, T>", $"parameter: {parameter}");
+        Log.Debug("PostAsync<S, T>", $"uriSegment: {uriSegment}");
         Log.Debug("PostAsync<R, S, T>", $"addons: {addons}");
 
         try
@@ -428,7 +424,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.PatchAsync<S, T>", "ENTER");
         Log.Debug("PatchAsync<S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("PatchAsync<S, T>", $"parameter: {parameter}");
         Log.Debug("PatchAsync<S, T>", $"addons: {addons}");
 
         try
@@ -503,7 +498,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.PutAsync<S, T>", "ENTER");
         Log.Debug("PutAsync<S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("PutAsync<S, T>", $"parameter: {parameter}");
         Log.Debug("PutAsync<S, T>", $"addons: {addons}");
 
         try
@@ -635,7 +629,6 @@ public abstract class AbstractRestClient
     {
         Log.Verbose("AbstractRestClient.DeleteAsync<S, T>", "ENTER");
         Log.Debug("DeleteAsync<S, T>", $"uriSegment: {uriSegment}");
-        Log.Debug("DeleteAsync<S, T>", $"parameter: {parameter}");
         Log.Debug("DeleteAsync<S, T>", $"addons: {addons}");
 
         try

--- a/Deepgram/Clients/Analyze/v1/Client.cs
+++ b/Deepgram/Clients/Analyze/v1/Client.cs
@@ -27,7 +27,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("AnalyzeClient.AnalyzeUrl", "ENTER");
         Log.Information("AnalyzeUrl", $"source: {source}");
-        Log.Information("AnalyzeUrl", $"analyzeSchema: {analyzeSchema}");
+        Log.Information("AnalyzeUrl", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyNoCallBack(nameof(AnalyzeUrl), analyzeSchema);
 
@@ -66,7 +66,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("AnalyzeClient.AnalyzeFile", "ENTER");
         Log.Information("AnalyzeFile", $"source: {source}");
-        Log.Information("AnalyzeFile", $"analyzeSchema: {analyzeSchema}");
+        Log.Information("AnalyzeFile", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyNoCallBack(nameof(AnalyzeFile), analyzeSchema);
 
@@ -109,7 +109,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("AnalyzeClient.AnalyzeFileCallBack", "ENTER");
         Log.Information("AnalyzeFileCallBack", $"source: {source}");
         Log.Information("AnalyzeFileCallBack", $"callBack: {callBack}");
-        Log.Information("AnalyzeFileCallBack", $"analyzeSchema: {analyzeSchema}");
+        Log.Information("AnalyzeFileCallBack", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyOneCallBackSet(nameof(AnalyzeFileCallBack), callBack, analyzeSchema);
         if (callBack != null)
@@ -139,7 +139,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("AnalyzeClient.AnalyzeUrlCallBack", "ENTER");
         Log.Information("AnalyzeUrlCallBack", $"source: {source}");
         Log.Information("AnalyzeUrlCallBack", $"callBack: {callBack}");
-        Log.Information("AnalyzeUrlCallBack", $"analyzeSchema: {analyzeSchema}");
+        Log.Information("AnalyzeUrlCallBack", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyOneCallBackSet(nameof(AnalyzeUrlCallBack), callBack, analyzeSchema);
         if (callBack != null)

--- a/Deepgram/Clients/Live/v1/Client.cs
+++ b/Deepgram/Clients/Live/v1/Client.cs
@@ -63,7 +63,7 @@ public class Client : Attribute, IDisposable
         Dictionary<string, string>? headers = null)
     {
         Log.Verbose("LiveClient.Connect", "ENTER");
-        Log.Information("Connect", $"options: {options}");
+        Log.Information("Connect", $"options:\n{JsonSerializer.Serialize(options, JsonSerializeOptions.DefaultOptions)}");
         Log.Debug("Connect", $"addons: {addons}");
 
         // check if the client is disposed

--- a/Deepgram/Clients/Manage/v1/Client.cs
+++ b/Deepgram/Clients/Manage/v1/Client.cs
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
-using System;
 using Deepgram.Models.Authenticate.v1;
 using Deepgram.Models.Manage.v1;
 
@@ -69,7 +68,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.UpdateProject", "ENTER");
         Log.Information("UpdateProject", $"projectId: {projectId}");
-        Log.Information("UpdateProject", $"updateProjectSchema: {updateProjectSchema}");
+        Log.Information("UpdateProject", $"updateProjectSchema:\n{JsonSerializer.Serialize(updateProjectSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}");
         var result = await PatchAsync<ProjectSchema, MessageResponse>(uri, updateProjectSchema, cancellationToken, addons, headers);
@@ -181,7 +180,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.CreateKey", "ENTER");
         Log.Information("CreateKey", $"projectId: {projectId}");
-        Log.Information("CreateKey", $"keySchema: {keySchema}");
+        Log.Information("CreateKey", $"keySchema:\n{JsonSerializer.Serialize(keySchema, JsonSerializeOptions.DefaultOptions)}");
 
         if (keySchema.ExpirationDate is not null && keySchema.TimeToLiveInSeconds is not null)
         {
@@ -280,7 +279,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.SendInvite", "ENTER");
         Log.Information("SendInvite", $"projectId: {projectId}");
-        Log.Information("SendInvite", $"inviteSchema: {inviteSchema}");
+        Log.Information("SendInvite", $"inviteSchema:\n{JsonSerializer.Serialize(inviteSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.INVITES}");
         var result = await PostAsync<InviteSchema, MessageResponse>(uri, inviteSchema, cancellationToken, addons, headers);
@@ -351,7 +350,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("ManageClient.UpdateMemberScope", "ENTER");
         Log.Information("UpdateMemberScope", $"projectId: {projectId}");
         Log.Information("UpdateMemberScope", $"memberId: {memberId}");
-        Log.Information("UpdateMemberScope", $"projectId: {scopeSchema}");
+        Log.Information("UpdateMemberScope", $"scopeSchema:\n{JsonSerializer.Serialize(scopeSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}/{memberId}/{UriSegments.SCOPES}");
         var result = await PutAsync<MemberScopeSchema, MessageResponse>(uri,scopeSchema, cancellationToken, addons, headers);
@@ -400,7 +399,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.GetUsageRequests", "ENTER");
         Log.Information("GetUsageRequests", $"projectId: {projectId}");
-        Log.Information("GetUsageRequests", $"usageRequestsSchema: {usageRequestsSchema}");
+        Log.Information("GetUsageRequests", $"usageRequestsSchema:\n{JsonSerializer.Serialize(usageRequestsSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.REQUESTS}");
         var result = await GetAsync<UsageRequestsSchema, UsageRequestsResponse>(uri, usageRequestsSchema, cancellationToken, addons, headers);
@@ -446,7 +445,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.GetUsageSummary", "ENTER");
         Log.Information("GetUsageSummary", $"projectId: {projectId}");
-        Log.Information("GetUsageSummary", $"summarySchema: {summarySchema}");
+        Log.Information("GetUsageSummary", $"summarySchema:\n{JsonSerializer.Serialize(summarySchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.USAGE}");
         var result = await GetAsync<UsageSummarySchema, UsageSummaryResponse>(uri, summarySchema, cancellationToken, addons, headers);
@@ -469,7 +468,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("ManageClient.GetUsageFields", "ENTER");
         Log.Information("GetUsageFields", $"projectId: {projectId}");
-        Log.Information("GetUsageFields", $"summarySchema: {fieldsSchema}");
+        Log.Information("GetUsageFields", $"summarySchema:\n{JsonSerializer.Serialize(fieldsSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.USAGE}/fields");
         var result = await GetAsync<UsageFieldsSchema, UsageFieldsResponse>(uri, fieldsSchema, cancellationToken, addons, headers);

--- a/Deepgram/Clients/OnPrem/v1/Client.cs
+++ b/Deepgram/Clients/OnPrem/v1/Client.cs
@@ -94,7 +94,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("OnPremClient.CreateCredentials", "ENTER");
         Log.Debug("CreateCredentials", $"projectId: {projectId}");
-        Log.Debug("CreateCredentials", $"credentialsSchema: {credentialsSchema}");
+        Log.Debug("CreateCredentials", $"credentialsSchema:\n{JsonSerializer.Serialize(credentialsSchema, JsonSerializeOptions.DefaultOptions)}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}");
         var result = await PostAsync<CredentialsSchema, CredentialResponse>(uri, credentialsSchema, cancellationToken, addons, headers);

--- a/Deepgram/Clients/PreRecorded/v1/Client.cs
+++ b/Deepgram/Clients/PreRecorded/v1/Client.cs
@@ -29,7 +29,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("PreRecordedClient.TranscribeUrl", "ENTER");
         Log.Information("TranscribeUrl", $"source: {source}");
-        Log.Information("TranscribeUrl", $"prerecordedSchema: {prerecordedSchema}");
+        Log.Information("TranscribeUrl", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyNoCallBack(nameof(TranscribeUrl), prerecordedSchema);
 
@@ -66,7 +66,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("PreRecordedClient.TranscribeFile", "ENTER");
         Log.Information("TranscribeFile", $"source: {source}");
-        Log.Information("TranscribeFile", $"prerecordedSchema: {prerecordedSchema}");
+        Log.Information("TranscribeFile", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyNoCallBack(nameof(TranscribeFile), prerecordedSchema);
 
@@ -108,7 +108,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("PreRecordedClient.TranscribeFileCallBack", "ENTER");
         Log.Information("TranscribeFileCallBack", $"source: {source}");
         Log.Information("TranscribeFileCallBack", $"callBack: {callBack}");
-        Log.Information("TranscribeFileCallBack", $"prerecordedSchema: {prerecordedSchema}");
+        Log.Information("TranscribeFileCallBack", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyOneCallBackSet(nameof(TranscribeFileCallBack), callBack, prerecordedSchema);
         if (callBack != null)
@@ -136,7 +136,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("PreRecordedClient.TranscribeUrlCallBack", "ENTER");
         Log.Information("TranscribeUrlCallBack", $"source: {source}");
         Log.Information("TranscribeUrlCallBack", $"callBack: {callBack}");
-        Log.Information("TranscribeUrlCallBack", $"prerecordedSchema: {prerecordedSchema}");
+        Log.Information("TranscribeUrlCallBack", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyOneCallBackSet(nameof(TranscribeUrlCallBack), callBack, prerecordedSchema);
 

--- a/Deepgram/Clients/Speak/v1/Client.cs
+++ b/Deepgram/Clients/Speak/v1/Client.cs
@@ -28,7 +28,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
     {
         Log.Verbose("SpeakClient.ToStream", "ENTER");
         Log.Information("ToStream", $"source: {source}");
-        Log.Information("ToStream", $"analyzeSchema: {speakSchema}");
+        Log.Information("ToStream", $"analyzeSchema:\n{JsonSerializer.Serialize(speakSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyNoCallBack(nameof(ToStream), speakSchema);
 
@@ -98,7 +98,6 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         )
     {
         Log.Verbose("Client.ToFile", "ENTER");
-        Log.Information("ToFile", $"source: {source}");
         Log.Information("ToFile", $"filename: {filename}");
 
         var response = await ToStream(source, speakSchema, cancellationToken, addons, headers);
@@ -133,7 +132,7 @@ public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramCl
         Log.Verbose("SpeakClient.StreamCallBack", "ENTER");
         Log.Information("StreamCallBack", $"source: {source}");
         Log.Information("StreamCallBack", $"callBack: {callBack}");
-        Log.Information("StreamCallBack", $"speakSchema: {speakSchema}");
+        Log.Information("StreamCallBack", $"speakSchema:\n{JsonSerializer.Serialize(speakSchema, JsonSerializeOptions.DefaultOptions)}");
 
         VerifyOneCallBackSet(nameof(StreamCallBack), callBack, speakSchema);
         if (callBack != null)

--- a/Deepgram/Factory/HttpClientFactory.cs
+++ b/Deepgram/Factory/HttpClientFactory.cs
@@ -13,11 +13,13 @@ internal class HttpClientFactory
 
     public static HttpClient Create(string? httpId = null)
     {
-        if (string.IsNullOrWhiteSpace(httpId))
+        if (string.IsNullOrEmpty(httpId))
             httpId = HTTPCLIENT_NAME;
 
+        Log.Information("HttpClientFactory.Create", $"HttpClient ID: {httpId}");
+
         var services = new ServiceCollection();
-        services.AddHttpClient(httpId ?? HTTPCLIENT_NAME)
+        services.AddHttpClient(httpId)
             .AddTransientHttpErrorPolicy(policyBuilder =>
             policyBuilder.WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), 5)));
         var sp = services.BuildServiceProvider();

--- a/Deepgram/Models/Live/v1/Alternative.cs
+++ b/Deepgram/Models/Live/v1/Alternative.cs
@@ -11,18 +11,18 @@ public record Alternative
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("transcript")]
-    public string Transcript { get; set; }
+    public string? Transcript { get; set; }
     /// <summary>
     /// Value between 0 and 1 indicating the model's relative confidence in this transcript.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("confidence")]
-    public double Confidence { get; set; }
+    public double? Confidence { get; set; }
 
     /// <summary>
     /// ReadOnly List of <see cref="Word"/> objects.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("words")]
-    public IReadOnlyList<Word> Words { get; set; }
+    public IReadOnlyList<Word>? Words { get; set; }
 }

--- a/Deepgram/Models/Live/v1/Channel.cs
+++ b/Deepgram/Models/Live/v1/Channel.cs
@@ -11,5 +11,5 @@ public record Channel
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("alternatives")]
-    public IReadOnlyList<Alternative> Alternatives { get; set; }
+    public IReadOnlyList<Alternative>? Alternatives { get; set; }
 }

--- a/Deepgram/Models/Live/v1/Metadata.cs
+++ b/Deepgram/Models/Live/v1/Metadata.cs
@@ -11,21 +11,21 @@ public record MetaData
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("request_id")]
-    public string RequestId { get; set; }
+    public string? RequestId { get; set; }
 
     /// <summary>
     /// Model UUID
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("model_uuid")]
-    public string ModelUUID { get; set; }
+    public string? ModelUUID { get; set; }
 
     /// <summary>
     /// IReadonlyDictionary of <see cref="ModelInfo"/>
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("model_info")]
-    public ModelInfo ModelInfo { get; set; }
+    public ModelInfo? ModelInfo { get; set; }
 
     /// <summary>
     /// Deepgram’s Extra Metadata feature allows you to attach arbitrary key-value pairs to your API requests that are attached to the API response for usage in downstream processing.

--- a/Deepgram/Models/Live/v1/ModelInfo.cs
+++ b/Deepgram/Models/Live/v1/ModelInfo.cs
@@ -11,19 +11,19 @@ public record ModelInfo
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("arch")]
-    public string Arch { get; set; }
+    public string? Arch { get; set; }
 
     /// <summary>
     /// Name of the model
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("name")]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     /// <summary>
     /// Version of the model
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("version")]
-    public string Version { get; set; }
+    public string? Version { get; set; }
 }

--- a/Deepgram/Models/Live/v1/ResultResponse.cs
+++ b/Deepgram/Models/Live/v1/ResultResponse.cs
@@ -10,49 +10,49 @@ public record ResultResponse
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("channel")]
-    public Channel Channel { get; set; }
+    public Channel? Channel { get; set; }
 
     /// <summary>
     /// Channel index.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("channel_index")]
-    public IReadOnlyList<int> ChannelIndex { get; set; }
+    public IReadOnlyList<int>? ChannelIndex { get; set; }
 
     /// <summary>
     /// Duration of the result.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("duration")]
-    public double Duration { get; set; }
+    public decimal? Duration { get; set; }
 
     /// <summary>
     /// Is the result final.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("is_final")]
-    public bool IsFinal { get; set; }
+    public bool? IsFinal { get; set; }
 
     /// <summary>
     /// Metadata information.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("metadata")]
-    public MetaData MetaData { get; set; }
+    public MetaData? MetaData { get; set; }
 
     /// <summary>
     /// Is the result a partial result.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("speech_final")]
-    public bool SpeechFinal { get; set; }
+    public bool? SpeechFinal { get; set; }
 
     /// <summary>
     /// Start time of the result.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("start")]
-    public decimal Start { get; set; }
+    public decimal? Start { get; set; }
 
     /// <summary>
     /// Result event type.
@@ -60,7 +60,7 @@ public record ResultResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public LiveType Type { get; set; } = LiveType.Results;
+    public LiveType? Type { get; set; } = LiveType.Results;
 
     // TODO: DYV is this needed???
     /// <summary>

--- a/Deepgram/Models/Live/v1/Word.cs
+++ b/Deepgram/Models/Live/v1/Word.cs
@@ -11,28 +11,28 @@ public record Word
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("word")]
-    public string HeardWord { get; set; }
+    public string? HeardWord { get; set; }
 
     /// <summary>
     /// Offset in seconds from the start of the audio to where the spoken word starts.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("start")]
-    public decimal Start { get; set; }
+    public decimal? Start { get; set; }
 
     /// <summary>
     /// Offset in seconds from the start of the audio to where the spoken word ends.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("end")]
-    public decimal End { get; set; }
+    public decimal? End { get; set; }
 
     /// <summary>
     /// Value between 0 and 1 indicating the model's relative confidence in this word.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("confidence")]
-    public double Confidence { get; set; }
+    public double? Confidence { get; set; }
 
     /// <summary>
     /// Punctuated version of the word

--- a/Deepgram/Models/PreRecorded/v1/Topic.cs
+++ b/Deepgram/Models/PreRecorded/v1/Topic.cs
@@ -18,6 +18,6 @@ public record Topic
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("topic")]
-    public string Text;
+    public string? Text;
 }
 

--- a/Deepgram/Utilities/JsonSerializeOptions.cs
+++ b/Deepgram/Utilities/JsonSerializeOptions.cs
@@ -1,0 +1,13 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Utilities;
+
+internal class JsonSerializeOptions
+{
+    public static JsonSerializerOptions DefaultOptions => new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true
+    };
+}

--- a/Deepgram/Utilities/QueryParameterUtil.cs
+++ b/Deepgram/Utilities/QueryParameterUtil.cs
@@ -19,7 +19,6 @@ internal static class QueryParameterUtil
         //checks for http:// https:// http https - https:// is include to ensure it is all stripped out and correctly formatted 
         Regex regex = new Regex(@"\b(http:\/\/|https:\/\/|http|https)\b", RegexOptions.IgnoreCase);
         if (!regex.IsMatch(uriSegment))
-            Log.Information("FormatURL", "uriSegment is missing a protocol. Adding https://");
             uriSegment = $"https://{uriSegment}";
 
         // schema to be used to build the query string

--- a/examples/analyze/intent/Program.cs
+++ b/examples/analyze/intent/Program.cs
@@ -5,6 +5,7 @@
 using System.Text.Json;
 
 using Deepgram.Models.Analyze.v1;
+using Deepgram.Logger;
 
 namespace PreRecorded
 {
@@ -15,6 +16,8 @@ namespace PreRecorded
             // Initialize Library with default logging
             // Normal logging is "Info" level
             Library.Initialize();
+            // OR to set logging level
+            //Library.Initialize(LogLevel.Debug);
 
             // JSON options
             JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
@@ -32,6 +35,10 @@ namespace PreRecorded
                 return;
             }
 
+            // increase timeout to 60 seconds
+            CancellationTokenSource cancelToken = new CancellationTokenSource();
+            cancelToken.CancelAfter(TimeSpan.FromSeconds(120));
+
             var audioData = File.ReadAllBytes(@"conversation.txt");
             var response = await deepgramClient.AnalyzeFile(
                 audioData,
@@ -39,7 +46,8 @@ namespace PreRecorded
                 {
                     Language = "en",
                     Intents = true,
-                });
+                },
+                cancelToken);
 
             Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
             Console.ReadKey();

--- a/examples/prerecorded/file/Program.cs
+++ b/examples/prerecorded/file/Program.cs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: MIT
 
 using System.Text.Json;
+
 using Deepgram.Logger;
+using Deepgram.Models.Authenticate.v1;
 using Deepgram.Models.PreRecorded.v1;
 
 namespace PreRecorded
@@ -14,9 +16,9 @@ namespace PreRecorded
         {
             // Initialize Library with default logging
             // Normal logging is "Info" level
-            Library.Initialize();
+            //Library.Initialize();
             // OR very chatty logging
-            //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
+            Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
             // JSON options
             JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
@@ -25,6 +27,8 @@ namespace PreRecorded
             };
 
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
+            //DeepgramHttpClientOptions dgOptions = new DeepgramHttpClientOptions(null, "38.104.135.210");
+            //var deepgramClient = new PreRecordedClient("", dgOptions);
             var deepgramClient = new PreRecordedClient();
 
             // check to see if the file exists
@@ -34,6 +38,10 @@ namespace PreRecorded
                 return;
             }
 
+            // increase timeout to a very large value
+            CancellationTokenSource cancelToken = new CancellationTokenSource();
+            cancelToken.CancelAfter(3600000);
+
             var audioData = File.ReadAllBytes(@"Bueller-Life-moves-pretty-fast.wav");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
@@ -41,7 +49,8 @@ namespace PreRecorded
                 {
                     Model = "nova-2",
                     Punctuate = true,
-                });
+                },
+                cancelToken);
 
             Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
             Console.WriteLine("Press any key to exit...");

--- a/examples/streaming/http/Program.cs
+++ b/examples/streaming/http/Program.cs
@@ -1,0 +1,75 @@
+// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Live.v1;
+using Deepgram.Logger;
+using System.Net.WebSockets;
+
+namespace SampleApp
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // Initialize Library with default logging
+            Library.Initialize();
+
+            // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
+            var liveClient = new LiveClient();
+
+            // Subscribe to the EventResponseReceived event
+            liveClient.Subscribe(new EventHandler<ResultResponse>((sender, e) =>
+            {
+                if (e.Channel.Alternatives[0].Transcript == "")
+                {
+                    return;
+                }
+                Console.WriteLine($"Speaker: {e.Channel.Alternatives[0].Transcript}");
+            }));
+
+            // Start the connection
+            var liveSchema = new LiveSchema()
+            {
+                Model = "nova-2",
+                Punctuate = true,
+                SmartFormat = true,
+            };
+            await liveClient.Connect(liveSchema);
+
+            // get the webcast data... this is a blocking operation
+            try
+            {
+                var url = "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service";
+                using (HttpClient client = new HttpClient())
+                {
+                    using (Stream receiveStream = await client.GetStreamAsync(url))
+                    {
+                        while (liveClient.State() == WebSocketState.Open)
+                        {
+                            byte[] buffer = new byte[2048];
+                            await receiveStream.ReadAsync(buffer, 0, buffer.Length);
+                            liveClient.Send(buffer);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.Message);
+            }
+
+            // Stop the connection
+            await liveClient.Stop();
+
+            // Dispose the client
+            liveClient.Dispose();
+
+            // Teardown Library
+            Library.Terminate();
+        }
+    }
+}

--- a/examples/streaming/http/Streaming.csproj
+++ b/examples/streaming/http/Streaming.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Deepgram\Deepgram.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Using Include="Deepgram" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="preamble.wav">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+
+</Project>


### PR DESCRIPTION
First thing, `rc.1` is broken and it took me a few hours to figure out why. The why I am surprised that the compile didn't warn or flag a problem but instead it caused all REST calls to just timeout. I still don't know why the logging would cause the timeout, but I know that this is the root cause.

The root cause is that the Logger is a Singleton that doesn't normally get instantiated until the `Library.Init` is called; however, by placing this single log line in `Deepgram/Utilities/QueryParameterUtil.cs` will cause the Logger to get created because the utility class itself is a static class (this class and subsequently the logger get created on application start) seen here:
https://github.com/deepgram/deepgram-dotnet-sdk/pull/271/files#diff-c64fc6a76bdff754827d325339cfe10b6649c111860869dc9831bcbbd4cc4f66L22

Why the logger would hold up the timer and the REST `SendAsync` call... I would need to think about it. Again, I know that this is the line causing the bonk on all REST calls in `rc.1`. So at least the problem is fixed.

Second, added an example for doing HTTP Webcast from BBC to LiveClient.

Third, this exposed some params that need to be null'able when certain options are not set. Particularly, in PreRecorded and Live Models.