### PR TITLE
Rename `OnPrem` -> `SelfHosted`

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/OnPremClientTests.cs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: MIT
 
 using Deepgram.Models.Authenticate.v1;
-using Deepgram.Models.OnPrem.v1;
-using Deepgram.Clients.OnPrem.v1;
+using Deepgram.Models.SelfHosted.v1;
+using Deepgram.Clients.SelfHosted.v1;
 
 namespace Deepgram.Tests.UnitTests.ClientTests;
 
-public class OnPremClientTests
+public class SelfHostedClientTests
 {
     DeepgramHttpClientOptions _options;
     string _projectId;
@@ -28,12 +28,12 @@ public class OnPremClientTests
     public async Task ListCredentials_Should_Call_GetAsync_Returning_CredentialsResponse()
     {
         // Input and Output
-        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.ONPREM}");
+        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.SELF_HOSTED}");
         var expectedResponse = new AutoFaker<CredentialsResponse>().Generate();
 
         // Fake client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
-        var onPremClient = Substitute.For<OnPremClient>(_apiKey, _options, null);
+        var onPremClient = Substitute.For<SelfHostedClient>(_apiKey, _options, null);
 
         // Mock methods
         onPremClient.When(x => x.GetAsync<CredentialsResponse>(Arg.Any<string>())).DoNotCallBase();
@@ -57,12 +57,12 @@ public class OnPremClientTests
     {
         // Input and Output
         var credentialsId = new Faker().Random.Guid().ToString();
-        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.ONPREM}/{credentialsId}");
+        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.SELF_HOSTED}/{credentialsId}");
         var expectedResponse = new AutoFaker<CredentialResponse>().Generate();
 
         // Fake client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
-        var onPremClient = Substitute.For<OnPremClient>(_apiKey, _options, null);
+        var onPremClient = Substitute.For<SelfHostedClient>(_apiKey, _options, null);
         
         // Mock methods
         onPremClient.When(x => x.GetAsync<CredentialResponse>(Arg.Any<string>())).DoNotCallBase();
@@ -86,12 +86,12 @@ public class OnPremClientTests
     {
         // Input and Output
         var credentialsId = new Faker().Random.Guid().ToString();
-        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.ONPREM}/{credentialsId}");
+        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.SELF_HOSTED}/{credentialsId}");
         var expectedResponse = new AutoFaker<MessageResponse>().Generate();
         
         // Fake client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
-        var onPremClient = Substitute.For<OnPremClient>(_apiKey, _options, null);
+        var onPremClient = Substitute.For<SelfHostedClient>(_apiKey, _options, null);
         
         // Mock methods
         onPremClient.When(x => x.DeleteAsync<MessageResponse>(Arg.Any<string>())).DoNotCallBase();
@@ -115,13 +115,13 @@ public class OnPremClientTests
     public async Task CreateCredentials_Should_Return_CredentialResponse()
     {
         // Input and Output
-        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.ONPREM}");
+        var url = AbstractRestClient.GetUri(_options, $"{UriSegments.PROJECTS}/{_projectId}/{UriSegments.SELF_HOSTED}");
         var expectedResponse = new AutoFaker<CredentialResponse>().Generate();
         var createOnPremCredentialsSchema = new CredentialsSchema();
 
         // Fake client
         var httpClient = MockHttpClient.CreateHttpClientWithResult(expectedResponse);
-        var onPremClient = Substitute.For<OnPremClient>(_apiKey, _options, null);
+        var onPremClient = Substitute.For<SelfHostedClient>(_apiKey, _options, null);
         
         // Mock methods
         onPremClient.When(x => x.PostAsync<CredentialsSchema, CredentialResponse>(Arg.Any<string>(), Arg.Any<CredentialsSchema>())).DoNotCallBase();

--- a/Deepgram/ClientFactory.cs
+++ b/Deepgram/ClientFactory.cs
@@ -45,15 +45,31 @@ public static class ClientFactory
     }
 
     /// <summary>
-    /// Create a new OnPremClient
+    // *********** WARNING ***********
+    // This function creates a OnPrem Client for the Deepgram API
+    //
+    // Deprecated: This function is deprecated. Use the `CreateSelfHostedClient` function instead.
+    // This will be removed in a future release.
+    //
+    // This class is frozen and no new functionality will be added.
+    // *********** WARNING ***********
+    /// </summary>
+    [Obsolete("Please use CreateSelfHostedClient instead", false)]
+    public static IOnPremClient CreateOnPremClient(string apiKey = "", DeepgramHttpClientOptions? options = null, string? httpId = null)
+    {
+        return new OnPremClient(apiKey, options, httpId);
+    }
+
+    /// <summary>
+    /// Create a new SelfHostedClient
     /// </summary>
     /// <param name="apiKey"></param>
     /// <param name="options"></param>
     /// <param name="httpId"></param>
     /// <returns></returns>
-    public static IOnPremClient CreateOnPremClient(string apiKey = "", DeepgramHttpClientOptions? options = null, string? httpId = null)
+    public static ISelfHostedClient CreateSelfHostedClient(string apiKey = "", DeepgramHttpClientOptions? options = null, string? httpId = null)
     {
-        return new OnPremClient(apiKey, options, httpId);
+        return new SelfHostedClient(apiKey, options, httpId);
     }
 
     /// <summary>

--- a/Deepgram/Clients/Interfaces/v1/IOnPremClient.cs
+++ b/Deepgram/Clients/Interfaces/v1/IOnPremClient.cs
@@ -2,49 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
-using Deepgram.Models.OnPrem.v1;
+using Deepgram.Clients.Interfaces.v1;
 
 namespace Deepgram.Clients.Interfaces.v1;
 
 /// <summary>
-/// Implements version 1 of the OnPrem Client.
+// *********** WARNING ***********
+// This class provides the IOnPremClient implementation
+//
+// Deprecated: This class is deprecated. Use ISelfHostedClient instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
 /// </summary>
-/// <param name="apiKey">Required DeepgramApiKey</param>
-/// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
-public interface IOnPremClient
+[Obsolete("Please use ISelfHostedClient instead", false)]
+public interface IOnPremClient : ISelfHostedClient
 {
-    /// <summary>
-    /// get a list of credentials associated with project
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <returns><see cref="CredentialsResponse"/></returns>
-    public Task<CredentialsResponse> ListCredentials(string projectId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
-
-    /// <summary>
-    /// Get credentials for the project that is associated with credential ID
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="credentialsId">Id of credentials</param>
-    /// <returns><see cref="CredentialResponse"/></returns>
-    public Task<CredentialResponse> GetCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
-
-    /// <summary>
-    /// Remove credentials in the project associated with the credentials ID
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="credentialsId">Id of credentials</param>
-    /// <returns><see cref="MessageResponse"/></returns>
-    public Task<MessageResponse> DeleteCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
-
-    /// <summary>
-    /// Create credentials for the associated projects
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="createOnPremCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
-    /// <returns><see cref="CredentialResponse"/></returns>
-    public Task<CredentialResponse> CreateCredentials(string projectId, CredentialsSchema credentialsSchema,
-        CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
 }

--- a/Deepgram/Clients/Interfaces/v1/ISelfHostedClient.cs
+++ b/Deepgram/Clients/Interfaces/v1/ISelfHostedClient.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.SelfHosted.v1;
+
+namespace Deepgram.Clients.Interfaces.v1;
+
+/// <summary>
+/// Implements version 1 of the OnPrem Client.
+/// </summary>
+/// <param name="apiKey">Required DeepgramApiKey</param>
+/// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
+public interface ISelfHostedClient
+{
+    /// <summary>
+    /// get a list of credentials associated with project
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <returns><see cref="CredentialsResponse"/></returns>
+    public Task<CredentialsResponse> ListCredentials(string projectId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
+
+    /// <summary>
+    /// Get credentials for the project that is associated with credential ID
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="credentialsId">Id of credentials</param>
+    /// <returns><see cref="CredentialResponse"/></returns>
+    public Task<CredentialResponse> GetCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
+
+    /// <summary>
+    /// Remove credentials in the project associated with the credentials ID
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="credentialsId">Id of credentials</param>
+    /// <returns><see cref="MessageResponse"/></returns>
+    public Task<MessageResponse> DeleteCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
+
+    /// <summary>
+    /// Create credentials for the associated projects
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="createOnPremCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
+    /// <returns><see cref="CredentialResponse"/></returns>
+    public Task<CredentialResponse> CreateCredentials(string projectId, CredentialsSchema credentialsSchema,
+        CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null);
+}

--- a/Deepgram/Clients/OnPrem/v1/Client.cs
+++ b/Deepgram/Clients/OnPrem/v1/Client.cs
@@ -3,106 +3,23 @@
 // SPDX-License-Identifier: MIT
 
 using Deepgram.Models.Authenticate.v1;
-using Deepgram.Models.OnPrem.v1;
 using Deepgram.Clients.Interfaces.v1;
+using SH = Deepgram.Clients.SelfHosted.v1;
 
 namespace Deepgram.Clients.OnPrem.v1;
 
 /// <summary>
-/// Implements version 1 of the OnPrem Client.
+// *********** WARNING ***********
+// This class provides the OnPrem Client implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Clients.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
 /// </summary>
-/// <param name="apiKey">Required DeepgramApiKey</param>
-/// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
+[Obsolete("Please use Deepgram.Clients.SelfHosted.v1.Client instead", false)]
 public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
-    : AbstractRestClient(apiKey, deepgramClientOptions, httpId), IOnPremClient
+    : SH.Client(apiKey, deepgramClientOptions, httpId), IOnPremClient
 {
-    /// <summary>
-    /// get a list of credentials associated with project
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <returns><see cref="CredentialsResponse"/></returns>
-    public async Task<CredentialsResponse> ListCredentials(string projectId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
-    {
-        Log.Verbose("OnPremClient.ListCredentials", "ENTER");
-        Log.Debug("ListCredentials", $"projectId: {projectId}");
-
-        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}");
-        var result = await GetAsync<CredentialsResponse>(uri, cancellationToken, addons, headers);
-
-        Log.Information("ListCredentials", $"{uri} Succeeded");
-        Log.Debug("ListCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.ListCredentials", "LEAVE");
-
-        return result;
-    }
-
-    /// <summary>
-    /// Get credentials for the project that is associated with credential ID
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="credentialsId">Id of credentials</param>
-    /// <returns><see cref="CredentialResponse"/></returns>
-    public async Task<CredentialResponse> GetCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
-    {
-        Log.Verbose("OnPremClient.GetCredentials", "ENTER");
-        Log.Debug("GetCredentials", $"projectId: {projectId}");
-        Log.Debug("GetCredentials", $"credentialsId: {credentialsId}");
-
-        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}/{credentialsId}");
-        var result = await GetAsync<CredentialResponse>(uri, cancellationToken, addons, headers);
-
-        Log.Information("GetCredentials", $"{uri} Succeeded");
-        Log.Debug("GetCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.GetCredentials", "LEAVE");
-
-        return result;
-    }
-
-    /// <summary>
-    /// Remove credentials in the project associated with the credentials ID
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="credentialsId">Id of credentials</param>
-    /// <returns><see cref="MessageResponse"/></returns>
-    public async Task<MessageResponse> DeleteCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
-        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
-    {
-        Log.Verbose("OnPremClient.DeleteCredentials", "ENTER");
-        Log.Debug("DeleteCredentials", $"projectId: {projectId}");
-        Log.Debug("DeleteCredentials", $"credentialsId: {credentialsId}");
-
-        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}/{credentialsId}");
-        var result = await DeleteAsync<MessageResponse>(uri, cancellationToken, addons, headers);
-
-        Log.Information("DeleteCredentials", $"{uri} Succeeded");
-        Log.Debug("DeleteCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.DeleteCredentials", "LEAVE");
-
-        return result;
-    }
-
-    /// <summary>
-    /// Create credentials for the associated projects
-    /// </summary>
-    /// <param name="projectId">Id of project</param>
-    /// <param name="createOnPremCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
-    /// <returns><see cref="CredentialResponse"/></returns>
-    public async Task<CredentialResponse> CreateCredentials(string projectId, CredentialsSchema credentialsSchema, 
-        CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
-    {
-        Log.Verbose("OnPremClient.CreateCredentials", "ENTER");
-        Log.Debug("CreateCredentials", $"projectId: {projectId}");
-        Log.Debug("CreateCredentials", $"credentialsSchema:\n{credentialsSchema}");
-
-        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.ONPREM}");
-        var result = await PostAsync<CredentialsSchema, CredentialResponse>(uri, credentialsSchema, cancellationToken, addons, headers);
-
-        Log.Information("CreateCredentials", $"{uri} Succeeded");
-        Log.Debug("CreateCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.CreateCredentials", "LEAVE");
-
-        return result;
-    }
 }

--- a/Deepgram/Clients/OnPrem/v1/UriSegments.cs
+++ b/Deepgram/Clients/OnPrem/v1/UriSegments.cs
@@ -4,6 +4,17 @@
 
 namespace Deepgram.Clients.OnPrem.v1;
 
+/// <summary>
+// *********** WARNING ***********
+// This class provides the UriSegments implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Clients.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Clients.SelfHosted.v1.UriSegments instead", false)]
 public static class UriSegments
 {
     //using constants instead of inline value(magic strings) make consistence

--- a/Deepgram/Clients/OnPrem/v1/UriSegments.cs
+++ b/Deepgram/Clients/OnPrem/v1/UriSegments.cs
@@ -5,6 +5,7 @@
 namespace Deepgram.Clients.OnPrem.v1;
 
 /// <summary>
+/// <remarks>
 // *********** WARNING ***********
 // This class provides the UriSegments implementation
 //
@@ -13,7 +14,7 @@ namespace Deepgram.Clients.OnPrem.v1;
 //
 // This package is frozen and no new functionality will be added.
 // *********** WARNING ***********
-/// </summary>
+/// </remarks>
 [Obsolete("Please use Deepgram.Clients.SelfHosted.v1.UriSegments instead", false)]
 public static class UriSegments
 {

--- a/Deepgram/Clients/SelfHosted/v1/Client.cs
+++ b/Deepgram/Clients/SelfHosted/v1/Client.cs
@@ -9,7 +9,7 @@ using Deepgram.Clients.Interfaces.v1;
 namespace Deepgram.Clients.SelfHosted.v1;
 
 /// <summary>
-/// Implements version 1 of the OnPrem Client.
+/// Implements version 1 of the SelfHosted Client.
 /// </summary>
 /// <param name="apiKey">Required DeepgramApiKey</param>
 /// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
@@ -24,7 +24,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     public async Task<CredentialsResponse> ListCredentials(string projectId, CancellationTokenSource? cancellationToken = default,
         Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
-        Log.Verbose("OnPremClient.ListCredentials", "ENTER");
+        Log.Verbose("SelfHostedClient.ListCredentials", "ENTER");
         Log.Debug("ListCredentials", $"projectId: {projectId}");
 
         var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.SELF_HOSTED}");
@@ -32,7 +32,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
 
         Log.Information("ListCredentials", $"{uri} Succeeded");
         Log.Debug("ListCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.ListCredentials", "LEAVE");
+        Log.Verbose("SelfHostedClient.ListCredentials", "LEAVE");
 
         return result;
     }
@@ -46,7 +46,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     public async Task<CredentialResponse> GetCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
         Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
-        Log.Verbose("OnPremClient.GetCredentials", "ENTER");
+        Log.Verbose("SelfHostedClient.GetCredentials", "ENTER");
         Log.Debug("GetCredentials", $"projectId: {projectId}");
         Log.Debug("GetCredentials", $"credentialsId: {credentialsId}");
 
@@ -55,7 +55,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
 
         Log.Information("GetCredentials", $"{uri} Succeeded");
         Log.Debug("GetCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.GetCredentials", "LEAVE");
+        Log.Verbose("SelfHostedClient.GetCredentials", "LEAVE");
 
         return result;
     }
@@ -69,7 +69,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     public async Task<MessageResponse> DeleteCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
         Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
-        Log.Verbose("OnPremClient.DeleteCredentials", "ENTER");
+        Log.Verbose("SelfHostedClient.DeleteCredentials", "ENTER");
         Log.Debug("DeleteCredentials", $"projectId: {projectId}");
         Log.Debug("DeleteCredentials", $"credentialsId: {credentialsId}");
 
@@ -78,7 +78,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
 
         Log.Information("DeleteCredentials", $"{uri} Succeeded");
         Log.Debug("DeleteCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.DeleteCredentials", "LEAVE");
+        Log.Verbose("SelfHostedClient.DeleteCredentials", "LEAVE");
 
         return result;
     }
@@ -87,12 +87,12 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
     /// Create credentials for the associated projects
     /// </summary>
     /// <param name="projectId">Id of project</param>
-    /// <param name="createOnPremCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
+    /// <param name="createSelfHostedCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
     /// <returns><see cref="CredentialResponse"/></returns>
     public async Task<CredentialResponse> CreateCredentials(string projectId, CredentialsSchema credentialsSchema, 
         CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
     {
-        Log.Verbose("OnPremClient.CreateCredentials", "ENTER");
+        Log.Verbose("SelfHostedClient.CreateCredentials", "ENTER");
         Log.Debug("CreateCredentials", $"projectId: {projectId}");
         Log.Debug("CreateCredentials", $"credentialsSchema:\n{credentialsSchema}");
 
@@ -101,7 +101,7 @@ public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClien
 
         Log.Information("CreateCredentials", $"{uri} Succeeded");
         Log.Debug("CreateCredentials", $"result: {result}");
-        Log.Verbose("OnPremClient.CreateCredentials", "LEAVE");
+        Log.Verbose("SelfHostedClient.CreateCredentials", "LEAVE");
 
         return result;
     }

--- a/Deepgram/Clients/SelfHosted/v1/Client.cs
+++ b/Deepgram/Clients/SelfHosted/v1/Client.cs
@@ -1,0 +1,108 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Authenticate.v1;
+using Deepgram.Models.SelfHosted.v1;
+using Deepgram.Clients.Interfaces.v1;
+
+namespace Deepgram.Clients.SelfHosted.v1;
+
+/// <summary>
+/// Implements version 1 of the OnPrem Client.
+/// </summary>
+/// <param name="apiKey">Required DeepgramApiKey</param>
+/// <param name="deepgramClientOptions"><see cref="DeepgramHttpClientOptions"/> for HttpClient Configuration</param>
+public class Client(string? apiKey = null, IDeepgramClientOptions? deepgramClientOptions = null, string? httpId = null)
+    : AbstractRestClient(apiKey, deepgramClientOptions, httpId), ISelfHostedClient
+{
+    /// <summary>
+    /// get a list of credentials associated with project
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <returns><see cref="CredentialsResponse"/></returns>
+    public async Task<CredentialsResponse> ListCredentials(string projectId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    {
+        Log.Verbose("OnPremClient.ListCredentials", "ENTER");
+        Log.Debug("ListCredentials", $"projectId: {projectId}");
+
+        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.SELF_HOSTED}");
+        var result = await GetAsync<CredentialsResponse>(uri, cancellationToken, addons, headers);
+
+        Log.Information("ListCredentials", $"{uri} Succeeded");
+        Log.Debug("ListCredentials", $"result: {result}");
+        Log.Verbose("OnPremClient.ListCredentials", "LEAVE");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Get credentials for the project that is associated with credential ID
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="credentialsId">Id of credentials</param>
+    /// <returns><see cref="CredentialResponse"/></returns>
+    public async Task<CredentialResponse> GetCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    {
+        Log.Verbose("OnPremClient.GetCredentials", "ENTER");
+        Log.Debug("GetCredentials", $"projectId: {projectId}");
+        Log.Debug("GetCredentials", $"credentialsId: {credentialsId}");
+
+        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.SELF_HOSTED}/{credentialsId}");
+        var result = await GetAsync<CredentialResponse>(uri, cancellationToken, addons, headers);
+
+        Log.Information("GetCredentials", $"{uri} Succeeded");
+        Log.Debug("GetCredentials", $"result: {result}");
+        Log.Verbose("OnPremClient.GetCredentials", "LEAVE");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Remove credentials in the project associated with the credentials ID
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="credentialsId">Id of credentials</param>
+    /// <returns><see cref="MessageResponse"/></returns>
+    public async Task<MessageResponse> DeleteCredentials(string projectId, string credentialsId, CancellationTokenSource? cancellationToken = default,
+        Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    {
+        Log.Verbose("OnPremClient.DeleteCredentials", "ENTER");
+        Log.Debug("DeleteCredentials", $"projectId: {projectId}");
+        Log.Debug("DeleteCredentials", $"credentialsId: {credentialsId}");
+
+        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.SELF_HOSTED}/{credentialsId}");
+        var result = await DeleteAsync<MessageResponse>(uri, cancellationToken, addons, headers);
+
+        Log.Information("DeleteCredentials", $"{uri} Succeeded");
+        Log.Debug("DeleteCredentials", $"result: {result}");
+        Log.Verbose("OnPremClient.DeleteCredentials", "LEAVE");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Create credentials for the associated projects
+    /// </summary>
+    /// <param name="projectId">Id of project</param>
+    /// <param name="createOnPremCredentialsSchema"><see cref="CredentialsSchema"/> for credentials to be created</param>
+    /// <returns><see cref="CredentialResponse"/></returns>
+    public async Task<CredentialResponse> CreateCredentials(string projectId, CredentialsSchema credentialsSchema, 
+        CancellationTokenSource? cancellationToken = default, Dictionary<string, string>? addons = null, Dictionary<string, string>? headers = null)
+    {
+        Log.Verbose("OnPremClient.CreateCredentials", "ENTER");
+        Log.Debug("CreateCredentials", $"projectId: {projectId}");
+        Log.Debug("CreateCredentials", $"credentialsSchema:\n{credentialsSchema}");
+
+        var uri = GetUri(_options, $"{UriSegments.PROJECTS}/{projectId}/{UriSegments.SELF_HOSTED}");
+        var result = await PostAsync<CredentialsSchema, CredentialResponse>(uri, credentialsSchema, cancellationToken, addons, headers);
+
+        Log.Information("CreateCredentials", $"{uri} Succeeded");
+        Log.Debug("CreateCredentials", $"result: {result}");
+        Log.Verbose("OnPremClient.CreateCredentials", "LEAVE");
+
+        return result;
+    }
+}

--- a/Deepgram/Clients/SelfHosted/v1/UriSegments.cs
+++ b/Deepgram/Clients/SelfHosted/v1/UriSegments.cs
@@ -1,0 +1,13 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Clients.SelfHosted.v1;
+
+public static class UriSegments
+{
+    //using constants instead of inline value(magic strings) make consistence
+    //across SDK And Test Projects Simpler and Easier to change
+    public const string PROJECTS = "projects";
+    public const string SELF_HOSTED = "onprem/distribution/credentials";
+}

--- a/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialResponse.cs
@@ -2,29 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public record CredentialResponse
+/// <summary>
+// *********** WARNING ***********
+// This class provides the CredentialResponse implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.CredentialResponse instead", false)]
+public record CredentialResponse : SH.CredentialResponse
 {
-    /// <summary>
-    /// Member information
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("member")]
-    public Member? Member { get; set; }
-
-    /// <summary>
-    /// Distribution credentials
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("distribution_credentials")]
-    public DistributionCredentials? DistributionCredentials { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsResponse.cs
@@ -2,22 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public record CredentialsResponse
+/// <summary>
+// *********** WARNING ***********
+// This class provides the CredentialsResponse implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.CredentialsResponse instead", false)]
+public record CredentialsResponse :  SH.CredentialsResponse
 {
-    /// <summary>
-    /// Distribution credentials
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("distribution_credentials")]
-    public IReadOnlyList<CredentialResponse>? DistributionCredentials { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
+++ b/Deepgram/Models/OnPrem/v1/CredentialsSchema.cs
@@ -2,36 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public class CredentialsSchema
+/// <summary>
+// *********** WARNING ***********
+// This class provides the CredentialsSchema implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.CredentialsSchema instead", false)]
+public class CredentialsSchema : SH.CredentialsSchema
 {
-    /// <summary>
-    /// comment to credentials
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("comment")]
-    public string? Comment { get; set; }
-
-    /// <summary>
-    /// scopes of credentials
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("scopes")]
-    public List<string>? Scopes { get; set; }
-
-    /// <summary>
-    /// provider
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("provider")]
-    public string? Provider { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
+++ b/Deepgram/Models/OnPrem/v1/DistributionCredentials.cs
@@ -2,50 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public record DistributionCredentials
+/// <summary>
+// *********** WARNING ***********
+// This class provides the DistributionCredentials implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.DistributionCredentials instead", false)]
+public record DistributionCredentials :  SH.DistributionCredentials
 {
-    /// <summary>
-    /// Distribution credentials ID
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("distribution_credentials_id")]
-    public string? DistributionCredentialsId { get; set; }
-
-    /// <summary>
-    /// Provider name
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("provider")]
-    public string? Provider { get; set; }
-
-    /// <summary>
-    /// Comment
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("comment")]
-    public string? Comment { get; set; }
-
-    /// <summary>
-    /// Scopes of the credentials
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("scopes")]
-    public IReadOnlyList<string>? Scopes { get; set; }
-
-    /// <summary>
-    /// Created date/time
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("created")]
-    public DateTime? Created { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/OnPrem/v1/Member.cs
+++ b/Deepgram/Models/OnPrem/v1/Member.cs
@@ -2,29 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public record Member
+/// <summary>
+// *********** WARNING ***********
+// This class provides the Member implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.Member instead", false)]
+public record Member : SH.Member
 {
-    /// <summary>
-    /// Member ID
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("member_id")]
-    public string? MemberId { get; set; }
-
-    /// <summary>
-    /// Email of the member
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("email")]
-    public string? Email { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/OnPrem/v1/MessageResponse.cs
+++ b/Deepgram/Models/OnPrem/v1/MessageResponse.cs
@@ -2,22 +2,21 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using SH = Deepgram.Models.SelfHosted.v1;
+
 namespace Deepgram.Models.OnPrem.v1;
 
-public record MessageResponse
+/// <summary>
+// *********** WARNING ***********
+// This class provides the MessageResponse implementation
+//
+// Deprecated: This class is deprecated. Use the `Deepgram.Models.SelfHosted.v1` namespace instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
+/// </summary>
+[Obsolete("Please use Deepgram.Models.SelfHosted.v1.MessageResponse instead", false)]
+public record MessageResponse : SH.MessageResponse
 {
-    /// <summary>
-    /// A message denoting the success of the operation
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("message")]
-    public string? Message { get; set; }
-
-    /// <summary>
-    /// Override ToString method to serialize the object
-    /// </summary>
-    public override string ToString()
-    {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
-    }
 }

--- a/Deepgram/Models/SelfHosted/v1/CredentialResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialResponse.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public record CredentialResponse
+{
+    /// <summary>
+    /// Member information
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("member")]
+    public Member? Member { get; set; }
+
+    /// <summary>
+    /// Distribution credentials
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("distribution_credentials")]
+    public DistributionCredentials? DistributionCredentials { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/Models/SelfHosted/v1/CredentialsResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialsResponse.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public record CredentialsResponse
+{
+    /// <summary>
+    /// Distribution credentials
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("distribution_credentials")]
+    public IReadOnlyList<CredentialResponse>? DistributionCredentials { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/Models/SelfHosted/v1/CredentialsSchema.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialsSchema.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public class CredentialsSchema
+{
+    /// <summary>
+    /// comment to credentials
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("comment")]
+    public string? Comment { get; set; }
+
+    /// <summary>
+    /// scopes of credentials
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("scopes")]
+    public List<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// provider
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/Models/SelfHosted/v1/DistributionCredentials.cs
+++ b/Deepgram/Models/SelfHosted/v1/DistributionCredentials.cs
@@ -1,0 +1,51 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public record DistributionCredentials
+{
+    /// <summary>
+    /// Distribution credentials ID
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("distribution_credentials_id")]
+    public string? DistributionCredentialsId { get; set; }
+
+    /// <summary>
+    /// Provider name
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("provider")]
+    public string? Provider { get; set; }
+
+    /// <summary>
+    /// Comment
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("comment")]
+    public string? Comment { get; set; }
+
+    /// <summary>
+    /// Scopes of the credentials
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("scopes")]
+    public IReadOnlyList<string>? Scopes { get; set; }
+
+    /// <summary>
+    /// Created date/time
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("created")]
+    public DateTime? Created { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/Models/SelfHosted/v1/Member.cs
+++ b/Deepgram/Models/SelfHosted/v1/Member.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public record Member
+{
+    /// <summary>
+    /// Member ID
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("member_id")]
+    public string? MemberId { get; set; }
+
+    /// <summary>
+    /// Email of the member
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/Models/SelfHosted/v1/MessageResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/MessageResponse.cs
@@ -1,0 +1,23 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.SelfHosted.v1;
+
+public record MessageResponse
+{
+    /// <summary>
+    /// A message denoting the success of the operation
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("message")]
+    public string? Message { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}

--- a/Deepgram/OnPremClient.cs
+++ b/Deepgram/OnPremClient.cs
@@ -8,8 +8,16 @@ using Deepgram.Models.Authenticate.v1;
 namespace Deepgram;
 
 /// <summary>
-/// Implements the latest supported version of the OnPrem Client.
+// *********** WARNING ***********
+// This class provides the OnPrem Client implementation
+//
+// Deprecated: This class is deprecated. Use SelfHostedClient instead.
+// This will be removed in a future release.
+//
+// This package is frozen and no new functionality will be added.
+// *********** WARNING ***********
 /// </summary>
+[Obsolete("Please use SelfHostedClient instead", false)]
 public class OnPremClient : Client
 {
     public OnPremClient(string apiKey = "", DeepgramHttpClientOptions? deepgramClientOptions = null,

--- a/Deepgram/SelfHostedClient.cs
+++ b/Deepgram/SelfHostedClient.cs
@@ -8,7 +8,7 @@ using Deepgram.Models.Authenticate.v1;
 namespace Deepgram;
 
 /// <summary>
-/// Implements the latest supported version of the OnPrem Client.
+/// Implements the latest supported version of the SelfHosted Client.
 /// </summary>
 public class SelfHostedClient : Client
 {

--- a/Deepgram/SelfHostedClient.cs
+++ b/Deepgram/SelfHostedClient.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Clients.SelfHosted.v1;
+using Deepgram.Models.Authenticate.v1;
+
+namespace Deepgram;
+
+/// <summary>
+/// Implements the latest supported version of the OnPrem Client.
+/// </summary>
+public class SelfHostedClient : Client
+{
+    public SelfHostedClient(string apiKey = "", DeepgramHttpClientOptions? deepgramClientOptions = null,
+        string? httpId = null) : base(apiKey, deepgramClientOptions, httpId)
+    {
+    }
+}


### PR DESCRIPTION
Addresses: https://github.com/deepgram/deepgram-dotnet-sdk/issues/297

Marks old `OnPrem` as obsolete to preserve backward compatibility.

The README was **NOT** updated because they need to be updated for `Listen` and `Speak`. Will do so in a subsequent PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `SelfHostedClient` for managing credentials in a self-hosted environment.
  - Added new methods for listing, getting, deleting, and creating credentials within `SelfHostedClient`.
  
- **Deprecations**
  - Deprecated `OnPremClient`, advising users to switch to `SelfHostedClient`.
  - Deprecated `IOnPremClient` interface in favor of `ISelfHostedClient`.
  
- **Enhancements**
  - Updated terminology from `OnPrem` to `SelfHosted` across the codebase for clarity and consistency.
  
- **Documentation**
  - Updated documentation to reflect the new terminology and deprecations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->