### PR TITLE
fix: add History message type support and prevent Content-Length header in WebSocket upgrade

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/AgentClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AgentClientTests.cs
@@ -644,4 +644,157 @@ public class AgentClientTests
     }
 
     #endregion
+
+    #region History Tests
+
+    [Test]
+    public void HistoryResponse_Should_Have_History_AgentType()
+    {
+        // Arrange & Act
+        var response = new HistoryResponse();
+
+        // Assert
+        response.Type.Should().Be(AgentType.History);
+    }
+
+    [Test]
+    public void HistoryResponse_With_Role_And_Content_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var response = new HistoryResponse
+        {
+            Role = "user",
+            Content = "Hello, how are you?"
+        };
+
+        // Act
+        var result = response.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().Contain("History");
+            result.Should().Contain("user");
+            result.Should().Contain("Hello, how are you?");
+
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.GetProperty("type").GetString().Should().Be("History");
+            parsed.RootElement.GetProperty("role").GetString().Should().Be("user");
+            parsed.RootElement.GetProperty("content").GetString().Should().Be("Hello, how are you?");
+        }
+    }
+
+    [Test]
+    public void HistoryResponse_With_FunctionCalls_Should_Serialize_Correctly()
+    {
+        // Arrange
+        var response = new HistoryResponse
+        {
+            Role = "assistant",
+            FunctionCalls = new List<HistoryFunctionCall>
+            {
+                new HistoryFunctionCall
+                {
+                    Id = "call_123",
+                    Name = "get_weather",
+                    ClientSide = false,
+                    Arguments = "location=Seattle",
+                    Response = "temperature=55"
+                }
+            }
+        };
+
+        // Act
+        var result = response.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+            result.Should().Contain("function_calls");
+            result.Should().Contain("call_123");
+            result.Should().Contain("get_weather");
+
+            var parsed = JsonDocument.Parse(result);
+            var functionCalls = parsed.RootElement.GetProperty("function_calls");
+            functionCalls.ValueKind.Should().Be(JsonValueKind.Array);
+            functionCalls.GetArrayLength().Should().Be(1);
+
+            var call = functionCalls[0];
+            call.GetProperty("id").GetString().Should().Be("call_123");
+            call.GetProperty("name").GetString().Should().Be("get_weather");
+            call.GetProperty("client_side").GetBoolean().Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void HistoryResponse_Null_Fields_Should_Not_Serialize()
+    {
+        // Arrange
+        var response = new HistoryResponse();
+
+        // Act
+        var result = response.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            result.Should().NotBeNull();
+
+            var parsed = JsonDocument.Parse(result);
+            parsed.RootElement.TryGetProperty("role", out _).Should().BeFalse();
+            parsed.RootElement.TryGetProperty("content", out _).Should().BeFalse();
+            parsed.RootElement.TryGetProperty("function_calls", out _).Should().BeFalse();
+        }
+    }
+
+    [Test]
+    public void HistoryFunctionCall_Should_Serialize_All_Fields()
+    {
+        // Arrange & Act
+        var response = new HistoryResponse
+        {
+            FunctionCalls = new List<HistoryFunctionCall>
+            {
+                new HistoryFunctionCall
+                {
+                    Id = "call_abc",
+                    Name = "search",
+                    ClientSide = true,
+                    Arguments = "query=test",
+                    Response = "results=none"
+                }
+            }
+        };
+        var result = response.ToString();
+
+        // Assert
+        using (new AssertionScope())
+        {
+            var parsed = JsonDocument.Parse(result);
+            var callJson = parsed.RootElement.GetProperty("function_calls")[0];
+            callJson.GetProperty("id").GetString().Should().Be("call_abc");
+            callJson.GetProperty("name").GetString().Should().Be("search");
+            callJson.GetProperty("client_side").GetBoolean().Should().BeTrue();
+            callJson.GetProperty("arguments").GetString().Should().Be("query=test");
+            callJson.GetProperty("response").GetString().Should().Be("results=none");
+        }
+    }
+
+    [Test]
+    public void AgentType_Should_Include_History()
+    {
+        // Assert
+        Enum.IsDefined(typeof(AgentType), AgentType.History).Should().BeTrue();
+    }
+
+    [Test]
+    public void AgentClientTypes_History_Constant_Should_Be_History()
+    {
+        // Assert
+        AgentClientTypes.History.Should().Be("History");
+    }
+
+    #endregion
 }

--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -115,7 +115,16 @@ public abstract class AbstractWebSocketClient : IDisposable
             Log.Debug("Connect", $"uri: {uri}");
 
             Log.Debug("Connect", "Connecting to Deepgram API...");
+#if NET5_0_OR_GREATER
+            // Use SocketsHttpHandler via HttpMessageInvoker to prevent Content-Length: 0 from
+            // being added to the WebSocket upgrade request, which violates WebSocket protocol
+            // and causes failures with strict proxies such as Azure API Management (APIM).
+            using var socketHandler = new System.Net.Http.SocketsHttpHandler();
+            using var invoker = new System.Net.Http.HttpMessageInvoker(socketHandler);
+            await _clientWebSocket.ConnectAsync(myUri, invoker, cancelToken.Token).ConfigureAwait(false);
+#else
             await _clientWebSocket.ConnectAsync(myUri, cancelToken.Token).ConfigureAwait(false);
+#endif
 
             if (!IsConnected())
             {

--- a/Deepgram/Clients/Agent/v2/Websocket/Client.cs
+++ b/Deepgram/Clients/Agent/v2/Websocket/Client.cs
@@ -45,6 +45,7 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
     private event EventHandler<InjectionRefusedResponse>? _injectionRefusedReceived;
     private event EventHandler<PromptUpdatedResponse>? _promptUpdatedReceived;
     private event EventHandler<SpeakUpdatedResponse>? _speakUpdatedReceived;
+    private event EventHandler<HistoryResponse>? _historyReceived;
     #endregion
 
     /// <summary>
@@ -375,6 +376,24 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
         try
         {
             _speakUpdatedReceived += (sender, e) => eventHandler(sender, e);
+        }
+        finally
+        {
+            _mutexSubscribe.Release();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Subscribe to a History event from the Deepgram API
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public async Task<bool> Subscribe(EventHandler<HistoryResponse> eventHandler)
+    {
+        await _mutexSubscribe.WaitAsync();
+        try
+        {
+            _historyReceived += (sender, e) => eventHandler(sender, e);
         }
         finally
         {
@@ -848,6 +867,24 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
 
                     Log.Debug("ProcessTextMessage", $"Invoking SpeakUpdatedResponse. event: {speakUpdatedResponse}");
                     InvokeParallel(_speakUpdatedReceived, speakUpdatedResponse);
+                    break;
+                case AgentType.History:
+                    var historyResponse = data.Deserialize<HistoryResponse>();
+                    if (_historyReceived == null)
+                    {
+                        Log.Debug("ProcessTextMessage", "_historyReceived has no listeners");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    if (historyResponse == null)
+                    {
+                        Log.Warning("ProcessTextMessage", "HistoryResponse is invalid");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+
+                    Log.Debug("ProcessTextMessage", $"Invoking HistoryResponse. event: {historyResponse}");
+                    InvokeParallel(_historyReceived, historyResponse);
                     break;
                 default:
                     Log.Debug("ProcessTextMessage", "Calling base.ProcessTextMessage...");

--- a/Deepgram/Clients/Interfaces/v2/IAgentWebSocketClient.cs
+++ b/Deepgram/Clients/Interfaces/v2/IAgentWebSocketClient.cs
@@ -123,6 +123,12 @@ public interface IAgentWebSocketClient
     /// </summary>
     /// <returns>True if successful</returns>
     public Task<bool> Subscribe(EventHandler<SpeakUpdatedResponse> eventHandler);
+
+    /// <summary>
+    /// Subscribe to a History event from the Deepgram API
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public Task<bool> Subscribe(EventHandler<HistoryResponse> eventHandler);
     #endregion
 
     #region Send Functions

--- a/Deepgram/Models/Agent/v2/WebSocket/AgentType.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/AgentType.cs
@@ -24,6 +24,7 @@ public enum AgentType
     SettingsApplied,
     PromptUpdated,
     SpeakUpdated,
+    History,
 }
 
 public static class AgentClientTypes
@@ -37,4 +38,5 @@ public static class AgentClientTypes
     public const string FunctionCallResponse = "FunctionCallResponse";
     public const string KeepAlive = "KeepAlive";
     public const string Close = "Close";
+    public const string History = "History";
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/HistoryResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/HistoryResponse.cs
@@ -1,0 +1,56 @@
+// Copyright 2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Agent.v2.WebSocket;
+
+public record HistoryFunctionCall
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("client_side")]
+    public bool? ClientSide { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("arguments")]
+    public string? Arguments { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("response")]
+    public string? Response { get; set; }
+}
+
+public record HistoryResponse
+{
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public AgentType? Type { get; } = AgentType.History;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("role")]
+    public string? Role { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("content")]
+    public string? Content { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("function_calls")]
+    public List<HistoryFunctionCall>? FunctionCalls { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+    }
+}


### PR DESCRIPTION
## Summary

- **History message type**: The Voice Agent API returns a `"type": "History"` server message that was not handled by the SDK — it would silently fall through to the `Unhandled` event. This PR adds full support so subscribers can receive and act on History events.
- **Content-Length header**: On .NET 5+, WebSocket upgrade requests now use `SocketsHttpHandler` via `HttpMessageInvoker`, which does not add a `Content-Length: 0` header to the upgrade request. This header violates the WebSocket protocol and causes failures with strict proxies such as Azure API Management (APIM).

## Changes

### History message type (`"type": "History"`)
- `Deepgram/Models/Agent/v2/WebSocket/HistoryResponse.cs` — New model with `Role`, `Content`, and `FunctionCalls` fields; includes a `HistoryFunctionCall` record
- `Deepgram/Models/Agent/v2/WebSocket/AgentType.cs` — Added `History` to the `AgentType` enum and `History = "History"` to `AgentClientTypes`
- `Deepgram/Clients/Agent/v2/Websocket/Client.cs` — Added `_historyReceived` event, `Subscribe(EventHandler<HistoryResponse>)`, and `case AgentType.History:` in `ProcessTextMessage`
- `Deepgram/Clients/Interfaces/v2/IAgentWebSocketClient.cs` — Added `Subscribe(EventHandler<HistoryResponse>)` to the interface

### Content-Length fix
- `Deepgram/Abstractions/v2/AbstractWebSocketClient.cs` — On `NET5_0_OR_GREATER`, `ConnectAsync` is called with an `HttpMessageInvoker` wrapping `SocketsHttpHandler` instead of the default handler, preventing `Content-Length: 0` from being included in the WebSocket upgrade request

## Test plan
- [x] 7 new unit tests added to `AgentClientTests.cs` covering `HistoryResponse` serialisation, `HistoryFunctionCall` field mapping, null-field omission, enum presence, and the `AgentClientTypes` constant
- [x] Full test suite passes (170/170)