### PR TITLE
Allow client to pass in their own serilog logger instance

### DIFF
--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -18,7 +18,15 @@ public sealed class Log
     }
     public static void Initialize(ILogger logger)
     {
+        if (logger == null) throw new ArgumentNullException(nameof(logger));
+        if (instance != null)
+        {
+            Log.Warning("Logger", "Attempt to re-initialize logger ignored.");
+            return;
+        }
+        
         instance = logger;
+        Log.Information("Logger", "Logger initialized.");
     }
     /// <summary>
     /// Initializes the logger with the specified log level and filename.

--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -16,7 +16,10 @@ public sealed class Log
     {
         // Do nothing
     }
-    
+    public static void Initialize(ILogger logger)
+    {
+        instance = logger;
+    }
     /// <summary>
     /// Initializes the logger with the specified log level and filename.
     /// </summary>
@@ -105,4 +108,6 @@ public sealed class Log
     {
         GetLogger().Fatal($"{identifier}: {trace}");
     }
+
+    
 }

--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -108,6 +108,4 @@ public sealed class Log
     {
         GetLogger().Fatal($"{identifier}: {trace}");
     }
-
-    
 }


### PR DESCRIPTION
Hi, right now you're creating a log.txt file in my working directory which is not something I need there.  Furthermore my actual logger writes to remote logging services etc.  I've already got a carefully configured Serilog logger and I'd like your library to use the one I've already made.  

The way you've made your library, it's quite easy to add this.  Please accept my 3-line pull request.  Thanks!
