### PR TITLE
`[main]` Implement Mutli-Lingual and Missing Speaker/NumWords

### DIFF
--- a/Deepgram/Models/Listen/v1/REST/Alternative.cs
+++ b/Deepgram/Models/Listen/v1/REST/Alternative.cs
@@ -22,6 +22,13 @@ public record Alternative
     public IReadOnlyList<Entity>? Entities { get; set; }
 
     /// <summary>
+    /// ReadOnlyList of Languages Detected
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("languages")]
+    public IReadOnlyList<string>? Languages { get; set; }
+
+    /// <summary>
     /// ReadOnly List of <see cref="ParagraphGroup"/> containing  separated transcript and <see cref="Paragraph"/> objects.
     /// </summary>
     /// <remark>Only used when the paragraph feature is enabled on the request</remark>

--- a/Deepgram/Models/Listen/v1/REST/Paragraph.cs
+++ b/Deepgram/Models/Listen/v1/REST/Paragraph.cs
@@ -18,7 +18,7 @@ public record Paragraph
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("num_words")]
-    internal int? NumWords { get; set; }
+    public int? NumWords { get; set; }
 
     /// <summary>
     /// Offset in seconds from the start of the audio to where the paragraph starts.
@@ -26,6 +26,13 @@ public record Paragraph
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
 	[JsonPropertyName("start")]
     public decimal? Start { get; set; }
+
+    /// <summary>
+    /// speak Index
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("speaker")]
+    public int? Speaker { get; set; }
 
     /// <summary>
     /// Offset in seconds from the start of the audio to where the paragraph ends.

--- a/Deepgram/Models/Listen/v1/REST/Word.cs
+++ b/Deepgram/Models/Listen/v1/REST/Word.cs
@@ -22,6 +22,13 @@ public record Word
     public decimal? End { get; set; }
 
     /// <summary>
+    /// Language detected
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    /// <summary>
     /// Punctuated version of the word
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Deepgram/Models/Listen/v1/WebSocket/Alternative.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Alternative.cs
@@ -27,6 +27,13 @@ public record Alternative
     public IReadOnlyList<Word>? Words { get; set; }
 
     /// <summary>
+    /// ReadOnlyList of Languages Detected
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("languages")]
+    public IReadOnlyList<string>? Languages { get; set; }
+
+    /// <summary>
     /// Override ToString method to serialize the object
     /// </summary>
     public override string ToString()

--- a/Deepgram/Models/Listen/v1/WebSocket/Word.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Word.cs
@@ -42,6 +42,13 @@ public record Word
     public string? PunctuatedWord { get; set; }
 
     /// <summary>
+    /// Language detected
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("language")]
+    public string? Language { get; set; }
+
+    /// <summary>
     /// Speaker index of who said this word
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
This implements multi-lingual support for `main` branch. This is implemented in the temp branch here:
https://github.com/dvonthenen/deepgram-python-sdk/tree/temp-v40-rel

Did not test. Implemented per the spec since this was pretty straight forward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added language detection capabilities to words and alternatives in both REST and WebSocket models.
  
- **Enhancements**
  - Made the `NumWords` property in the Paragraph model publicly accessible.
  - Added a new `Speaker` property to the Paragraph model for identifying speakers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->