### PR TITLE
Implement ClientOptionsFromEnv with Defined Interface for ClientOptions

### DIFF
--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -16,18 +16,21 @@ public abstract class AbstractRestClient
     /// <summary>
     /// Copy of the options for the client
     /// </summary>
-    internal DeepgramHttpClientOptions _options;
+    internal IDeepgramClientOptions _options;
 
     /// <summary>
     /// Constructor that take the options and a httpClient
     /// </summary>
     /// <param name="deepgramClientOptions"><see cref="_deepgramClientOptions"/>Options for the Deepgram client</param>
 
-    internal AbstractRestClient(string? apiKey = null, DeepgramHttpClientOptions? options = null, string? httpId = null)
+    internal AbstractRestClient(string? apiKey = null, IDeepgramClientOptions? options = null, string? httpId = null)
     {
         Log.Verbose("AbstractRestClient", "ENTER");
 
-        options ??= new DeepgramHttpClientOptions(apiKey);
+        if (options == null)
+        {
+            options = (IDeepgramClientOptions) new DeepgramHttpClientOptions(apiKey);
+        }
         _httpClient = HttpClientFactory.Create(httpId);
         _httpClient = HttpClientFactory.ConfigureDeepgram(_httpClient, options);
         _options = options;
@@ -681,7 +684,7 @@ public abstract class AbstractRestClient
         }
     }
 
-    internal static string GetUri(DeepgramHttpClientOptions options, string path)
+    internal static string GetUri(IDeepgramClientOptions options, string path)
     {
         return $"{options.BaseAddress}/{path}";
     }

--- a/Deepgram/Clients/Analyze/v1/Client.cs
+++ b/Deepgram/Clients/Analyze/v1/Client.cs
@@ -13,7 +13,7 @@ namespace Deepgram.Clients.Analyze.v1;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramClientOptions = null, string? httpId = null)
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
     : AbstractRestClient(apiKey, deepgramClientOptions, httpId), IAnalyzeClient
 {
     #region NoneCallBacks

--- a/Deepgram/Clients/Live/v1/Client.cs
+++ b/Deepgram/Clients/Live/v1/Client.cs
@@ -15,7 +15,7 @@ namespace Deepgram.Clients.Live.v1;
 public class Client : IDisposable, ILiveClient
 {
     #region Fields
-    private readonly DeepgramWsClientOptions _deepgramClientOptions;
+    private readonly IDeepgramClientOptions _deepgramClientOptions;
 
     private ClientWebSocket? _clientWebSocket;
     private CancellationTokenSource? _cancellationTokenSource;
@@ -25,8 +25,8 @@ public class Client : IDisposable, ILiveClient
     #endregion
 
     /// <param name="apiKey">Required DeepgramApiKey</param>
-    /// <param name="deepgramClientOptions"><see cref="DeepgramWsClientOptions"/> for HttpClient Configuration</param>
-    public Client(string? apiKey = null, DeepgramWsClientOptions? options = null)
+    /// <param name="deepgramClientOptions"><see cref="IDeepgramClientOptions"/> for HttpClient Configuration</param>
+    public Client(string? apiKey = null, IDeepgramClientOptions? options = null)
     {
         Log.Verbose("LiveClient", "ENTER");
 
@@ -800,7 +800,7 @@ public class Client : IDisposable, ILiveClient
     /// <summary>
     /// Get the URI for the WebSocket connection
     /// </summary> 
-    internal static Uri GetUri(DeepgramWsClientOptions options, LiveSchema parameter, Dictionary<string, string>? addons = null)
+    internal static Uri GetUri(IDeepgramClientOptions options, LiveSchema parameter, Dictionary<string, string>? addons = null)
     {
         var propertyInfoList = parameter.GetType()
             .GetProperties()

--- a/Deepgram/Clients/Manage/v1/Client.cs
+++ b/Deepgram/Clients/Manage/v1/Client.cs
@@ -13,7 +13,7 @@ namespace Deepgram.Clients.Manage.v1;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramClientOptions = null, string? httpId = null)
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
     : AbstractRestClient(apiKey, deepgramClientOptions, httpId), IManageClient
 {
     #region Projects

--- a/Deepgram/Clients/OnPrem/v1/Client.cs
+++ b/Deepgram/Clients/OnPrem/v1/Client.cs
@@ -13,7 +13,7 @@ namespace Deepgram.Clients.OnPrem.v1;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramClientOptions = null, string? httpId = null)
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
     : AbstractRestClient(apiKey, deepgramClientOptions, httpId), IOnPremClient
 {
     /// <summary>

--- a/Deepgram/Clients/PreRecorded/v1/Client.cs
+++ b/Deepgram/Clients/PreRecorded/v1/Client.cs
@@ -13,7 +13,7 @@ namespace Deepgram.Clients.PreRecorded.v1;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramClientOptions = null, string? httpId = null)
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
     : AbstractRestClient(apiKey, deepgramClientOptions, httpId), IPreRecordedClient
 
 {

--- a/Deepgram/Clients/Speak/v1/Client.cs
+++ b/Deepgram/Clients/Speak/v1/Client.cs
@@ -13,7 +13,7 @@ namespace Deepgram.Clients.Speak.v1;
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public class Client(string? apiKey = null, DeepgramHttpClientOptions? deepgramClientOptions = null, string? httpId = null)
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
     : AbstractRestClient(apiKey, deepgramClientOptions, httpId), ISpeakClient
 {
     #region NoneCallBacks

--- a/Deepgram/Factory/HttpClientFactory.cs
+++ b/Deepgram/Factory/HttpClientFactory.cs
@@ -32,7 +32,7 @@ internal class HttpClientFactory
         return client;
     }
 
-    internal static HttpClient ConfigureDeepgram(HttpClient client, DeepgramHttpClientOptions? options = null)
+    internal static HttpClient ConfigureDeepgram(HttpClient client, IDeepgramClientOptions? options = null)
     {
         options ??= new DeepgramHttpClientOptions();
 

--- a/Deepgram/Models/Authenticate/v1/DeepgramHttpClientOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramHttpClientOptions.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Authenticate.v1;
 /// <summary>
 /// Configuration for the Deepgram client
 /// </summary>
-public class DeepgramHttpClientOptions
+public class DeepgramHttpClientOptions : IDeepgramClientOptions
 {
     /*****************************/
     // General Options
@@ -36,6 +36,11 @@ public class DeepgramHttpClientOptions
     /*****************************/
     // Prerecorded
     /*****************************/
+
+    /*****************************/
+    // Live
+    /*****************************/
+    public bool KeepAlive { get; }
 
     /*****************************/
     // OnPrem
@@ -68,6 +73,7 @@ public class DeepgramHttpClientOptions
         Log.Debug("DeepgramHttpClientOptions", onPrem == null ? "OnPrem is null" : "OnPrem provided");
         Log.Debug("DeepgramHttpClientOptions", headers == null ? "Headers is null" : "Headers provided");
 
+        KeepAlive = false;
         ApiKey = apiKey ?? "";
         BaseAddress = baseAddress ?? Defaults.DEFAULT_URI;
         OnPrem = onPrem ?? false;

--- a/Deepgram/Models/Authenticate/v1/DeepgramOptionsFromEnv.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramOptionsFromEnv.cs
@@ -1,0 +1,96 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Authenticate.v1;
+
+public class DeepgramOptionsFromEnv : IDeepgramClientOptions
+{
+    /*****************************/
+    // General Options
+    /*****************************/
+    /// <summary>
+    /// Deepgram API KEY
+    /// </summary>
+    public string ApiKey { get; set; }
+
+    /// <summary>
+    /// BaseAddress of the server :defaults to api.deepgram.com
+    /// no need to attach the protocol it will be added internally
+    /// </summary>
+    public string BaseAddress { get; set; } = Defaults.DEFAULT_URI;
+
+    /// <summary>
+    /// Api endpoint version
+    /// </summary>
+    public string APIVersion { get; set; } = Defaults.DEFAULT_API_VERSION;
+
+    /// <summary>
+    /// Global headers to always be added to the request
+    /// </summary>
+    public Dictionary<string, string> Headers { get; set; }
+
+    /*****************************/
+    // Prerecorded
+    /*****************************/
+
+    /*****************************/
+    // Live
+    /*****************************/
+    /// <summary>
+    /// Enable sending KeepAlives for Streaming
+    /// </summary>
+    public bool KeepAlive { get; set; } = false;
+
+    /*****************************/
+    // OnPrem
+    /*****************************/
+    /// <summary>
+    /// Enable when using OnPrem mode
+    /// </summary>
+    public bool OnPrem { get; set; } = false;
+
+    /*****************************/
+    // Manage
+    /*****************************/
+
+    /*****************************/
+    // Analyze
+    /*****************************/
+
+    /*****************************/
+    // Speak
+    /*****************************/
+
+    /*****************************/
+    // Constructor
+    /*****************************/
+
+    public DeepgramOptionsFromEnv()
+    {
+        ApiKey = Environment.GetEnvironmentVariable("DEEPGRAM_API_KEY") ?? "";
+        BaseAddress = Environment.GetEnvironmentVariable("DEEPGRAM_HOST") ?? Defaults.DEFAULT_URI;
+        APIVersion = Environment.GetEnvironmentVariable("DEEPGRAM_API_VERSION") ?? Defaults.DEFAULT_API_VERSION;
+        var onPrem = Environment.GetEnvironmentVariable("DEEPGRAM_ON_PREM") ?? "";
+        var keepAlive = Environment.GetEnvironmentVariable("DEEPGRAM_KEEP_ALIVE") ?? "";
+
+        Headers = new Dictionary<string, string>();
+        for (int x = 0; x < 20; x++)
+        {
+            var param = Environment.GetEnvironmentVariable($"DEEPGRAM_PARAM_{x}");
+            if (param != null)
+            {
+                var value = Environment.GetEnvironmentVariable($"DEEPGRAM_PARAM_VALUE_{x}") ?? "";
+                Headers[param] = value;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        OnPrem = onPrem.ToLower() == "true";
+        KeepAlive = keepAlive.ToLower() == "true";
+    }
+
+}

--- a/Deepgram/Models/Authenticate/v1/DeepgramWsClientOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/DeepgramWsClientOptions.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Authenticate.v1;
 /// <summary>
 /// Configuration for the Deepgram client
 /// </summary>
-public class DeepgramWsClientOptions
+public class DeepgramWsClientOptions : IDeepgramClientOptions
 {
     /*****************************/
     // General Options

--- a/Deepgram/Models/Authenticate/v1/IDeepgramOptions.cs
+++ b/Deepgram/Models/Authenticate/v1/IDeepgramOptions.cs
@@ -1,0 +1,64 @@
+﻿// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Authenticate.v1;
+
+public interface IDeepgramClientOptions
+{
+    /*****************************/
+    // General Options
+    /*****************************/
+    /// <summary>
+    /// Deepgram API KEY
+    /// </summary>
+    public string ApiKey { get; }
+
+    /// <summary>
+    /// BaseAddress of the server :defaults to api.deepgram.com
+    /// no need to attach the protocol it will be added internally
+    /// </summary>
+    public string BaseAddress { get; }
+
+    /// <summary>
+    /// Api endpoint version
+    /// </summary>
+    public string APIVersion { get; }
+
+    /// <summary>
+    /// Global headers to always be added to the request
+    /// </summary>
+    public Dictionary<string, string> Headers { get; }
+
+    /*****************************/
+    // Prerecorded
+    /*****************************/
+
+    /*****************************/
+    // Live
+    /*****************************/
+    /// <summary>
+    /// Enable sending KeepAlives for Streaming
+    /// </summary>
+    public bool KeepAlive { get; }
+
+    /*****************************/
+    // OnPrem
+    /*****************************/
+    /// <summary>
+    /// Enable when using OnPrem mode
+    /// </summary>
+    public bool OnPrem { get; }
+
+    /*****************************/
+    // Manage
+    /*****************************/
+
+    /*****************************/
+    // Analyze
+    /*****************************/
+
+    /*****************************/
+    // Speak
+    /*****************************/
+}


### PR DESCRIPTION
Addresses issue: https://github.com/deepgram/deepgram-dotnet-sdk/issues/267

Although .NET/Windows apps are pretty rare in containers, they still do happen with the windows headless server installs. This allows you do set key client options using environment variables. This also creates an IDeepgramClientOptions interface as not to expose the clients to configuration/class changes.