### PR TITLE
adds section on backwards compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Official .NET SDK for [Deepgram](https://www.deepgram.com/). Power your apps wit
   - [Live Audio Transcription Quickstart](#live-audio-transcription-quickstart)
 - [Example Code](#example-code)
 - [Logging](#logging)
+- [Backwards Compatability](#backwards-compatibility)
 - [Development and Contributing](#development-and-contributing)
 - [Getting Help](#getting-help)
 - [Backwards Compatability](#backwards-compatibility)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Official .NET SDK for [Deepgram](https://www.deepgram.com/). Power your apps wit
 - [Backwards Compatability](#backwards-compatibility)
 - [Development and Contributing](#development-and-contributing)
 - [Getting Help](#getting-help)
-- [Backwards Compatability](#backwards-compatibility)
+- [Backwards Compatibility](#backwards-compatibility)
 
 # Documentation
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Official .NET SDK for [Deepgram](https://www.deepgram.com/). Power your apps wit
 - [Logging](#logging)
 - [Development and Contributing](#development-and-contributing)
 - [Getting Help](#getting-help)
+- [Backwards Compatability](#backwards-compatibility)
 
 # Documentation
 
@@ -209,6 +210,10 @@ To increase the logging output/verbosity for debug or troubleshooting purposes, 
 ```csharp
 Library.Initialize(LogLevel.Debug);
 ```
+
+# Backwards Compatibility
+
+Older SDK versions will receive Priority 1 (P1) bug support only. Security issues, both in our code and dependencies, are promptly addressed. Significant bugs without clear workarounds are also given priority attention.
 
 # Development and Contributing
 


### PR DESCRIPTION
Adds this info which is now defined here: https://developers.deepgram.com/docs/deepgram-sdks#backwards-compatibility-of-sdks