### PR TITLE
Fix Type in Warning class. Introduce Converter.

### DIFF
--- a/Deepgram/Models/Listen/v1/REST/Warning.cs
+++ b/Deepgram/Models/Listen/v1/REST/Warning.cs
@@ -17,9 +17,26 @@ public record Warning
     /// The type of warning
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("type")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public WarningType? Type { get; set; }
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    /// <summary>
+    /// Returns the WarningType enum value based on the Type string
+    /// </summary>
+    public WarningType WarningType
+    {
+        get
+        {
+            return Type switch
+            {
+                "unsupported_language" => WarningType.UnsupportedLanguage,
+                "unsupported_model" => WarningType.UnsupportedModel,
+                "unsupported_encoding" => WarningType.UnsupportedEncoding,
+                "deprecated" => WarningType.Deprecated,
+                _ => WarningType.UnsupportedLanguage
+            };
+        }
+    }
 
     /// <summary>
     /// The warning message


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses Issue: https://github.com/deepgram/deepgram-dotnet-sdk/issues/329

I think this is a good compromise to get the serialization to work correctly and also provide a mechanism to get the `WarningType` if so desired.

This works below:
```
var json = "{ \"metadata\": { \"warnings\": [ { \"parameter\": \"sentiment\", \"type\": \"unsupported_language\", \"message\": \"Sentiment is only supported for English.\" } ] } }";
var result = System.Text.Json.JsonSerializer.Deserialize<SyncResponse>(json);

Console.WriteLine(result.Metadata.Warnings[0].Type);
Console.WriteLine(result.Metadata.Warnings[0].WarningType);
```

## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The `Type` property in the `Warning` record now accepts string values, enhancing flexibility.
	- Introduced a new computed property, `WarningType`, to convert string values to corresponding enum values.

- **Bug Fixes**
	- Improved handling of unsupported language warnings through default case mapping in the new `WarningType` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->