### PR TITLE
feat: adds support for agent mip_opt_out

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/AgentClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AgentClientTests.cs
@@ -198,4 +198,165 @@ public class AgentClientTests
             parsed.RootElement.GetProperty("content").GetString().Should().Be("Hello! Can you hear me?");
         }
     }
+
+    #region MipOptOut Tests
+
+    [Test]
+    public void Agent_MipOptOut_Should_Have_Default_Value_False()
+    {
+        // Arrange & Act
+        var agent = new Agent();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            agent.MipOptOut.Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void Agent_MipOptOut_Should_Be_Settable()
+    {
+        // Arrange & Act
+        var agent = new Agent
+        {
+            MipOptOut = true
+        };
+
+        // Assert
+        using (new AssertionScope())
+        {
+            agent.MipOptOut.Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void Agent_MipOptOut_Should_Serialize_To_Snake_Case()
+    {
+        // Arrange
+        var agent = new Agent
+        {
+            MipOptOut = true
+        };
+
+        // Act
+        var result = agent.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().Contain("mip_opt_out");
+            result.Should().Contain("true");
+
+            // Verify it's valid JSON by parsing it
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.GetProperty("mip_opt_out").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void Agent_MipOptOut_False_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var agent = new Agent
+        {
+            MipOptOut = false
+        };
+
+        // Act
+        var result = agent.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().Contain("mip_opt_out");
+            result.Should().Contain("false");
+
+            // Verify it's valid JSON by parsing it
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.GetProperty("mip_opt_out").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void Agent_MipOptOut_Null_Should_Not_Serialize()
+    {
+        // Arrange
+        var agent = new Agent
+        {
+            MipOptOut = null
+        };
+
+        // Act
+        var result = agent.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().NotContain("mip_opt_out");
+
+            // Verify it's valid JSON by parsing it
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.TryGetProperty("mip_opt_out", out _).Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void Agent_With_MipOptOut_Should_Serialize_With_Other_Properties()
+    {
+        // Arrange
+        var agent = new Agent
+        {
+            Language = "en",
+            Greeting = "Hello, I'm your agent",
+            MipOptOut = true
+        };
+
+        // Act
+        var result = agent.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().Contain("language");
+            result.Should().Contain("greeting");
+            result.Should().Contain("mip_opt_out");
+
+            // Verify it's valid JSON by parsing it
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.GetProperty("language").GetString().Should().Be("en");
+            parsed.RootElement.GetProperty("greeting").GetString().Should().Be("Hello, I'm your agent");
+            parsed.RootElement.GetProperty("mip_opt_out").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    [Test]
+    public void Agent_MipOptOut_Schema_Should_Match_API_Specification()
+    {
+        // Arrange - Test both default (false) and explicit true values
+        var agentDefault = new Agent();
+        var agentOptOut = new Agent { MipOptOut = true };
+
+        // Act
+        var defaultResult = agentDefault.ToString();
+        var optOutResult = agentOptOut.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            // Default should be false
+            var defaultParsed = JsonDocument.Parse(defaultResult);
+            defaultParsed.RootElement.GetProperty("mip_opt_out").GetBoolean().Should().BeFalse();
+
+            // Explicit true should be true
+            var optOutParsed = JsonDocument.Parse(optOutResult);
+            optOutParsed.RootElement.GetProperty("mip_opt_out").GetBoolean().Should().BeTrue();
+        }
+    }
+
+    #endregion
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Agent.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Agent.cs
@@ -33,11 +33,18 @@ public record Agent
     public string? Greeting { get; set; }
 
     /// <summary>
+    /// To opt out of Deepgram Model Improvement Program
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("mip_opt_out")]
+    public bool? MipOptOut { get; set; } = false;
+
+    /// <summary>
     /// Override ToString method to serialize the object
     /// </summary>
     public override string ToString()
     {
         return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
     }
-    
+
 }


### PR DESCRIPTION
## PR Summary: Add `mip_opt_out` Agent Setting Support

### TL;DR
Added support for the new `mip_opt_out` boolean field to the Deepgram Agent API, allowing users to opt out of the Deepgram Model Improvement Program. The field defaults to `false` and serializes correctly as `mip_opt_out` in JSON. Includes comprehensive unit tests and maintains full backward compatibility.

## 🎯 **Purpose**
This PR implements the new `mip_opt_out` agent setting that allows users to opt out of Deepgram's Model Improvement Program. This feature provides users with greater control over how their data is used for model improvements.

## 📋 **API Specification**
According to the provided API specification:
```yaml
mip_opt_out:
  type: boolean
  default: false
  description: To opt out of Deepgram Model Improvement Program
```

## 🔧 **Changes Made**

### Core Implementation
**File:** `Deepgram/Models/Agent/v2/WebSocket/Agent.cs`
- ✅ Added `MipOptOut` property of type `bool?`
- ✅ Defaults to `false` as per API specification
- ✅ Uses `JsonPropertyName("mip_opt_out")` for correct snake_case serialization
- ✅ Implements `JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)` for null handling
- ✅ Includes comprehensive XML documentation

```csharp
/// <summary>
/// To opt out of Deepgram Model Improvement Program
/// </summary>
[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
[JsonPropertyName("mip_opt_out")]
public bool? MipOptOut { get; set; } = false;
```

### Testing Implementation
**File:** `Deepgram.Tests/UnitTests/ClientTests/AgentClientTests.cs`
- ✅ Added 7 comprehensive unit tests
- ✅ Tests cover default values, explicit values, JSON serialization, null handling, and integration scenarios
- ✅ Follows existing testing patterns and uses FluentAssertions

## 🧪 **Testing Strategy**

### Unit Tests Added (7 new tests)
1. **Default Value Test** - Ensures field defaults to `false`
2. **Property Assignment Test** - Verifies field can be set to `true`
3. **JSON Serialization Test** - Confirms correct snake_case serialization (`mip_opt_out`)
4. **Explicit False Test** - Validates explicit `false` serialization
5. **Null Value Test** - Ensures null values are properly omitted from JSON
6. **Integration Test** - Verifies compatibility with other Agent properties
7. **API Compliance Test** - Validates implementation matches API specification

### Schema Validation
- Created and executed temporary demo application for end-to-end schema testing
- Validated JSON serialization/deserialization in both directions
- Confirmed integration with existing Agent configuration properties
- Demo app focused on **Schema Testing** rather than live API testing as requested
- Demo app was cleaned up after successful validation

## 📊 **Test Results**
- ✅ **All 142 tests passing** (increased from 135 - added 7 new tests)
- ✅ **No regressions** detected in existing functionality
- ✅ **100% backward compatibility** maintained
- ✅ **Schema validation successful** across all test scenarios

## 🔄 **Usage Example**

### Basic Usage
```csharp
var agent = new Agent
{
    Language = "en",
    Greeting = "Hello, how can I help you?",
    MipOptOut = true  // Opt out of Model Improvement Program
};
```

### JSON Output
```json
{
  "language": "en",
  "greeting": "Hello, how can I help you?",
  "mip_opt_out": true,
  "listen": { "provider": {} },
  "think": { "provider": {} },
  "speak": { "provider": {} }
}
```

### Null Handling (Field Omitted)
```csharp
var agent = new Agent
{
    MipOptOut = null  // Field will be omitted from JSON
};
```

## 🔒 **Backward Compatibility**
- ✅ **Fully backward compatible** - Existing code continues to work unchanged
- ✅ **Optional field** - Defaults to `false`, existing configurations unaffected
- ✅ **JSON compatibility** - Null values are omitted, maintaining clean JSON output
- ✅ **No breaking changes** - All existing APIs and behaviors preserved


## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

