### PR TITLE
chore(docs): replace broken Discord badge with shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![NuGet](https://img.shields.io/nuget/v/deepgram)](https://www.nuget.org/packages/Deepgram)
 [![Build Status](https://github.com/deepgram-devs/deepgram-dotnet-sdk/workflows/CI/badge.svg)](https://github.com/deepgram-devs/deepgram-dotnet-sdk/actions?query=CI)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](./.github/CODE_OF_CONDUCT.md)
-[![Discord](https://dcbadge.vercel.app/api/server/xWRaCDBtW4?style=flat)](https://discord.gg/xWRaCDBtW4)
+[![Discord](https://img.shields.io/badge/Discord-Deepgram-5865F2?logo=discord&logoColor=white&style=flat)](https://discord.gg/deepgram)
 
 Official .NET SDK for [Deepgram](https://www.deepgram.com/).
 Power your apps with world-class speech and Language AI models.


### PR DESCRIPTION
## Summary
- Replace `dcbadge.vercel.app` Discord badge with a `shields.io` badge
- Update Discord invite link to use the canonical `deepgram` slug

## Motivation
The current badge image from `dcbadge.vercel.app` returns a 404, resulting in a
broken image in the README. This switches to shields.io, a more widely-used and
reliable badge service.
## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)


