### PR TITLE
Improve WebSocketMessage Buffer Length Handling

### DIFF
--- a/Deepgram/Clients/Listen/v1/WebSocket/WebSocketMessage.cs
+++ b/Deepgram/Clients/Listen/v1/WebSocket/WebSocketMessage.cs
@@ -13,7 +13,7 @@ internal readonly struct WebSocketMessage
 
     public WebSocketMessage(byte[] message, WebSocketMessageType type, int length)
     {
-        if (length != Constants.UseArrayLengthForSend || length < Constants.UseArrayLengthForSend)
+        if (length != Constants.UseArrayLengthForSend && length <= message.Length && length > 0)
         {
             Message = new ArraySegment<byte>(message, 0, length);
         }
@@ -22,10 +22,9 @@ internal readonly struct WebSocketMessage
             Message = new ArraySegment<byte>(message, 0, message.Length);
         }
         MessageType = type;
-        Length = length;
     }
 
-    public int Length { get; }
+    public int Length => Message.Count;
 
     public ArraySegment<byte> Message { get; }
 

--- a/Deepgram/Clients/Speak/v1/WebSocket/WebSocketMessage.cs
+++ b/Deepgram/Clients/Speak/v1/WebSocket/WebSocketMessage.cs
@@ -13,7 +13,7 @@ internal readonly struct WebSocketMessage
 
     public WebSocketMessage(byte[] message, WebSocketMessageType type, int length)
     {
-        if (length != Constants.UseArrayLengthForSend || length < Constants.UseArrayLengthForSend)
+        if (length != Constants.UseArrayLengthForSend && length <= message.Length && length > 0)
         {
             Message = new ArraySegment<byte>(message, 0, length);
         }
@@ -22,10 +22,9 @@ internal readonly struct WebSocketMessage
             Message = new ArraySegment<byte>(message, 0, message.Length);
         }
         MessageType = type;
-        Length = length;
     }
 
-    public int Length { get; }
+    public int Length => Message.Count;
 
     public ArraySegment<byte> Message { get; }
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Slight improvement to the buffer handling.

## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation logic for the `length` parameter in WebSocket message handling, ensuring it meets stricter criteria for message integrity.
	- Updated the `Length` property to accurately reflect the count of the message segments, enhancing reliability in message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->