### PR TITLE
Return Deepgram REST Error to User + JSON Serialize for Topics

### DIFF
--- a/Deepgram.Dev.sln
+++ b/Deepgram.Dev.sln
@@ -163,6 +163,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Factory", "examples\speak\f
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Factory", "examples\streaming\factory_example\Factory.csproj", "{2A876DE1-0D84-4FF5-BE82-7C393B6697B7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "throw_exception", "throw_exception", "{02746530-6811-4F1B-8851-544C89CA66DA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ThrowException", "tests\expected_failures\rest\throw_exception\ThrowException.csproj", "{B98F6A00-292E-431F-8B11-0CFCA5FD1E37}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -309,6 +313,10 @@ Global
 		{2A876DE1-0D84-4FF5-BE82-7C393B6697B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A876DE1-0D84-4FF5-BE82-7C393B6697B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A876DE1-0D84-4FF5-BE82-7C393B6697B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B98F6A00-292E-431F-8B11-0CFCA5FD1E37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B98F6A00-292E-431F-8B11-0CFCA5FD1E37}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B98F6A00-292E-431F-8B11-0CFCA5FD1E37}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B98F6A00-292E-431F-8B11-0CFCA5FD1E37}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -389,6 +397,8 @@ Global
 		{CB254D55-5C90-4EAF-8EE7-5C9C284317E7} = {6DFDB911-5172-44F0-A3F1-98C301D7B26F}
 		{3DD86C52-7EF9-4F96-B057-58DFA30CCD27} = {C5428CBF-4741-46E6-A721-AF00716CBAA8}
 		{2A876DE1-0D84-4FF5-BE82-7C393B6697B7} = {2B3AF9D0-879A-4B8A-A6EC-0C95F36A1DC5}
+		{02746530-6811-4F1B-8851-544C89CA66DA} = {7FA977F3-415E-4681-B316-5C273DF3A1C6}
+		{B98F6A00-292E-431F-8B11-0CFCA5FD1E37} = {02746530-6811-4F1B-8851-544C89CA66DA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8D4ABC6D-7126-4EE2-9303-43A954616B2A}

--- a/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AbstractRestClientTests.cs
@@ -5,6 +5,8 @@
 using Deepgram.Models.Authenticate.v1;
 using Deepgram.Models.Manage.v1;
 using Deepgram.Models.PreRecorded.v1;
+using Deepgram.Models.Exceptions.v1;
+
 using Deepgram.Clients.Manage.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
@@ -127,14 +129,14 @@ public class AbstractRestfulClientTests
     public async Task Delete_Should_Throws_HttpRequestException_On_Response_Containing_Error()
     {
         // Input and Output  
-        var httpClient = MockHttpClient.CreateHttpClientWithException(new HttpRequestException());
+        var httpClient = MockHttpClient.CreateHttpClientWithException(new DeepgramException());
 
         // Fake Clients
         var client = new ConcreteRestClient(_apiKey, _clientOptions);
 
         // Act & Assert
         await client.Invoking(async y => await y.DeleteAsync<MessageResponse>($"{Defaults.DEFAULT_URI}/{UriSegments.PROJECTS}"))
-             .Should().ThrowAsync<HttpRequestException>();
+             .Should().ThrowAsync<DeepgramException>();
     }
 
     //Test for the delete calls that do not return a value

--- a/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/PrerecordedClientTests.cs
@@ -29,7 +29,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<SyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         prerecordedSchema.CallBack = null;
         var source = new AutoFaker<UrlSource>().Generate();
 
@@ -38,14 +38,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
-        prerecordedClient.PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
+        prerecordedClient.PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeUrl(source, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>());
+        await prerecordedClient.Received().PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>());
 
         using (new AssertionScope())
         {
@@ -61,7 +61,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<SyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = new AutoFaker<UrlSource>().Generate();
         
         // Fake Client
@@ -69,14 +69,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
-        prerecordedClient.PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
+        prerecordedClient.PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
 
         // Act and Assert
         await prerecordedClient.Invoking(y => y.TranscribeUrl(source, prerecordedSchema))
             .Should().ThrowAsync<ArgumentException>();
 
-        await prerecordedClient.DidNotReceive().PostAsync<UrlSource, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>());
+        await prerecordedClient.DidNotReceive().PostAsync<UrlSource, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>());
     }
 
     [Test]
@@ -86,15 +86,15 @@ public class PreRecordedClientTests
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
         var source = new AutoFaker<UrlSource>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         
         // Fake Client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
-        prerecordedClient.PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
+        prerecordedClient.PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
 
         //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
         var callBackParameter = prerecordedSchema.CallBack;
@@ -104,7 +104,7 @@ public class PreRecordedClientTests
         var result = await prerecordedClient.TranscribeUrlCallBack(source, callBackParameter, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>());
+        await prerecordedClient.Received().PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -120,21 +120,21 @@ public class PreRecordedClientTests
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
         var source = new AutoFaker<UrlSource>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
 
         // Fake Client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
-        prerecordedClient.PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>())).DoNotCallBase();
+        prerecordedClient.PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeUrlCallBack(source, null, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>());
+        await prerecordedClient.Received().PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -150,15 +150,15 @@ public class PreRecordedClientTests
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
         var source = new AutoFaker<UrlSource>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
 
         // Fake Client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>())).DoNotCallBase();
-        prerecordedClient.PostAsync<PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>())).DoNotCallBase();
+        prerecordedClient.PostAsync<PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>()).Returns(expectedResponse);
 
         var callBackParameter = prerecordedSchema.CallBack;
 
@@ -166,7 +166,7 @@ public class PreRecordedClientTests
         await prerecordedClient.Invoking(y => y.TranscribeUrlCallBack(source, callBackParameter, prerecordedSchema))
             .Should().ThrowAsync<ArgumentException>();
 
-        await prerecordedClient.DidNotReceive().PostAsync<PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>());
+        await prerecordedClient.DidNotReceive().PostAsync<PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>());
     }
 
     [Test]
@@ -176,7 +176,7 @@ public class PreRecordedClientTests
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
         var source = new AutoFaker<UrlSource>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         prerecordedSchema.CallBack = null;
 
         // Fake Client
@@ -184,14 +184,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>())).DoNotCallBase();
-        prerecordedClient.PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>())).DoNotCallBase();
+        prerecordedClient.PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<UrlSource>()).Returns(expectedResponse);
 
         // Act and Assert
         await prerecordedClient.Invoking(y => y.TranscribeUrlCallBack(source, null, prerecordedSchema))
             .Should().ThrowAsync<ArgumentException>();
 
-        await prerecordedClient.DidNotReceive().PostAsync<PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>());
+        await prerecordedClient.DidNotReceive().PostAsync<PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>());
     }
 
     [Test]
@@ -200,7 +200,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<SyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         prerecordedSchema.CallBack = null;
 
         // Fake Client
@@ -209,14 +209,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
 
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeFile(source, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -231,7 +231,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<SyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         prerecordedSchema.CallBack = null;
         var source = GetFakeByteArray();
 
@@ -240,14 +240,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
 
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, SyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeFile(source, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, SyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, SyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -262,7 +262,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeStream(GetFakeByteArray());
 
         // Fake Client
@@ -270,14 +270,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeFileCallBack(source, null, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -292,7 +292,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeByteArray();
 
         // Fake Client
@@ -300,14 +300,14 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         // Act
         var result = await prerecordedClient.TranscribeFileCallBack(source, null, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
 
         using (new AssertionScope())
         {
@@ -323,7 +323,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeStream(GetFakeByteArray());
 
         // Fake Client
@@ -331,8 +331,8 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
         var callBack = prerecordedSchema.CallBack;
@@ -342,7 +342,7 @@ public class PreRecordedClientTests
         var result = await prerecordedClient.TranscribeFileCallBack(source, callBack, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -357,7 +357,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeByteArray();
 
         // Fake Client
@@ -365,8 +365,8 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
 
         //before we act to test this call with the callBack parameter and not the callBack property we need to null the callBack property
         var callBack = prerecordedSchema.CallBack;
@@ -376,7 +376,7 @@ public class PreRecordedClientTests
         var result = await prerecordedClient.TranscribeFileCallBack(source, callBack, prerecordedSchema);
 
         // Assert
-        await prerecordedClient.Received().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.Received().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
@@ -391,7 +391,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeStream(GetFakeByteArray());
 
         // Fake Client
@@ -399,8 +399,8 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
         
         var callBack = prerecordedSchema.CallBack;
 
@@ -408,7 +408,7 @@ public class PreRecordedClientTests
         await prerecordedClient.Invoking(y => y.TranscribeFileCallBack(source, callBack, prerecordedSchema))
            .Should().ThrowAsync<ArgumentException>();
 
-        await prerecordedClient.DidNotReceive().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.DidNotReceive().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
     }
 
     [Test]
@@ -417,7 +417,7 @@ public class PreRecordedClientTests
         // Input and Output
         var url = AbstractRestClient.GetUri(_options, $"{UriSegments.LISTEN}");
         var expectedResponse = new AutoFaker<AsyncResponse>().Generate();
-        var prerecordedSchema = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedSchema = new AutoFaker<PreRecordedSchema>().Generate();
         var source = GetFakeByteArray();
 
         // Fake Client
@@ -425,8 +425,8 @@ public class PreRecordedClientTests
         var prerecordedClient = Substitute.For<PreRecordedClient>(_apiKey, _options, null);
         
         // Mock Methods
-        prerecordedClient.When(x => x.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
-        prerecordedClient.PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
+        prerecordedClient.When(x => x.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(Arg.Any<string>(), Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>())).DoNotCallBase();
+        prerecordedClient.PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>()).Returns(expectedResponse);
         
         prerecordedSchema.CallBack = null;
 
@@ -434,7 +434,7 @@ public class PreRecordedClientTests
         await prerecordedClient.Invoking(y => y.TranscribeFileCallBack(source, null, prerecordedSchema))
            .Should().ThrowAsync<ArgumentException>();
 
-        await prerecordedClient.DidNotReceive().PostAsync<Stream, PrerecordedSchema, AsyncResponse>(url, Arg.Any<PrerecordedSchema>(), Arg.Any<Stream>());
+        await prerecordedClient.DidNotReceive().PostAsync<Stream, PreRecordedSchema, AsyncResponse>(url, Arg.Any<PreRecordedSchema>(), Arg.Any<Stream>());
     }
 
     private static Stream GetFakeStream(byte[] source)

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -13,7 +13,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_EmptyString_When_Parameters_Is_Null()
     {
         // Input and Output
-        PrerecordedSchema? para = null;
+        PreRecordedSchema? para = null;
         var expected = $"https://{Defaults.DEFAULT_URI}";
 
         //Act
@@ -27,7 +27,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_String_Parameter()
     {
         // Input and Output
-        var prerecordedOptions = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedOptions = new AutoFaker<PreRecordedSchema>().Generate();
         var expectedModel = HttpUtility.UrlEncode(prerecordedOptions.Model)!;
         var expected = $"{nameof(prerecordedOptions.Model).ToLower()}={expectedModel}";
         //Act
@@ -42,7 +42,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_Respecting_CallBack_Casing()
     {
         // Input and Output
-        var prerecordedOptions = new AutoFaker<PrerecordedSchema>().Generate();
+        var prerecordedOptions = new AutoFaker<PreRecordedSchema>().Generate();
         prerecordedOptions.CallBack = "https://Signed23.com";
         var expected = $"{nameof(prerecordedOptions.CallBack).ToLower()}={HttpUtility.UrlEncode("https://Signed23.com")}";
         //Act
@@ -57,7 +57,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_Int_Parameter()
     {
         // Input and Output 
-        var obj = new PrerecordedSchema() { Alternatives = 1 };
+        var obj = new PreRecordedSchema() { Alternatives = 1 };
         var expected = $"alternatives={obj.Alternatives}";
 
         //Act
@@ -72,7 +72,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_Array_Parameter()
     {
         // Input and Output
-        var prerecordedOptions = new PrerecordedSchema
+        var prerecordedOptions = new PreRecordedSchema
         {
             Keywords = ["test", "acme"]
         };
@@ -89,7 +89,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_Dictonary_Parameter()
     {
         // Input and Output
-        var prerecordedOptions = new PrerecordedSchema()
+        var prerecordedOptions = new PreRecordedSchema()
         {
             Extra = new Dictionary<string, string>
             {
@@ -111,7 +111,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_Decimal_Parameter()
     {
         // Input and Output
-        var prerecordedOptions = new PrerecordedSchema() { UttSplit = 2.3 };
+        var prerecordedOptions = new PreRecordedSchema() { UttSplit = 2.3 };
         var expected = $"utt_split={HttpUtility.UrlEncode(prerecordedOptions.UttSplit.ToString())}";
 
         //Act
@@ -128,7 +128,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_String_When_Passing_Boolean_Parameter()
     {
         // Input and Output 
-        var obj = new PrerecordedSchema() { Paragraphs = true };
+        var obj = new PreRecordedSchema() { Paragraphs = true };
         var expected = $"{nameof(obj.Paragraphs).ToLower()}=true";
         //Act
         var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, obj);
@@ -164,7 +164,7 @@ public class QueryParameterUtilTests
         var expected = HttpUtility.UrlEncode(signedCallBackUrl);
 
         //Act
-        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, new PrerecordedSchema() { CallBack = signedCallBackUrl, Diarize = true });
+        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, new PreRecordedSchema() { CallBack = signedCallBackUrl, Diarize = true });
 
         //Assert
         result.Should().NotBeNull();
@@ -175,7 +175,7 @@ public class QueryParameterUtilTests
     public void GetParameters_Should_Return_Empty_String_When_Parameter_Has_No_Values()
     {
         //Act
-        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, new PrerecordedSchema());
+        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, new PreRecordedSchema());
 
         //Assert
         result.Should().NotBeNull();

--- a/Deepgram/Abstractions/AbstractRestClient.cs
+++ b/Deepgram/Abstractions/AbstractRestClient.cs
@@ -4,6 +4,7 @@
 
 using Deepgram.Encapsulations;
 using Deepgram.Models.Authenticate.v1;
+using Deepgram.Models.Exceptions.v1;
 
 namespace Deepgram.Abstractions;
 
@@ -81,7 +82,14 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("GetAsync<T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("GetAsync<T>", response, resultStr);
+            }
+
+            Log.Verbose("GetAsync<T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
             Log.Debug("GetAsync<T>", "Succeeded");
@@ -137,7 +145,14 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("GetAsync<S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("GetAsync<S, T>", response, resultStr);
+            }
+
+            Log.Verbose("GetAsync<S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
             Log.Debug("GetAsync<S, T>", "Succeeded");
@@ -207,7 +222,11 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("PostRetrieveLocalFileAsync<R, S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("PostRetrieveLocalFileAsync<R, S, T>", response, response.Content.ReadAsStringAsync().Result);
+            }
 
             var result = new Dictionary<string, string>();
 
@@ -322,10 +341,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("PostAsync<S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("PostAsync<S, T>", response, resultStr);
+            }
+
+            Log.Verbose("PostAsync<S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("PostAsync<S, T>", $"Succeeded. Result: {result}");
+            Log.Debug("PostAsync<S, T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.PostAsync<S, T>", "LEAVE");
 
             return result;
@@ -392,10 +418,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("PostAsync<R, S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("PostAsync<R, S, T>", response, resultStr);
+            }
+
+            Log.Verbose("PostAsync<R, S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("PostAsync<R, S, T>", $"Succeeded. Result: {result}");
+            Log.Debug("PostAsync<R, S, T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.PostAsync<R, S, T>", "LEAVE");
 
             return result;
@@ -465,10 +498,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("PatchAsync<S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("PatchAsync<S, T>", response, resultStr);
+            }
+
+            Log.Verbose("PatchAsync<S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("PatchAsync<S, T>", $"Succeeded. Result: {result}");
+            Log.Debug("PatchAsync<S, T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.PatchAsync<S, T>", "LEAVE");
 
             return result;
@@ -536,10 +576,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("PutAsync<S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("PutAsync<S, T>", response, resultStr);
+            }
+
+            Log.Verbose("PutAsync<S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("PutAsync<S, T>", $"Succeeded. Result: {result}");
+            Log.Debug("PutAsync<S, T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.PutAsync<S, T>", "LEAVE");
 
             return result;
@@ -597,10 +644,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("DeleteAsync<T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("DeleteAsync<T>", response, resultStr);
+            }
+
+            Log.Verbose("DeleteAsync<T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("DeleteAsync<T>", $"Succeeded. Result: {result}");
+            Log.Debug("DeleteAsync<T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.DeleteAsync<T>", "LEAVE");
 
             return result;
@@ -660,10 +714,17 @@ public abstract class AbstractRestClient
             // do the request
             Log.Verbose("DeleteAsync<S, T>", "Calling _httpClient.SendAsync...");
             var response = await _httpClient.SendAsync(request, cancellationToken.Token);
-            response.EnsureSuccessStatusCode();
+
+            var resultStr = response.Content.ReadAsStringAsync().Result;
+            if (!response.IsSuccessStatusCode)
+            {
+                await ThrowException("DeleteAsync<S, T>", response, resultStr);
+            }
+
+            Log.Verbose("DeleteAsync<S, T>", $"Response:\n{resultStr}");
             var result = await HttpRequestUtil.DeserializeAsync<T>(response);
 
-            Log.Debug("DeleteAsync<S, T>", $"Succeeded. Result: {result}");
+            Log.Debug("DeleteAsync<S, T>", $"Succeeded");
             Log.Verbose("AbstractRestClient.DeleteAsync<S, T>", "LEAVE");
 
             return result;
@@ -682,6 +743,35 @@ public abstract class AbstractRestClient
             Log.Verbose("AbstractRestClient.DeleteAsync<S, T>", "LEAVE");
             throw;
         }
+    }
+
+    private static async Task ThrowException(string module, HttpResponseMessage response, string errMsg)
+    {
+        if (errMsg == null || errMsg.Length == 0)
+        {
+            Log.Verbose(module, $"HTTP/REST Exception thrown");
+            response.EnsureSuccessStatusCode(); // this throws the exception
+        }
+
+        Log.Verbose(module, $"Deepgram Exception: {errMsg}");
+        DeepgramRESTException? resException = null;
+        try
+        {
+            resException = await HttpRequestUtil.DeserializeAsync<DeepgramRESTException>(response);
+        }
+        catch (Exception ex)
+        {
+            Log.Verbose(module, $"DeserializeAsync Error Exception: {ex}");
+        }
+
+        if (resException != null)
+        {
+            Log.Verbose(module, "DeepgramRESTException thrown");
+            throw resException;
+        }
+
+        Log.Verbose(module, $"Deepgram Generic Exception thrown");
+        throw new DeepgramException(errMsg);
     }
 
     internal static string GetUri(IDeepgramClientOptions options, string path)

--- a/Deepgram/Clients/Analyze/v1/Client.cs
+++ b/Deepgram/Clients/Analyze/v1/Client.cs
@@ -66,7 +66,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("AnalyzeClient.AnalyzeFile", "ENTER");
         Log.Information("AnalyzeFile", $"source: {source}");
-        Log.Information("AnalyzeFile", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("AnalyzeFile", $"analyzeSchema:\n{analyzeSchema}");
 
         VerifyNoCallBack(nameof(AnalyzeFile), analyzeSchema);
 
@@ -109,7 +109,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
         Log.Verbose("AnalyzeClient.AnalyzeFileCallBack", "ENTER");
         Log.Information("AnalyzeFileCallBack", $"source: {source}");
         Log.Information("AnalyzeFileCallBack", $"callBack: {callBack}");
-        Log.Information("AnalyzeFileCallBack", $"analyzeSchema:\n{JsonSerializer.Serialize(analyzeSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("AnalyzeFileCallBack", $"analyzeSchema:\n{analyzeSchema}");
 
         VerifyOneCallBackSet(nameof(AnalyzeFileCallBack), callBack, analyzeSchema);
         if (callBack != null)

--- a/Deepgram/Clients/Interfaces/v1/IPreRecordedClient.cs
+++ b/Deepgram/Clients/Interfaces/v1/IPreRecordedClient.cs
@@ -19,27 +19,27 @@ public interface IPreRecordedClient
     ///  Transcribe a file by providing a url 
     /// </summary>
     /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"></param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public Task<SyncResponse> TranscribeUrl(UrlSource source, PrerecordedSchema? prerecordedSchema,
+    public Task<SyncResponse> TranscribeUrl(UrlSource source, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
 
     /// <summary>
     /// Transcribes a file using the provided byte array
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public Task<SyncResponse> TranscribeFile(byte[] source, PrerecordedSchema? prerecordedSchema,
+    public Task<SyncResponse> TranscribeFile(byte[] source, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
 
     /// <summary>
     /// Transcribes a file using the provided stream
     /// </summary>
     /// <param name="source">file is the form of a streasm <see cref="Stream"/></param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public Task<SyncResponse> TranscribeFile(Stream source, PrerecordedSchema? prerecordedSchema,
+    public Task<SyncResponse> TranscribeFile(Stream source, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null,
         Dictionary<string, string>? headers = null);
     #endregion
@@ -50,9 +50,9 @@ public interface IPreRecordedClient
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>  
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public Task<AsyncResponse> TranscribeFileCallBack(byte[] source, string? callBack, PrerecordedSchema? prerecordedSchema,
+    public Task<AsyncResponse> TranscribeFileCallBack(byte[] source, string? callBack, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null,
         Dictionary<string, string>? headers = null);
 
@@ -61,9 +61,9 @@ public interface IPreRecordedClient
     /// </summary>
     /// <param name="source">file is the form of a stream <see cref="Stream"></param>  
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public Task<AsyncResponse> TranscribeFileCallBack(Stream source, string? callBack, PrerecordedSchema? prerecordedSchema,
+    public Task<AsyncResponse> TranscribeFileCallBack(Stream source, string? callBack, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null,
         Dictionary<string, string>? headers = null);
 
@@ -72,9 +72,9 @@ public interface IPreRecordedClient
     /// </summary>
     /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"/></param>
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public Task<AsyncResponse> TranscribeUrlCallBack(UrlSource source, string? callBack, PrerecordedSchema? prerecordedSchema,
+    public Task<AsyncResponse> TranscribeUrlCallBack(UrlSource source, string? callBack, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null,
         Dictionary<string, string>? headers = null);
     #endregion 

--- a/Deepgram/Clients/Manage/v1/Client.cs
+++ b/Deepgram/Clients/Manage/v1/Client.cs
@@ -69,7 +69,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.UpdateProject", "ENTER");
         Log.Information("UpdateProject", $"projectId: {projectId}");
-        Log.Information("UpdateProject", $"updateProjectSchema:\n{JsonSerializer.Serialize(updateProjectSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("UpdateProject", $"updateProjectSchema:\n{updateProjectSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}");
         var result = await PatchAsync<ProjectSchema, MessageResponse>(uri, updateProjectSchema, cancellationToken, addons, headers);
@@ -181,7 +181,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.CreateKey", "ENTER");
         Log.Information("CreateKey", $"projectId: {projectId}");
-        Log.Information("CreateKey", $"keySchema:\n{JsonSerializer.Serialize(keySchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("CreateKey", $"keySchema:\n{keySchema}");
 
         if (keySchema.ExpirationDate is not null && keySchema.TimeToLiveInSeconds is not null)
         {
@@ -280,7 +280,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.SendInvite", "ENTER");
         Log.Information("SendInvite", $"projectId: {projectId}");
-        Log.Information("SendInvite", $"inviteSchema:\n{JsonSerializer.Serialize(inviteSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("SendInvite", $"inviteSchema:\n{inviteSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.INVITES}");
         var result = await PostAsync<InviteSchema, MessageResponse>(uri, inviteSchema, cancellationToken, addons, headers);
@@ -351,7 +351,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
         Log.Verbose("ManageClient.UpdateMemberScope", "ENTER");
         Log.Information("UpdateMemberScope", $"projectId: {projectId}");
         Log.Information("UpdateMemberScope", $"memberId: {memberId}");
-        Log.Information("UpdateMemberScope", $"scopeSchema:\n{JsonSerializer.Serialize(scopeSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("UpdateMemberScope", $"scopeSchema:\n{scopeSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.MEMBERS}/{memberId}/{UriSegments.SCOPES}");
         var result = await PutAsync<MemberScopeSchema, MessageResponse>(uri,scopeSchema, cancellationToken, addons, headers);
@@ -400,7 +400,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.GetUsageRequests", "ENTER");
         Log.Information("GetUsageRequests", $"projectId: {projectId}");
-        Log.Information("GetUsageRequests", $"usageRequestsSchema:\n{JsonSerializer.Serialize(usageRequestsSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("GetUsageRequests", $"usageRequestsSchema:\n{usageRequestsSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.REQUESTS}");
         var result = await GetAsync<UsageRequestsSchema, UsageRequestsResponse>(uri, usageRequestsSchema, cancellationToken, addons, headers);
@@ -446,7 +446,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.GetUsageSummary", "ENTER");
         Log.Information("GetUsageSummary", $"projectId: {projectId}");
-        Log.Information("GetUsageSummary", $"summarySchema:\n{JsonSerializer.Serialize(summarySchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("GetUsageSummary", $"summarySchema:\n{summarySchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.USAGE}");
         var result = await GetAsync<UsageSummarySchema, UsageSummaryResponse>(uri, summarySchema, cancellationToken, addons, headers);
@@ -469,7 +469,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("ManageClient.GetUsageFields", "ENTER");
         Log.Information("GetUsageFields", $"projectId: {projectId}");
-        Log.Information("GetUsageFields", $"summarySchema:\n{JsonSerializer.Serialize(fieldsSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("GetUsageFields", $"summarySchema:\n{fieldsSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.USAGE}/fields");
         var result = await GetAsync<UsageFieldsSchema, UsageFieldsResponse>(uri, fieldsSchema, cancellationToken, addons, headers);

--- a/Deepgram/Clients/OnPrem/v1/Client.cs
+++ b/Deepgram/Clients/OnPrem/v1/Client.cs
@@ -94,7 +94,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("OnPremClient.CreateCredentials", "ENTER");
         Log.Debug("CreateCredentials", $"projectId: {projectId}");
-        Log.Debug("CreateCredentials", $"credentialsSchema:\n{JsonSerializer.Serialize(credentialsSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Debug("CreateCredentials", $"credentialsSchema:\n{credentialsSchema}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}");
         var result = await PostAsync<CredentialsSchema, CredentialResponse>(uri, credentialsSchema, cancellationToken, addons, headers);

--- a/Deepgram/Clients/PreRecorded/v1/Client.cs
+++ b/Deepgram/Clients/PreRecorded/v1/Client.cs
@@ -22,19 +22,19 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     ///  Transcribe a file by providing a url 
     /// </summary>
     /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"></param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeUrl(UrlSource source, PrerecordedSchema? prerecordedSchema,
+    public async Task<SyncResponse> TranscribeUrl(UrlSource source, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("PreRecordedClient.TranscribeUrl", "ENTER");
         Log.Information("TranscribeUrl", $"source: {source}");
-        Log.Information("TranscribeUrl", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("TranscribeUrl", $"prerecordedSchema:\n{prerecordedSchema}");
 
         VerifyNoCallBack(nameof(TranscribeUrl), prerecordedSchema);
 
         var uri = GetUri(_options, $"{UriSegments.LISTEN}");
-        var result = await PostAsync<UrlSource, PrerecordedSchema, SyncResponse>( uri, prerecordedSchema, source, cancellationToken, addons, headers);
+        var result = await PostAsync<UrlSource, PreRecordedSchema, SyncResponse>( uri, prerecordedSchema, source, cancellationToken, addons, headers);
 
         Log.Information("TranscribeUrl", $"{uri} Succeeded");
         Log.Debug("TranscribeUrl", $"result: {result}");
@@ -47,9 +47,9 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// Transcribes a file using the provided byte array
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeFile(byte[] source, PrerecordedSchema? prerecordedSchema,
+    public async Task<SyncResponse> TranscribeFile(byte[] source, PreRecordedSchema? prerecordedSchema,
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         MemoryStream stream = new MemoryStream(source);
@@ -60,18 +60,18 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// Transcribes a file using the provided stream
     /// </summary>
     /// <param name="source">file is the form of a streasm <see cref="Stream"/></param>
-    /// <param name="prerecordedSchema">Options for the transcription <see cref="PrerecordedSchema"/></param>
+    /// <param name="prerecordedSchema">Options for the transcription <see cref="PreRecordedSchema"/></param>
     /// <returns><see cref="SyncResponse"/></returns>
-    public async Task<SyncResponse> TranscribeFile(Stream source, PrerecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    public async Task<SyncResponse> TranscribeFile(Stream source, PreRecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("PreRecordedClient.TranscribeFile", "ENTER");
         Log.Information("TranscribeFile", $"source: {source}");
-        Log.Information("TranscribeFile", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("TranscribeFile", $"prerecordedSchema:\n{prerecordedSchema}");
 
         VerifyNoCallBack(nameof(TranscribeFile), prerecordedSchema);
 
         var uri = GetUri(_options, $"{UriSegments.LISTEN}");
-        var result = await PostAsync<Stream, PrerecordedSchema, SyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
+        var result = await PostAsync<Stream, PreRecordedSchema, SyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
 
         Log.Information("TranscribeFile", $"{uri} Succeeded");
         Log.Debug("TranscribeFile", $"result: {result}");
@@ -88,9 +88,9 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// </summary>
     /// <param name="source">file is the form of a byte[]</param>  
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeFileCallBack(byte[] source, string? callBack, PrerecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    public async Task<AsyncResponse> TranscribeFileCallBack(byte[] source, string? callBack, PreRecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         MemoryStream stream = new MemoryStream(source);
         return await TranscribeFileCallBack(stream, callBack, prerecordedSchema, cancellationToken, addons, headers);
@@ -101,21 +101,21 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// </summary>
     /// <param name="source">file is the form of a stream <see cref="Stream"></param>  
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeFileCallBack(Stream source, string? callBack, PrerecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    public async Task<AsyncResponse> TranscribeFileCallBack(Stream source, string? callBack, PreRecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("PreRecordedClient.TranscribeFileCallBack", "ENTER");
         Log.Information("TranscribeFileCallBack", $"source: {source}");
         Log.Information("TranscribeFileCallBack", $"callBack: {callBack}");
-        Log.Information("TranscribeFileCallBack", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("TranscribeFileCallBack", $"prerecordedSchema:\n{prerecordedSchema}");
 
         VerifyOneCallBackSet(nameof(TranscribeFileCallBack), callBack, prerecordedSchema);
         if (callBack != null)
             prerecordedSchema.CallBack = callBack;
 
         var uri = GetUri(_options, $"{UriSegments.LISTEN}");
-        var result = await PostAsync<Stream, PrerecordedSchema, AsyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
+        var result = await PostAsync<Stream, PreRecordedSchema, AsyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
 
         Log.Information("TranscribeFileCallBack", $"{uri} Succeeded");
         Log.Debug("TranscribeFileCallBack", $"result: {result}");
@@ -129,14 +129,14 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// </summary>
     /// <param name="source">Url to the file that is to be transcribed <see cref="UrlSource"/></param>
     /// <param name="callBack">CallBack url</param>    
-    /// <param name="prerecordedSchema">Options for the transcription<see cref="PrerecordedSchema"></param>
+    /// <param name="prerecordedSchema">Options for the transcription<see cref="PreRecordedSchema"></param>
     /// <returns><see cref="AsyncResponse"/></returns>
-    public async Task<AsyncResponse> TranscribeUrlCallBack(UrlSource source, string? callBack, PrerecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    public async Task<AsyncResponse> TranscribeUrlCallBack(UrlSource source, string? callBack, PreRecordedSchema? prerecordedSchema, CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("PreRecordedClient.TranscribeUrlCallBack", "ENTER");
         Log.Information("TranscribeUrlCallBack", $"source: {source}");
         Log.Information("TranscribeUrlCallBack", $"callBack: {callBack}");
-        Log.Information("TranscribeUrlCallBack", $"prerecordedSchema:\n{JsonSerializer.Serialize(prerecordedSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("TranscribeUrlCallBack", $"prerecordedSchema:\n{prerecordedSchema}");
 
         VerifyOneCallBackSet(nameof(TranscribeUrlCallBack), callBack, prerecordedSchema);
 
@@ -144,7 +144,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
             prerecordedSchema.CallBack = callBack;
 
         var uri = GetUri(_options, $"{UriSegments.LISTEN}");
-        var result = await PostAsync<UrlSource, PrerecordedSchema, AsyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
+        var result = await PostAsync<UrlSource, PreRecordedSchema, AsyncResponse>(uri, prerecordedSchema, source, cancellationToken, addons, headers);
 
         Log.Information("TranscribeUrlCallBack", $"{uri} Succeeded");
         Log.Debug("TranscribeUrlCallBack", $"result: {result}");
@@ -155,7 +155,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     #endregion
 
     #region CallbackChecks
-    private void VerifyNoCallBack(string method, PrerecordedSchema? prerecordedSchema)
+    private void VerifyNoCallBack(string method, PreRecordedSchema? prerecordedSchema)
     {
         Log.Debug("VerifyNoCallBack", $"method: {method}");
 
@@ -167,7 +167,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
         }
     }
 
-    private void VerifyOneCallBackSet(string method, string? callBack, PrerecordedSchema? prerecordedSchema)
+    private void VerifyOneCallBackSet(string method, string? callBack, PreRecordedSchema? prerecordedSchema)
     {
         Log.Debug("VerifyOneCallBackSet", $"method: {method}");
 

--- a/Deepgram/Clients/Speak/v1/Client.cs
+++ b/Deepgram/Clients/Speak/v1/Client.cs
@@ -28,7 +28,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     {
         Log.Verbose("SpeakClient.ToStream", "ENTER");
         Log.Information("ToStream", $"source: {source}");
-        Log.Information("ToStream", $"analyzeSchema:\n{JsonSerializer.Serialize(speakSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("ToStream", $"analyzeSchema:\n{speakSchema}");
 
         VerifyNoCallBack(nameof(ToStream), speakSchema);
 
@@ -131,7 +131,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
         Log.Verbose("SpeakClient.StreamCallBack", "ENTER");
         Log.Information("StreamCallBack", $"source: {source}");
         Log.Information("StreamCallBack", $"callBack: {callBack}");
-        Log.Information("StreamCallBack", $"speakSchema:\n{JsonSerializer.Serialize(speakSchema, JsonSerializeOptions.DefaultOptions)}");
+        Log.Information("StreamCallBack", $"speakSchema:\n{speakSchema}");
 
         VerifyOneCallBackSet(nameof(StreamCallBack), callBack, speakSchema);
         if (callBack != null)

--- a/Deepgram/GlobalSuppressions.cs
+++ b/Deepgram/GlobalSuppressions.cs
@@ -16,7 +16,7 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.OnPrem.v1.CredentialsResponse")]
 [assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.OnPrem.v1.CredentialResponse")]
 [assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.PreRecorded.v1.AsyncResponse")]
-[assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.PreRecorded.v1.PrerecordedSchema")]
+[assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.PreRecorded.v1.PreRecordedSchema")]
 [assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "type", Target = "~T:Deepgram.Models.PreRecorded.v1.SyncResponse")]
 [assembly: SuppressMessage("Performance", "SYSLIB1045:Convert to 'GeneratedRegexAttribute'.", Justification = "<Pending>", Scope = "member", Target = "~M:Deepgram.Utilities.UserAgentUtil.GetInfo~System.String")]
 [assembly: SuppressMessage("Spellchecker", "CRRSP08:A misspelled word has been found", Justification = "<Pending>", Scope = "namespace", Target = "~N:Deepgram")]

--- a/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
+++ b/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
@@ -82,5 +82,13 @@ public class AnalyzeSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("topics")]
     public bool? Topics { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/AsyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/AsyncResponse.cs
@@ -13,5 +13,13 @@ public record AsyncResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("request_id")]
     public string? RequestId { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/Average.cs
+++ b/Deepgram/Models/Analyze/v1/Average.cs
@@ -19,4 +19,12 @@ public record Average
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sentiment_score")]
     public double? SentimentScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/Intent.cs
+++ b/Deepgram/Models/Analyze/v1/Intent.cs
@@ -19,6 +19,14 @@ public record Intent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("confidence_score")]
     public double? ConfidenceScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/Analyze/v1/IntentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/IntentGroup.cs
@@ -13,4 +13,12 @@ public record IntentGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("segments")]
     public IReadOnlyList<Segment>? Segments { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/IntentsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/IntentsInfo.cs
@@ -26,6 +26,14 @@ public record IntentsInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/Analyze/v1/Metadata.cs
+++ b/Deepgram/Models/Analyze/v1/Metadata.cs
@@ -54,4 +54,12 @@ public record Metadata
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("topics_info")]
     public TopicsInfo? TopicsInfo { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/Results.cs
+++ b/Deepgram/Models/Analyze/v1/Results.cs
@@ -33,5 +33,13 @@ public record Results
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("topics")]
     public TopicGroup? Topics { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/Segment.cs
+++ b/Deepgram/Models/Analyze/v1/Segment.cs
@@ -54,4 +54,12 @@ public record Segment
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("intents")]
     public IReadOnlyList<Intent>? Intents { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/SentimentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentGroup.cs
@@ -19,6 +19,14 @@ public record SentimentGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("average")]
     public Average? Average { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/Analyze/v1/SentimentInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentInfo.cs
@@ -26,6 +26,14 @@ public record SentimentInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/Analyze/v1/Summary.cs
+++ b/Deepgram/Models/Analyze/v1/Summary.cs
@@ -12,5 +12,13 @@ public record Summary
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("text")]
     public string? Text { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/SummaryInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SummaryInfo.cs
@@ -26,4 +26,12 @@ public record SummaryInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/SyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/SyncResponse.cs
@@ -19,4 +19,12 @@ public record SyncResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("results")]
     public Results? Results { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Analyze/v1/Topic.cs
+++ b/Deepgram/Models/Analyze/v1/Topic.cs
@@ -10,14 +10,22 @@ public record Topic
     /// Value between 0 and 1 indicating the model's relative confidence in this topic.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("confidence")]
+    [JsonPropertyName("confidence_score")]
     public double? Confidence { get; set; }
 
     /// <summary>
-    /// The discover topic.
+    /// Discovered topic.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("topic")]
-    public string Text;
+    [JsonPropertyName("topic")]
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/TopicGroup.cs
+++ b/Deepgram/Models/Analyze/v1/TopicGroup.cs
@@ -12,5 +12,13 @@ public record TopicGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("segments")]
     public IReadOnlyList<Segment>? Segments { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Analyze/v1/TopicsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/TopicsInfo.cs
@@ -26,6 +26,14 @@ public record TopicsInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/Analyze/v1/UrlSource.cs
+++ b/Deepgram/Models/Analyze/v1/UrlSource.cs
@@ -12,5 +12,13 @@ public class UrlSource(string url)
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("url")]
     public string? Url { get; set; } = url;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Exceptions/v1/DeepgramConnectionException.cs
+++ b/Deepgram/Models/Exceptions/v1/DeepgramConnectionException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Exceptions.v1;
+
+public class DeepgramConectionException : DeepgramException
+{
+    public DeepgramConectionException(string errMsg) : base(errMsg)
+    {
+    }
+}

--- a/Deepgram/Models/Exceptions/v1/DeepgramException.cs
+++ b/Deepgram/Models/Exceptions/v1/DeepgramException.cs
@@ -1,0 +1,40 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Exceptions.v1;
+
+public class DeepgramException : Exception
+{
+    public DeepgramException() : base()
+    {
+    }
+
+    public DeepgramException(string errMsg) : base(errMsg)
+    {
+        ErrMsg = errMsg;
+        ErrCode = "Unknown Error Code";
+        RequestId = "Unknown Request ID";
+    }
+
+    /// <summary>
+    /// Error code
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("err_code")]
+    public string ErrCode { get; set; }
+
+    /// <summary>
+    /// Error code
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("err_msg")]
+    public string ErrMsg { get; set; }
+
+    /// <summary>
+    /// Error code
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("request_id")]
+    public string RequestId { get; set; }
+}

--- a/Deepgram/Models/Exceptions/v1/DeepgramRESTException.cs
+++ b/Deepgram/Models/Exceptions/v1/DeepgramRESTException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Exceptions.v1;
+
+public class DeepgramRESTException : DeepgramException
+{
+    public DeepgramRESTException(string errMsg) : base(errMsg)
+    {
+    }
+}

--- a/Deepgram/Models/Exceptions/v1/DeepgramWebSocketException.cs
+++ b/Deepgram/Models/Exceptions/v1/DeepgramWebSocketException.cs
@@ -1,0 +1,12 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Exceptions.v1;
+
+public class DeepgramWebSocketException : DeepgramException
+{
+    public DeepgramWebSocketException(string errMsg) : base(errMsg)
+    {
+    }
+}

--- a/Deepgram/Models/Live/v1/Alternative.cs
+++ b/Deepgram/Models/Live/v1/Alternative.cs
@@ -25,4 +25,12 @@ public record Alternative
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("words")]
     public IReadOnlyList<Word>? Words { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/Average.cs
+++ b/Deepgram/Models/Live/v1/Average.cs
@@ -19,4 +19,12 @@ public record Average
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sentiment_score")]
     public double? SentimentScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/Channel.cs
+++ b/Deepgram/Models/Live/v1/Channel.cs
@@ -12,4 +12,12 @@ public record Channel
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("alternatives")]
     public IReadOnlyList<Alternative>? Alternatives { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/CloseResponse.cs
+++ b/Deepgram/Models/Live/v1/CloseResponse.cs
@@ -13,4 +13,12 @@ public record CloseResponse
 	[JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public LiveType? Type { get; set; } = LiveType.Close;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/ErrorResponse.cs
+++ b/Deepgram/Models/Live/v1/ErrorResponse.cs
@@ -34,4 +34,12 @@ public record ErrorResponse
 	[JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public LiveType? Type { get; set; } = LiveType.Error;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/Metadata.cs
+++ b/Deepgram/Models/Live/v1/Metadata.cs
@@ -35,4 +35,12 @@ public record MetaData
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("extra")]
     public Dictionary<string, string>? Extra { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/MetadataResponse.cs
+++ b/Deepgram/Models/Live/v1/MetadataResponse.cs
@@ -78,4 +78,12 @@ public record MetadataResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("extra")]
     public Dictionary<string, string>? Extra { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/ModelInfo.cs
+++ b/Deepgram/Models/Live/v1/ModelInfo.cs
@@ -26,4 +26,12 @@ public record ModelInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("version")]
     public string? Version { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/OpenResponse.cs
+++ b/Deepgram/Models/Live/v1/OpenResponse.cs
@@ -13,4 +13,12 @@ public record OpenResponse
 	[JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public LiveType? Type { get; set; } = LiveType.Open;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/ResultResponse.cs
+++ b/Deepgram/Models/Live/v1/ResultResponse.cs
@@ -67,4 +67,12 @@ public record ResultResponse
     /// Error information.
     /// </summary>
     public Exception? Error { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Live/v1/SpeechStartedResponse.cs
@@ -27,4 +27,12 @@ public record SpeechStartedResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("timestamp")]
     public decimal? Timestamp { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/UnhandledResponse.cs
+++ b/Deepgram/Models/Live/v1/UnhandledResponse.cs
@@ -20,4 +20,12 @@ public record UnhandledResponse
 	[JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public LiveType? Type { get; set; } = LiveType.Unhandled;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Live/v1/UtteranceEndResponse.cs
@@ -27,4 +27,12 @@ public record UtteranceEndResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("last_word_end")]
     public decimal? LastWordEnd { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Live/v1/Word.cs
+++ b/Deepgram/Models/Live/v1/Word.cs
@@ -47,4 +47,12 @@ public record Word
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("speaker")]
     public int? Speaker { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/BalanceResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalanceResponse.cs
@@ -33,4 +33,12 @@ public record BalanceResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("purchase")]
     public string? Purchase { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/BalancesResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalancesResponse.cs
@@ -12,4 +12,12 @@ public record BalancesResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("balances")]
     public IReadOnlyList<BalanceResponse>? Balances { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Callback.cs
+++ b/Deepgram/Models/Manage/v1/Callback.cs
@@ -26,4 +26,12 @@ public record Callback
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("completed")]
     public string? Completed { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Config.cs
+++ b/Deepgram/Models/Manage/v1/Config.cs
@@ -118,4 +118,12 @@ public record Config
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("utterances")]
     public bool? Utterances { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Details.cs
+++ b/Deepgram/Models/Manage/v1/Details.cs
@@ -75,4 +75,12 @@ public record Details
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("config")]
     public Config? Config { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Invite.cs
+++ b/Deepgram/Models/Manage/v1/Invite.cs
@@ -19,4 +19,12 @@ public record Invite
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("scope")]
     public string? Scope { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/InviteSchema.cs
+++ b/Deepgram/Models/Manage/v1/InviteSchema.cs
@@ -20,4 +20,11 @@ public class InviteSchema
     [JsonPropertyName("scope")]
     public string? Scope { get; set; }
 
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/InvitesResponse.cs
+++ b/Deepgram/Models/Manage/v1/InvitesResponse.cs
@@ -12,4 +12,12 @@ public record InvitesResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("invites")]
     public IReadOnlyList<Invite>? Invites { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Key.cs
+++ b/Deepgram/Models/Manage/v1/Key.cs
@@ -40,5 +40,13 @@ public record Key
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("tags")]
     public IReadOnlyList<string>? Tags { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Manage/v1/KeyResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyResponse.cs
@@ -6,5 +6,12 @@ namespace Deepgram.Models.Manage.v1;
 
 public record KeyResponse : Key
 {
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Manage/v1/KeySchema.cs
+++ b/Deepgram/Models/Manage/v1/KeySchema.cs
@@ -42,4 +42,12 @@ public class KeySchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("time_to_live_in_seconds")]
     public int? TimeToLiveInSeconds { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
@@ -19,4 +19,12 @@ public record KeyScopeResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("api_key")]
     public Key? ApiKey { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/KeysResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeysResponse.cs
@@ -12,4 +12,12 @@ public record KeysResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("api_keys")]
     public IReadOnlyList<KeyScopeResponse>? ApiKeys { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Member.cs
+++ b/Deepgram/Models/Manage/v1/Member.cs
@@ -41,4 +41,12 @@ public record Member
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("scopes")]
     public List<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
@@ -12,4 +12,12 @@ public class MemberScopeSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("scope")]
     public string? Scope { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
@@ -12,4 +12,12 @@ public record MemberScopesResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("scopes")]
     public IReadOnlyList<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/MembersResponse.cs
+++ b/Deepgram/Models/Manage/v1/MembersResponse.cs
@@ -12,4 +12,12 @@ public record MembersResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("members")]
     public IReadOnlyList<Member>? Members { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/MessageResponse.cs
+++ b/Deepgram/Models/Manage/v1/MessageResponse.cs
@@ -12,4 +12,12 @@ public record MessageResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("message")]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Model.cs
+++ b/Deepgram/Models/Manage/v1/Model.cs
@@ -33,5 +33,13 @@ public record Model
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("model_id")]
     public string? ModelId { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Manage/v1/Project.cs
+++ b/Deepgram/Models/Manage/v1/Project.cs
@@ -26,4 +26,12 @@ public record Project
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("company")]
     public string? Company { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/ProjectResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectResponse.cs
@@ -6,4 +6,11 @@ namespace Deepgram.Models.Manage.v1;
 
 public record ProjectResponse : Project
 {
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/ProjectSchema.cs
+++ b/Deepgram/Models/Manage/v1/ProjectSchema.cs
@@ -19,4 +19,12 @@ public class ProjectSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("company")]
     public string? Company { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/ProjectsResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectsResponse.cs
@@ -12,4 +12,12 @@ public record ProjectsResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("projects")]
     public IReadOnlyList<ProjectResponse>? Projects { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Resolution.cs
+++ b/Deepgram/Models/Manage/v1/Resolution.cs
@@ -19,4 +19,12 @@ public record Resolution
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("amount")]
     public int? Amount { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Response.cs
+++ b/Deepgram/Models/Manage/v1/Response.cs
@@ -33,4 +33,12 @@ public record Response
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("token_details")]
     public List<TokenDetails>? TokenDetails { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/Result.cs
+++ b/Deepgram/Models/Manage/v1/Result.cs
@@ -47,5 +47,13 @@ public record Result
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("tokens")]
     public Token? Tokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Manage/v1/Token.cs
+++ b/Deepgram/Models/Manage/v1/Token.cs
@@ -19,4 +19,12 @@ public record Token
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("out")]
     public int? Out { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/TokenDetails.cs
+++ b/Deepgram/Models/Manage/v1/TokenDetails.cs
@@ -33,4 +33,12 @@ public record TokenDetails
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("model")]
     public string? Model { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
@@ -41,4 +41,12 @@ public record UsageFieldsResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("features")]
     public IReadOnlyList<string>? Features { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
@@ -19,4 +19,12 @@ public class UsageFieldsSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("end")]
     public DateTime? End { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequest.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequest.cs
@@ -62,4 +62,12 @@ public record UsageRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("callback")]
     public Callback? Callback { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
@@ -6,4 +6,11 @@ namespace Deepgram.Models.Manage.v1;
 
 public record UsageRequestResponse : UsageRequest
 {
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
@@ -26,4 +26,12 @@ public record UsageRequestsResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("requests")]
     public IReadOnlyList<UsageRequest>? Requests { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
@@ -41,4 +41,12 @@ public class UsageRequestsSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("status")]
     public string? Status { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
@@ -33,4 +33,12 @@ public record UsageSummaryResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("results")]
     public IReadOnlyList<Result>? Results { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
@@ -212,4 +212,12 @@ public class UsageSummarySchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("utt_split")]
     public bool? UttSplit { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
@@ -19,4 +19,12 @@ public record CredentialResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("distribution_credentials")]
     public DistributionCredentials? DistributionCredentials { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
@@ -12,4 +12,12 @@ public record CredentialsResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("distribution_credentials")]
     public IReadOnlyList<CredentialResponse>? DistributionCredentials { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
@@ -26,4 +26,12 @@ public class CredentialsSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("provider")]
     public string? Provider { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
+++ b/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
@@ -40,4 +40,12 @@ public record DistributionCredentials
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("created")]
     public DateTime? Created { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/Member.cs
+++ b/Deepgram/Models/OnPrem/v1/Member.cs
@@ -19,4 +19,12 @@ public record Member
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("email")]
     public string? Email { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/OnPrem/v1/MessageResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/MessageResponse.cs
@@ -12,4 +12,12 @@ public record MessageResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("message")]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Alternative.cs
+++ b/Deepgram/Models/PreRecorded/v1/Alternative.cs
@@ -59,4 +59,12 @@ public record Alternative
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("words")]
     public IReadOnlyList<Word>? Words { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/AsyncResponse.cs
+++ b/Deepgram/Models/PreRecorded/v1/AsyncResponse.cs
@@ -13,5 +13,13 @@ public record AsyncResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("request_id")]
     public string? RequestId { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Average.cs
+++ b/Deepgram/Models/PreRecorded/v1/Average.cs
@@ -19,4 +19,12 @@ public record Average
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sentiment_score")]
     public double? SentimentScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Channel.cs
+++ b/Deepgram/Models/PreRecorded/v1/Channel.cs
@@ -34,4 +34,12 @@ public record Channel
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("search")]
     public IReadOnlyList<Search>? Search { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Entity.cs
+++ b/Deepgram/Models/PreRecorded/v1/Entity.cs
@@ -41,4 +41,12 @@ public record Entity
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("confidence")]
     public double? Confidence { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Hit.cs
+++ b/Deepgram/Models/PreRecorded/v1/Hit.cs
@@ -34,4 +34,12 @@ public record Hit
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("start")]
     public decimal? Start { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Intent.cs
+++ b/Deepgram/Models/PreRecorded/v1/Intent.cs
@@ -19,6 +19,14 @@ public record Intent
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("confidence_score")]
     public double? ConfidenceScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/PreRecorded/v1/IntentGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/IntentGroup.cs
@@ -13,4 +13,12 @@ public record IntentGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("segments")]
     public IReadOnlyList<Segment>? Segments { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/IntentsInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/IntentsInfo.cs
@@ -26,6 +26,14 @@ public record IntentsInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/PreRecorded/v1/Metadata.cs
+++ b/Deepgram/Models/PreRecorded/v1/Metadata.cs
@@ -106,4 +106,12 @@ public record Metadata
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("warnings")]
     public List<Warning>? Warnings { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/ModelInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/ModelInfo.cs
@@ -26,4 +26,12 @@ public record ModelInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("version")]
     public string? Version { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Paragraph.cs
+++ b/Deepgram/Models/PreRecorded/v1/Paragraph.cs
@@ -47,5 +47,13 @@ public record Paragraph
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sentiment_score")]
     public double? SentimentScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/ParagraphGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/ParagraphGroup.cs
@@ -19,5 +19,13 @@ public record ParagraphGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("paragraphs")]
     public IReadOnlyList<Paragraph>? Paragraphs { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/PreRecordedSchema.cs
+++ b/Deepgram/Models/PreRecorded/v1/PreRecordedSchema.cs
@@ -4,7 +4,7 @@
 
 namespace Deepgram.Models.PreRecorded.v1;
 
-public class PrerecordedSchema
+public class PreRecordedSchema
 {
     /// <summary>
     /// Number of transcripts to return per request
@@ -301,4 +301,12 @@ public class PrerecordedSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("version")]
     public string? Version { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Results.cs
+++ b/Deepgram/Models/PreRecorded/v1/Results.cs
@@ -47,5 +47,13 @@ public record Results
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("utterances")]
     public IReadOnlyList<Utterance>? Utterances { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Search.cs
+++ b/Deepgram/Models/PreRecorded/v1/Search.cs
@@ -19,5 +19,13 @@ public record Search
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("hits")]
     public IReadOnlyList<Hit>? Hits { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Segment.cs
+++ b/Deepgram/Models/PreRecorded/v1/Segment.cs
@@ -54,4 +54,12 @@ public record Segment
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("intents")]
     public IReadOnlyList<Intent>? Intents { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Sentence.cs
+++ b/Deepgram/Models/PreRecorded/v1/Sentence.cs
@@ -40,5 +40,13 @@ public record Sentence
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sentiment_score")]
     public double? SentimentScore { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/SentimentGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/SentimentGroup.cs
@@ -19,6 +19,14 @@ public record SentimentGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("average")]
     public Average? Average { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/PreRecorded/v1/SentimentInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/SentimentInfo.cs
@@ -26,6 +26,14 @@ public record SentimentInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/PreRecorded/v1/Summary.cs
+++ b/Deepgram/Models/PreRecorded/v1/Summary.cs
@@ -19,5 +19,13 @@ public record Summary // aka SummaryV2
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("result")]
     public string? Result { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/SummaryInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/SummaryInfo.cs
@@ -26,4 +26,12 @@ public record SummaryInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/SummaryObsolete.cs
+++ b/Deepgram/Models/PreRecorded/v1/SummaryObsolete.cs
@@ -24,5 +24,13 @@ public record SummaryObsolete // aka SummaryV1
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("end_word")]
     public int? EndWord { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/SyncResponse.cs
+++ b/Deepgram/Models/PreRecorded/v1/SyncResponse.cs
@@ -19,4 +19,12 @@ public record SyncResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("results")]
     public Results? Results { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/PreRecorded/v1/Topic.cs
+++ b/Deepgram/Models/PreRecorded/v1/Topic.cs
@@ -10,7 +10,7 @@ public record Topic
     /// Value between 0 and 1 indicating the model's relative confidence in this topic.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("confidence")]
+	[JsonPropertyName("confidence_score")]
     public double? Confidence { get; set; }
 
     /// <summary>
@@ -18,6 +18,14 @@ public record Topic
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("topic")]
-    public string? Text;
+    public string? Text { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/TopicGroup.cs
+++ b/Deepgram/Models/PreRecorded/v1/TopicGroup.cs
@@ -12,5 +12,13 @@ public record TopicGroup
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("segments")]
     public IReadOnlyList<Segment>? Segments { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/TopicsInfo.cs
+++ b/Deepgram/Models/PreRecorded/v1/TopicsInfo.cs
@@ -26,6 +26,14 @@ public record TopicsInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("output_tokens")]
     public int? OutputTokens { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 
 

--- a/Deepgram/Models/PreRecorded/v1/Translation.cs
+++ b/Deepgram/Models/PreRecorded/v1/Translation.cs
@@ -19,5 +19,13 @@ public record Translation
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("language")]
     public string? Language { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/UrlSource.cs
+++ b/Deepgram/Models/PreRecorded/v1/UrlSource.cs
@@ -10,7 +10,15 @@ public class UrlSource(string url)
     /// Url of the file to transcribe
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("url")]
+    [JsonPropertyName("url")]
     public string? Url { get; set; } = url;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Utterance.cs
+++ b/Deepgram/Models/PreRecorded/v1/Utterance.cs
@@ -77,5 +77,13 @@ public record Utterance
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("words")]
     public List<Word>? Words { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Warning.cs
+++ b/Deepgram/Models/PreRecorded/v1/Warning.cs
@@ -27,5 +27,13 @@ public record Warning
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("message")]
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/PreRecorded/v1/Word.cs
+++ b/Deepgram/Models/PreRecorded/v1/Word.cs
@@ -69,5 +69,13 @@ public record Word
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("word")]
     public string? HeardWord { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Speak/v1/AsyncResponse.cs
+++ b/Deepgram/Models/Speak/v1/AsyncResponse.cs
@@ -13,5 +13,13 @@ public record AsyncResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("request_id")]
     public string? RequestId { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/Models/Speak/v1/SpeakSchema.cs
+++ b/Deepgram/Models/Speak/v1/SpeakSchema.cs
@@ -54,4 +54,12 @@ public class SpeakSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("sample_rate")]
     public string? SampleRate { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Speak/v1/SyncResponse.cs
+++ b/Deepgram/Models/Speak/v1/SyncResponse.cs
@@ -64,4 +64,12 @@ public record SyncResponse
     /// The filename of the audio file
     /// </summary>
     public string? Filename { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }

--- a/Deepgram/Models/Speak/v1/TextSource.cs
+++ b/Deepgram/Models/Speak/v1/TextSource.cs
@@ -10,7 +10,15 @@ public class TextSource(string text)
     /// Text of the words to speak
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("text")]
+    [JsonPropertyName("text")]
     public string? Text { get; set; } = text;
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
 }
 

--- a/Deepgram/README.md
+++ b/Deepgram/README.md
@@ -20,7 +20,7 @@ Official .NET SDK for [Deepgram](https://www.deepgram.com/). Power your apps wit
   - [Remote File](#remote-file) 
     - [UrlSource](#urlsource)
   - [Local files](#local-files)    
-    - [PrerecordedSchema](#prerecordedschema)
+    - [PreRecordedSchema](#prerecordedschema)
   - [CallBackAsync Methods](#callbackasync-methods) 
   - [Live Audio](#live-audio)
     - [LiveSchema](#liveSchema)
@@ -158,12 +158,12 @@ To quickly get started with examples for prerecorded and streaming, run the file
 # Transcription
 
 ## Remote File
-> for available options see PrerecordedSchema
+> for available options see PreRecordedSchema
 ```csharp
 var client = new PrerecordedClient(apiKey);
 var response = await client.TranscribeUrlAsync(
     new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-    new PrerecordedSchema()
+    new PreRecordedSchema()
     {
         Punctuate = true
     });
@@ -182,7 +182,7 @@ var response = await client.TranscribeUrlAsync(
 var client = new PrerecordedClient(apiKey);
 var response = await client.TranscribeFileAsync(
     stream,
-     new PrerecordedSchema()
+     new PreRecordedSchema()
     {
         Punctuate = true
     });
@@ -190,10 +190,10 @@ var response = await client.TranscribeFileAsync(
 
 ### CallBackAsync Methods
 >TranscibeFileCallBackAsync and TranscibeUrlCallBackAsync are the methods to use if you want to use a CallBack url
->you can either pass the the CallBack in the method or by setting  the CallBack proeprty in the PrerecordedSchema, but NOT in both
+>you can either pass the the CallBack in the method or by setting  the CallBack proeprty in the PreRecordedSchema, but NOT in both
 
 
-#### PrerecordedSchema
+#### PreRecordedSchema
 also see [TranscribeSchema] which prerecored Schema is derived from for more options
 
 | Property          | Value Type |                                                      reason for                                    |

--- a/Deepgram/Utilities/QueryParameterUtil.cs
+++ b/Deepgram/Utilities/QueryParameterUtil.cs
@@ -57,7 +57,7 @@ internal static class QueryParameterUtil
                 var pValue = pInfo.GetValue(parameters);
 
                 //need to check for the CallBack property so the value  is not changed to lowercase - required by Signed uri
-                if (typeof(T) == typeof(PrerecordedSchema) && string.Compare(name, nameof(PrerecordedSchema.CallBack).ToLower(), StringComparison.Ordinal) == 0)
+                if (typeof(T) == typeof(PreRecordedSchema) && string.Compare(name, nameof(PreRecordedSchema.CallBack).ToLower(), StringComparison.Ordinal) == 0)
                 {
                     sb.Append($"{name}={HttpUtility.UrlEncode(pValue.ToString())}&");
                     continue;

--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ var deepgramClient = new PreRecordedClient();
 
 var response = await deepgramClient.TranscribeUrl(
   new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-  new PrerecordedSchema()
+  new PreRecordedSchema()
   {
     Model = "nova-2",
   });
 
-Console.WriteLine(JsonSerializer.Serialize(response, options));
+Console.WriteLine(response);
 ```
 
 ## Live Audio Transcription Quickstart

--- a/examples/analyze/factory_example/Program.cs
+++ b/examples/analyze/factory_example/Program.cs
@@ -19,12 +19,6 @@ namespace PreRecorded
             // OR to set logging level
             //Library.Initialize(LogLevel.Debug);
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
             var deepgramClient = ClientFactory.CreateAnalyzeClient();
 
@@ -49,7 +43,7 @@ namespace PreRecorded
                 },
                 cancelToken);
 
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/analyze/intent/Program.cs
+++ b/examples/analyze/intent/Program.cs
@@ -15,15 +15,9 @@ namespace PreRecorded
         {
             // Initialize Library with default logging
             // Normal logging is "Info" level
-            Library.Initialize();
+            //Library.Initialize();
             // OR to set logging level
-            //Library.Initialize(LogLevel.Debug);
-
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
+            Library.Initialize(LogLevel.Debug);
 
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new AnalyzeClient();
@@ -49,7 +43,7 @@ namespace PreRecorded
                 },
                 cancelToken);
 
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/analyze/sentiment/Program.cs
+++ b/examples/analyze/sentiment/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new AnalyzeClient();
 
@@ -41,7 +35,7 @@ namespace PreRecorded
                     Sentiment = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/analyze/summary/Program.cs
+++ b/examples/analyze/summary/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new AnalyzeClient();
 
@@ -41,7 +35,7 @@ namespace PreRecorded
                     Summarize = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/analyze/topic/Program.cs
+++ b/examples/analyze/topic/Program.cs
@@ -4,6 +4,7 @@
 
 using System.Text.Json;
 
+using Deepgram.Logger;
 using Deepgram.Models.Analyze.v1;
 
 namespace PreRecorded
@@ -15,12 +16,8 @@ namespace PreRecorded
             // Initialize Library with default logging
             // Normal logging is "Info" level
             Library.Initialize();
-
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
+            // OR very chatty logging
+            //Library.Initialize(LogLevel.Verbose); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new AnalyzeClient();
@@ -41,7 +38,7 @@ namespace PreRecorded
                     Topics = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/manage/balances/Program.cs
+++ b/examples/manage/balances/Program.cs
@@ -15,15 +15,9 @@ namespace SampleApp
         {
             // Initialize Library with default logging
             // Normal logging is "Info" level
-            Library.Initialize();
+            //Library.Initialize();
             // OR very chatty logging
-            //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
-
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
+            Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
@@ -34,7 +28,7 @@ namespace SampleApp
                 Console.WriteLine("No projects found.");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine($"\n\n{response}\n\n");
 
             var projectId = "";
             foreach (var project in response.Projects)
@@ -44,29 +38,29 @@ namespace SampleApp
                 break;
             }
 
-            var balanacesResponse = deepgramClient.GetBalances(projectId);
+            var balanacesResponse = await deepgramClient.GetBalances(projectId);
             if (balanacesResponse == null)
             {
                 Console.WriteLine("\n\nNo balance found.\n\n");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(balanacesResponse, options)}\n\n");
+            Console.WriteLine($"\n\n{balanacesResponse}\n\n");
 
             string balanceId = "";
-            foreach (var balance in balanacesResponse.Result.Balances)
+            foreach (var balance in balanacesResponse.Balances)
             {
                 Console.WriteLine($"Using Balance ID: {balance.BalanceId}");
                 balanceId = balance.BalanceId;
                 break;
             }
 
-            var balanceResponse = deepgramClient.GetBalance(projectId, balanceId);
+            var balanceResponse = await deepgramClient.GetBalance(projectId, balanceId);
             if (balanceResponse == null)
             {
                 Console.WriteLine("\n\nNo balance found.\n\n");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(balanceResponse, options)}\n\n");
+            Console.WriteLine($"\n\n{balanceResponse}\n\n");
 
             Console.WriteLine("\n\nPress any key to exit.");
             Console.ReadKey();

--- a/examples/manage/factory_example/Program.cs
+++ b/examples/manage/factory_example/Program.cs
@@ -19,12 +19,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
             var deepgramClient = ClientFactory.CreateManageClient();
 
@@ -34,7 +28,7 @@ namespace SampleApp
                 Console.WriteLine("No projects found.");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine($"\n\n{response}\n\n");
 
             var projectId = "";
             foreach (var project in response.Projects)
@@ -50,7 +44,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nNo balance found.\n\n");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(balanacesResponse, options)}\n\n");
+            Console.WriteLine($"\n\n{balanacesResponse}\n\n");
 
             string balanceId = "";
             foreach (var balance in balanacesResponse.Result.Balances)
@@ -66,7 +60,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nNo balance found.\n\n");
                 return;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(balanceResponse, options)}\n\n");
+            Console.WriteLine($"\n\n{balanceResponse}\n\n");
 
             Console.WriteLine("\n\nPress any key to exit.");
             Console.ReadKey();

--- a/examples/manage/invitations/Program.cs
+++ b/examples/manage/invitations/Program.cs
@@ -19,12 +19,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -54,7 +48,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // send invite
@@ -65,7 +59,7 @@ namespace SampleApp
             };
 
             var createResp = await deepgramClient.SendInvite(myId, createInvite);
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(createResp, options)}\n\n");
+            Console.WriteLine($"\n\n{createResp}\n\n");
 
             // list invites
             listResp = await deepgramClient.GetInvites(myId);
@@ -75,12 +69,12 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // delete invite
             var delResp = await deepgramClient.DeleteInvite(myId, "spam@spam.com");
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+            Console.WriteLine($"\n\n{listResp}\n\n");
 
             // list invites
             listResp = await deepgramClient.GetInvites(myId);
@@ -90,7 +84,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // Leave commented out unless you are running this from a secondary account

--- a/examples/manage/keys/Program.cs
+++ b/examples/manage/keys/Program.cs
@@ -19,12 +19,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -54,7 +48,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // create key
@@ -74,7 +68,7 @@ namespace SampleApp
             else
             {
                 myKeyId = createResp.ApiKeyId;
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(createResp, options)}\n\n");
+                Console.WriteLine($"\n\n{createResp}\n\n");
             }
 
             // list keys
@@ -85,7 +79,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // get key
@@ -97,7 +91,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(getResp, options)}\n\n");
+                Console.WriteLine($"\n\n{getResp}\n\n");
             }
 
             // delete key
@@ -109,7 +103,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(deleteResp, options)}\n\n");
+                Console.WriteLine($"\n\n{deleteResp}\n\n");
             }
 
             // list keys
@@ -120,7 +114,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
 

--- a/examples/manage/members/Program.cs
+++ b/examples/manage/members/Program.cs
@@ -21,12 +21,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -55,7 +49,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
 
                 foreach (var member in listResp.Result.Members)
                 {
@@ -85,7 +79,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             // List members
@@ -96,7 +90,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
             }
 
             Console.WriteLine("\n\nPress any key to exit.");

--- a/examples/manage/projects/Program.cs
+++ b/examples/manage/projects/Program.cs
@@ -21,12 +21,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -50,11 +44,11 @@ namespace SampleApp
                 myId = project.ProjectId;
                 myName = project.Name;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+            Console.WriteLine($"\n\n{listResp}\n\n");
 
             // get project
             var getResp = await deepgramClient.GetProject(myId);
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(getResp, options)}\n\n");
+            Console.WriteLine($"\n\n{getResp}\n\n");
 
             // update project
             var updateOptions = new ProjectSchema()
@@ -68,7 +62,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nUpdateProject failed.\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(updateResp, options)}\n\n");
+            Console.WriteLine($"\n\n{updateResp}\n\n");
 
             // get project
             getResp = await deepgramClient.GetProject(myId);
@@ -77,7 +71,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nGetProject failed.\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(getResp, options)}\n\n");
+            Console.WriteLine($"\n\n{getResp}\n\n");
 
             // update project
             updateOptions = new ProjectSchema()
@@ -90,7 +84,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nUpdateProject failed.\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(updateResp, options)}\n\n");
+            Console.WriteLine($"\n\n{updateResp}\n\n");
 
             // get project
             getResp = await deepgramClient.GetProject(myId);
@@ -99,7 +93,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nGetProject failed.\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(getResp, options)}\n\n");
+            Console.WriteLine($"\n\n{getResp}\n\n");
 
             // delete project
             if (myDeleteId == null)
@@ -118,7 +112,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nDeleteProject failed.\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(respDelete, options)}\n\n");
+            Console.WriteLine($"\n\n{respDelete}\n\n");
 
             Console.WriteLine("\n\nPress any key to exit.");
             Console.ReadKey();

--- a/examples/manage/scopes/Program.cs
+++ b/examples/manage/scopes/Program.cs
@@ -21,12 +21,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -46,7 +40,7 @@ namespace SampleApp
                 myName = project.Name;
                 break;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(projectResp, options)}\n\n");
+            Console.WriteLine($"\n\n{projectResp}\n\n");
 
             // list members
             string memberId = null;
@@ -57,7 +51,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
 
                 foreach (var member in listResp.Members)
                 {
@@ -83,7 +77,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nNo scopes found\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(memberResp, options)}\n\n");
+            Console.WriteLine($"\n\n{memberResp}\n\n");
 
             // update scope
             var scopeUpdate = new MemberScopeSchema()
@@ -91,7 +85,7 @@ namespace SampleApp
                 Scope = "admin"
             };
             var updateResp = await deepgramClient.UpdateMemberScope(myId, memberId, scopeUpdate);
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(updateResp, options)}\n\n");
+            Console.WriteLine($"\n\n{updateResp}\n\n");
 
             // get member scope
             memberResp = await deepgramClient.GetMemberScopes(myId, memberId);
@@ -100,7 +94,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nNo scopes found\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(memberResp, options)}\n\n");
+            Console.WriteLine($"\n\n{memberResp}\n\n");
 
             // update scope
             scopeUpdate = new MemberScopeSchema()
@@ -108,7 +102,7 @@ namespace SampleApp
                 Scope = "member",
             };
             updateResp = await deepgramClient.UpdateMemberScope(myId, memberId, scopeUpdate);
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(updateResp, options)}\n\n");
+            Console.WriteLine($"\n\n{updateResp}\n\n");
 
             // get member scope
             memberResp = await deepgramClient.GetMemberScopes(myId, memberId);
@@ -117,7 +111,7 @@ namespace SampleApp
                 Console.WriteLine("\n\nNo scopes found\n\n");
                 Environment.Exit(1);
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(memberResp, options)}\n\n");
+            Console.WriteLine($"\n\n{memberResp}\n\n");
 
 
             Console.WriteLine("\n\nPress any key to exit.");

--- a/examples/manage/usage/Program.cs
+++ b/examples/manage/usage/Program.cs
@@ -19,12 +19,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new ManageClient();
 
@@ -44,7 +38,7 @@ namespace SampleApp
                 myName = project.Name;
                 break;
             }
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(projectResp, options)}\n\n");
+            Console.WriteLine($"\n\n{projectResp}\n\n");
 
             // list requests
             string requestId = null;
@@ -56,7 +50,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(listResp, options)}\n\n");
+                Console.WriteLine($"\n\n{listResp}\n\n");
 
                 foreach (var request in listResp.Requests)
                 {
@@ -74,7 +68,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(reqResp, options)}\n\n");
+                Console.WriteLine($"\n\n{reqResp}\n\n");
             }
 
             // get fields
@@ -87,7 +81,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(fieldsResp, options)}\n\n");
+                Console.WriteLine($"\n\n{fieldsResp}\n\n");
             }
 
             // list usage
@@ -99,7 +93,7 @@ namespace SampleApp
             }
             else
             {
-                Console.WriteLine($"\n\n{JsonSerializer.Serialize(summaryResp, options)}\n\n");
+                Console.WriteLine($"\n\n{summaryResp}\n\n");
             }
 
 

--- a/examples/prerecorded/factory_example/Program.cs
+++ b/examples/prerecorded/factory_example/Program.cs
@@ -20,12 +20,6 @@ namespace PreRecorded
             // OR very chatty logging
             Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
             var deepgramClient = ClientFactory.CreatePreRecordedClient();
 
@@ -43,14 +37,14 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"Bueller-Life-moves-pretty-fast.wav");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
                 },
                 cancelToken);
 
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine($"\n\n{response}\n\n");
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
 

--- a/examples/prerecorded/file/Program.cs
+++ b/examples/prerecorded/file/Program.cs
@@ -20,12 +20,6 @@ namespace PreRecorded
             // OR very chatty logging
             Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             //DeepgramHttpClientOptions dgOptions = new DeepgramHttpClientOptions(null, "38.104.135.210");
             //var deepgramClient = new PreRecordedClient("", dgOptions);
@@ -45,14 +39,14 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"Bueller-Life-moves-pretty-fast.wav");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
                 },
                 cancelToken);
 
-            Console.WriteLine($"\n\n{JsonSerializer.Serialize(response, options)}\n\n");
+            Console.WriteLine($"\n\n{response}\n\n");
             Console.WriteLine("Press any key to exit...");
             Console.ReadKey();
 

--- a/examples/prerecorded/intent/Program.cs
+++ b/examples/prerecorded/intent/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new PreRecordedClient();
 
@@ -35,14 +29,14 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"CallCenterPhoneCall.mp3");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
                     Intents = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/prerecorded/sentiment/Program.cs
+++ b/examples/prerecorded/sentiment/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new PreRecordedClient();
 
@@ -35,7 +29,7 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"CallCenterPhoneCall.mp3");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
@@ -43,7 +37,7 @@ namespace PreRecorded
                     Sentiment = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/prerecorded/summary/Program.cs
+++ b/examples/prerecorded/summary/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new PreRecordedClient();
 
@@ -35,14 +29,14 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"CallCenterPhoneCall.mp3");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
                     Summarize = "v2",
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/prerecorded/topic/Program.cs
+++ b/examples/prerecorded/topic/Program.cs
@@ -16,12 +16,6 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new PreRecordedClient();
 
@@ -35,14 +29,14 @@ namespace PreRecorded
             var audioData = File.ReadAllBytes(@"CallCenterPhoneCall.mp3");
             var response = await deepgramClient.TranscribeFile(
                 audioData,
-                new PrerecordedSchema()
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                     Punctuate = true,
                     Topics = true,
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/prerecorded/url/Program.cs
+++ b/examples/prerecorded/url/Program.cs
@@ -16,23 +16,17 @@ namespace PreRecorded
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new PreRecordedClient();
 
             var response = await deepgramClient.TranscribeUrl(
-                new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-                new PrerecordedSchema()
+                new UrlSource("https://dpgr.am/bueller.wav"),
+                new PreRecordedSchema()
                 {
                     Model = "nova-2",
                 });
 
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/speak/file/factory_example/Program.cs
+++ b/examples/speak/file/factory_example/Program.cs
@@ -20,12 +20,6 @@ namespace SampleApp
             // OR very chatty logging
             //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
             var deepgramClient = ClientFactory.CreateSpeakClient();
 
@@ -38,7 +32,7 @@ namespace SampleApp
                 });
 
             //Console.WriteLine(response);
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/speak/file/hello-world/Program.cs
+++ b/examples/speak/file/hello-world/Program.cs
@@ -16,15 +16,9 @@ namespace SampleApp
         {
             // Initialize Library with default logging
             // Normal logging is "Info" level
-            Library.Initialize();
+            //Library.Initialize();
             // OR very chatty logging
-            //Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
-
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
+            Library.Initialize(LogLevel.Debug); // LogLevel.Default, LogLevel.Debug, LogLevel.Verbose
 
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new SpeakClient();
@@ -38,7 +32,7 @@ namespace SampleApp
                 });
 
             //Console.WriteLine(response);
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/speak/file/woodchuck/Program.cs
+++ b/examples/speak/file/woodchuck/Program.cs
@@ -17,12 +17,6 @@ namespace SampleApp
             // Normal logging is "Info" level
             Library.Initialize();
 
-            // JSON options
-            JsonSerializerOptions options = new(JsonSerializerDefaults.Web)
-            {
-                WriteIndented = true
-            };
-
             // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
             var deepgramClient = new SpeakClient();
 
@@ -35,7 +29,7 @@ namespace SampleApp
                 });
 
             //Console.WriteLine(response);
-            Console.WriteLine(JsonSerializer.Serialize(response, options));
+            Console.WriteLine(response);
             Console.ReadKey();
 
             // Teardown Library

--- a/examples/streaming/factory_example/Program.cs
+++ b/examples/streaming/factory_example/Program.cs
@@ -26,7 +26,8 @@ namespace SampleApp
             Console.WriteLine("\n\nPress any key to stop and exit...\n\n\n");
 
             // use the client factory with a API Key set with the "DEEPGRAM_API_KEY" environment variable
-            var liveClient = ClientFactory.CreateLiveClient();
+            var options = new DeepgramWsClientOptions(null, null, true);
+            var liveClient = ClientFactory.CreateLiveClient("", options);
 
             // Subscribe to the EventResponseReceived event
             liveClient.Subscribe(new EventHandler<OpenResponse>((sender, e) =>

--- a/examples/streaming/http/Program.cs
+++ b/examples/streaming/http/Program.cs
@@ -1,9 +1,6 @@
 // Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
-// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
-// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
-// SPDX-License-Identifier: MIT
 
 using Deepgram.Models.Live.v1;
 using Deepgram.Logger;

--- a/tests/expected_failures/rest/bad_host/Program.cs
+++ b/tests/expected_failures/rest/bad_host/Program.cs
@@ -27,7 +27,7 @@ namespace SampleApp
             {
                 var response = await deepgramClient.TranscribeUrl(
                     new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-                    new PrerecordedSchema()
+                    new PreRecordedSchema()
                     {
                         Model = "nova-2",
                     });

--- a/tests/expected_failures/rest/throw_exception/Program.cs
+++ b/tests/expected_failures/rest/throw_exception/Program.cs
@@ -1,0 +1,43 @@
+// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using System.Text.Json;
+
+using Deepgram.Models.PreRecorded.v1;
+
+namespace PreRecorded
+{
+    class Program
+    {
+        static async Task Main(string[] args)
+        {
+            // Initialize Library with default logging
+            // Normal logging is "Info" level
+            Library.Initialize();
+
+            // Set "DEEPGRAM_API_KEY" environment variable to your Deepgram API Key
+            var deepgramClient = new PreRecordedClient();
+
+            try
+            {
+                var response = await deepgramClient.TranscribeUrl(
+                    new UrlSource("https://dpgr.am/bad.wav"),
+                    new PreRecordedSchema()
+                    {
+                        Model = "nova-2",
+                    });
+
+                Console.WriteLine(response);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Exception: {e.Message}");
+            }
+            Console.ReadKey();
+
+            // Teardown Library
+            Library.Terminate();
+        }
+    }
+}

--- a/tests/expected_failures/rest/throw_exception/ThrowException.csproj
+++ b/tests/expected_failures/rest/throw_exception/ThrowException.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>net6.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>	
+	</PropertyGroup>
+	
+	<ItemGroup>	
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\..\Deepgram\Deepgram.csproj" />
+	</ItemGroup>
+
+    <ItemGroup>
+	  <Using Include="Deepgram" />
+    </ItemGroup>
+
+</Project>

--- a/tests/expected_failures/rest/trigger_cancel/Program.cs
+++ b/tests/expected_failures/rest/trigger_cancel/Program.cs
@@ -28,13 +28,13 @@ namespace SampleApp
             {
                 var response = await deepgramClient.TranscribeUrl(
                     new UrlSource("https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"),
-                    new PrerecordedSchema()
+                    new PreRecordedSchema()
                     {
                         Model = "nova-2",
                     },
                     cancelToken);
 
-                    Console.WriteLine(JsonSerializer.Serialize(response));
+                    Console.WriteLine(response);
             }
             catch (OperationCanceledException)
             {


### PR DESCRIPTION
This PR fixes a bunch of issues found from users and I will attempt to break it down below:
- [BUG] Fix a problem (also occurs in `v3`) where the DG exception/error is not sent to the user. this PR introduces DG Exceptions to the Project `Deepgram/Models/Exceptions/v1`
  - there is an example project of this exception throwing here: `tests/expected_failures/rest/throw_exception`
- [BUG] Fixed `Analyze` Topics so that the `Topics` field in the result is populated (was missing the `{ get; set; }`)
- [FEATURE] added a `ToString()` function in `Models` to override a class struct dump in favor of a dump everything to JSON. I grew tired of serializing objects to JSON.
- [FEATURE] Fixed logging for dumping raw JSON immediately after performing the HTTP GET, POST, PATCH, DELETE, etc to they can use the `ToString()` which means just doing something like `Console.Writeline("Dump: {object}");` since objects can now be written/converted to a string.
- [FEATURE] the class and file `PrerecordSchema` -> `PreRecordSchema` should match the naming convention of `PreRecorded` this is the reason why you see a bunch of `Deepgram.Tests` changes. *I would just ignore anything starting with `Deepgram.Tests` for changes.*

Yea, this looks like a lot. The majority of changes are ToString and display related things. The code changes of importance  is really:
- https://github.com/deepgram/deepgram-dotnet-sdk/pull/277/files#diff-735e0c678327218305e87a5ed3f41471e03b145f6cf96c0d1b9cc4d6463b3b80R748
- https://github.com/deepgram/deepgram-dotnet-sdk/pull/277/files#diff-e79c6dab5c6e760922e8f1951d8a7c42105fb01b53e9e809874321db4edfc29bR21

Tested examples:
- Analyze Topics
- Microphone streaming
- PreRecorded URL and File
- Manage Invites and Balances
- Speak hello world
- New test `tests/expected_failures/rest/throw_exception`