### PR TITLE
Adds Missing Dictation Param

### DIFF
--- a/Deepgram/Models/Listen/v1/WebSocket/LiveSchema.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/LiveSchema.cs
@@ -59,6 +59,15 @@ public class LiveSchema
     public string? DiarizeVersion { get; set; }
 
     /// <summary>
+    /// Dictation is a feature of Deepgram’s Speech-to-Text API that converts spoken dictation commands into their corresponding punctuation marks. 
+    /// <see href="https://developers.deepgram.com/docs/dictation">
+    /// default is false
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("dictation")]
+    public bool? Dictation { get; set; }
+
+    /// <summary>
     /// Encoding allows you to specify the expected encoding of your submitted audio.
     /// <see href="https://developers.deepgram.com/docs/encoding">
     /// supported encodings <see cref="AudioEncoding"/>


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses: https://github.com/deepgram/deepgram-dotnet-sdk/issues/317

## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `Dictation` property to enhance the LiveSchema with speaker diarization capabilities, allowing for improved audio transcription by recognizing speaker changes.
- **Documentation**
	- Added summary documentation to clarify the functionality of the new `Dictation` property and provide links to relevant resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->