### PR TITLE
feat: improve 5 lowest-scoring skill definitions

### DIFF
--- a/.agents/skills/deepgram-dotnet-conversational-stt/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-conversational-stt/SKILL.md
@@ -1,20 +1,15 @@
 ---
 name: deepgram-dotnet-conversational-stt
-description: Use when evaluating or extending conversational / Flux-style streaming STT support in this C# SDK. The repo has a latest WebSocket listen client under `Deepgram.Models.Listen.v2.WebSocket`, but it does not currently expose Flux-specific request params or turn-aware response types like `TurnInfo`. Use this skill to document that gap honestly and to guide work on the closest supported surface.
+description: "Use when evaluating, extending, or writing C# code for conversational speech-to-text, Flux-style real-time transcription, or turn-taking streaming in the Deepgram .NET SDK. Identifies missing Flux request parameters (language_hint, eot_threshold), maps existing WebSocket response types, provides the closest supported LiveSchema code path, and guides adding TurnInfo models and Flux examples. Use `deepgram-dotnet-speech-to-text` for standard streaming transcription without turn awareness."
 ---
 
 # Using Deepgram Conversational STT / Flux (.NET SDK)
 
 This repo does **not** currently expose a dedicated Flux / conversational STT API surface comparable to the Python SDK's `listen.v2.connect(...)` + `TurnInfo` flow.
 
-## When to use this product
-
-- Use this skill when someone asks for **Flux**, **conversational STT**, **turn-taking**, or `/v2/listen` support in the .NET SDK.
-- Use it when deciding whether the current `Listen.v2.WebSocket` client is sufficient for the task.
-
 **Use a different skill when:**
-- You only need standard streaming transcription with `ResultResponse`, `SpeechStartedResponse`, and `UtteranceEndResponse` → `deepgram-dotnet-speech-to-text`.
-- You need a full voice assistant instead of transcription-only → `deepgram-dotnet-voice-agent`.
+- You only need standard streaming transcription without turn awareness → `deepgram-dotnet-speech-to-text`.
+- You need a full voice assistant (STT + LLM + TTS) → `deepgram-dotnet-voice-agent`.
 
 ## Current repo status
 
@@ -30,26 +25,13 @@ What is **not** present in the current repo search:
 - No `language_hint`, `eager_eot_threshold`, `eot_threshold`, or similar Flux request properties.
 - No README/examples that mention conversational STT explicitly.
 
-## Authentication
-
-```bash
-dotnet add package Deepgram
-```
-
-```csharp
-using Deepgram;
-
-Library.Initialize();
-var client = ClientFactory.CreateListenWebSocketClient();
-```
-
-`ClientFactory` reads credentials from the `DEEPGRAM_API_KEY` (or `DEEPGRAM_ACCESS_TOKEN`) environment variable by default. To pass them explicitly: `ClientFactory.CreateListenWebSocketClient(apiKey: "...", options: ...)`. `DeepgramWsClientOptions` throws if neither the env var nor an explicit credential is provided.
-
 ## Closest supported code path today
 
 ```csharp
+using Deepgram;
 using Deepgram.Models.Listen.v2.WebSocket;
 
+Library.Initialize(); // reads DEEPGRAM_API_KEY env var
 var liveClient = ClientFactory.CreateListenWebSocketClient();
 
 await liveClient.Subscribe(new EventHandler<ResultResponse>((sender, e) =>
@@ -83,29 +65,21 @@ Treat this as **standard live STT**, not true Flux parity.
 
 On `LiveSchema`: `Model`, `Encoding`, `SampleRate`, `InterimResults`, `UtteranceEnd`, `VadEvents`, `Endpointing`, `NoDelay`, `Punctuate`, `SmartFormat`, `Keywords`, `Keyterm`, `Diarize`, `Redact`.
 
-## API reference (layered)
+## Workflow: adding Flux support to the SDK
 
-1. **In-repo source of truth**:
-   - `Deepgram/ClientFactory.cs`
-   - `Deepgram/Clients/Listen/v2/WebSocket/Client.cs`
-   - `Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs`
-   - `Deepgram/Models/Listen/v2/WebSocket/*.cs`
-2. **Canonical OpenAPI**: not the primary reference for this streaming gap
-3. **Canonical AsyncAPI (what the product can support, even if this SDK is incomplete)**: https://developers.deepgram.com/asyncapi.yaml
-4. **Context7**:
-   - repo mirror: `https://context7.com/deepgram/deepgram-dotnet-sdk`
-   - docs corpus: `/llmstxt/developers_deepgram_llms_txt`
-5. **Product docs**:
-   - https://developers.deepgram.com/reference/speech-to-text/listen-flux
-   - https://developers.deepgram.com/docs/flux/quickstart
-   - https://developers.deepgram.com/docs/flux/language-prompting
+If the task requires real Flux parity, follow these steps in order:
+
+1. **Add request params** — extend `Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs` with `LanguageHint`, `EagerEotThreshold`, `EotThreshold`, and other Flux-specific fields. Validate against the AsyncAPI spec.
+2. **Add response models** — create `TurnInfo` and any turn-aware event types under `Deepgram/Models/Listen/v2/WebSocket/`. Verify field names match the AsyncAPI spec.
+3. **Wire events in the client** — update `Deepgram/Clients/Listen/v2/WebSocket/Client.cs` to deserialize and dispatch new event types.
+4. **Write tests** — add unit tests covering serialization of new request params and deserialization of new response types.
+5. **Add an example** — create `examples/speech-to-text/websocket/flux/Program.cs` demonstrating a Flux session with turn-taking.
 
 ## Gotchas
 
-1. **Be honest: Flux is not first-class here yet.** Do not invent `TurnInfo`-style .NET models or `ConnectFluxAsync(...)` helpers.
-2. **The repo's `Listen.v2.WebSocket` naming is misleading if you expect Python parity.** It is the newest streaming client, but not a full conversational surface.
-3. **Default API version still resolves from shared options.** `DeepgramWsClientOptions` defaults `APIVersion` to `v1`, so inspect connection URIs before assuming `/v2/listen` behavior.
-4. **If the task requires real Flux parity, start by adding models, request params, examples, and tests.** Do not paper over the gap in docs or code.
+1. **Flux is not first-class here yet.** Do not invent `TurnInfo`-style .NET models or `ConnectFluxAsync(...)` helpers that are not backed by real implementation.
+2. **`Listen.v2.WebSocket` naming is misleading for Python-parity expectations.** It is the newest streaming client, but not a full conversational surface.
+3. **`DeepgramWsClientOptions` defaults `APIVersion` to `v1`.** Inspect connection URIs before assuming `/v2/listen` behavior.
 
 ## Example files in this repo
 
@@ -113,12 +87,8 @@ On `LiveSchema`: `Model`, `Encoding`, `SampleRate`, `InterimResults`, `Utterance
 - `examples/speech-to-text/websocket/http/Program.cs`
 - `examples/speech-to-text/websocket/microphone/Program.cs`
 
-## Central product skills
+## References
 
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+- In-repo: `Deepgram/Clients/Listen/v2/WebSocket/Client.cs`, `Deepgram/Models/Listen/v2/WebSocket/*.cs`
+- AsyncAPI (target spec): https://developers.deepgram.com/asyncapi.yaml
+- Product docs: https://developers.deepgram.com/reference/speech-to-text/listen-flux

--- a/.agents/skills/deepgram-dotnet-management-api/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-management-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepgram-dotnet-management-api
-description: Use when writing or reviewing C# code in this repo that calls Deepgram Management APIs for projects, models, keys, members, invitations, usage, balances, and auth token grants. Covers `ClientFactory.CreateManageClient()` and `ClientFactory.CreateAuthClient()`. Unlike some other SDKs, this repo does not currently expose reusable Voice Agent configuration management endpoints.
+description: "Use when writing or reviewing C# code in this repo that calls Deepgram Management APIs for projects, models, keys, members, invitations, usage, balances, and auth token grants. Covers `ClientFactory.CreateManageClient()` and `ClientFactory.CreateAuthClient()`. Unlike some other SDKs, this repo does not currently expose reusable Voice Agent configuration management endpoints."
 ---
 
 # Using Deepgram Management API (.NET SDK)
@@ -103,31 +103,40 @@ Auth:
 - `GrantToken()`
 - `GrantToken(GrantTokenSchema)`
 
-## API reference (layered)
+## References
 
-1. **In-repo source of truth**:
-   - `Deepgram/ClientFactory.cs`
-   - `Deepgram/Clients/Manage/v1/Client.cs`
-   - `Deepgram/Clients/Auth/v1/Client.cs`
-   - `Deepgram/Models/Manage/v1/*.cs`
-   - `Deepgram/Models/Auth/v1/*.cs`
-2. **Canonical OpenAPI (REST)**: https://developers.deepgram.com/openapi.yaml
-3. **AsyncAPI**: not applicable for these admin endpoints
-4. **Context7**:
-   - repo mirror: `https://context7.com/deepgram/deepgram-dotnet-sdk`
-   - docs corpus: `/llmstxt/developers_deepgram_llms_txt`
-5. **Product docs**:
-   - https://developers.deepgram.com/reference/manage/projects/list
-   - https://developers.deepgram.com/reference/manage/models/list
-   - https://developers.deepgram.com/reference/auth/grant-token
+- In-repo: `Deepgram/Clients/Manage/v1/Client.cs`, `Deepgram/Clients/Auth/v1/Client.cs`, `Deepgram/Models/Manage/v1/*.cs`, `Deepgram/Models/Auth/v1/*.cs`
+- OpenAPI: https://developers.deepgram.com/openapi.yaml
+- Product docs: https://developers.deepgram.com/reference/manage/projects/list, https://developers.deepgram.com/reference/auth/grant-token
+
+## Guard pattern for destructive operations
+
+```csharp
+// 1. Verify the resource exists
+var key = await client.GetKey(projectId, keyId);
+Console.WriteLine($"Found key: {key.ApiKey.Comment} ({keyId})");
+
+// 2. Delete
+await client.DeleteKey(projectId, keyId);
+
+// 3. Verify deletion succeeded
+try
+{
+    await client.GetKey(projectId, keyId);
+    Console.Error.WriteLine("ERROR: key still exists after deletion");
+}
+catch
+{
+    Console.WriteLine("Key deleted successfully.");
+}
+```
 
 ## Gotchas
 
 1. **This repo does not currently expose Voice Agent configuration CRUD.** Do not copy Python `client.voice_agent.configurations.*` examples into C#.
-2. **Management and auth are separate clients.** Use `CreateManageClient()` for admin APIs and `CreateAuthClient()` for `GrantToken()`.
-3. **Destructive methods are real.** `DeleteProject`, `DeleteKey`, `DeleteInvite`, and `RemoveMember` should stay commented or guarded in examples/tests unless you mean it.
-4. **Bearer-token auth is supported.** `DeepgramHttpClientOptions` prefers explicit `accessToken` over `apiKey`, then env vars in that order.
-5. **Current examples often fetch a project ID first.** Many sub-resources are project-scoped.
+2. **Destructive methods are irreversible.** `DeleteProject`, `DeleteKey`, `DeleteInvite`, and `RemoveMember` should always use the verify-delete-verify pattern above.
+3. **Bearer-token auth is supported.** `DeepgramHttpClientOptions` prefers explicit `accessToken` over `apiKey`, then env vars in that order.
+4. **Most sub-resources are project-scoped.** Fetch a project ID first via `GetProjects()` before calling key/member/usage methods.
 
 ## Example files in this repo
 
@@ -142,12 +151,4 @@ Auth:
 - `examples/auth/grant-token/Program.cs`
 - `examples/auth/bearer-token-workflow/Program.cs`
 
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+Cross-language product knowledge (API reference, recipes, MCP setup): `npx skills add deepgram/skills`.

--- a/.agents/skills/deepgram-dotnet-speech-to-text/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-speech-to-text/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepgram-dotnet-speech-to-text
-description: Use when writing or reviewing C# code in this repo that calls Deepgram Speech-to-Text for prerecorded or live transcription. Covers `ClientFactory.CreateListenRESTClient()` with `TranscribeUrl` / `TranscribeFile`, and `ClientFactory.CreateListenWebSocketClient()` with `Connect`, `Subscribe`, and `Send`. Use `deepgram-dotnet-audio-intelligence` for summaries/sentiment/topics overlays, `deepgram-dotnet-conversational-stt` for Flux-specific work (not fully surfaced in this SDK), and `deepgram-dotnet-voice-agent` for full-duplex assistants.
+description: "Use when writing or reviewing C# code in this repo that calls Deepgram Speech-to-Text for prerecorded or live transcription. Covers `ClientFactory.CreateListenRESTClient()` with `TranscribeUrl` / `TranscribeFile`, and `ClientFactory.CreateListenWebSocketClient()` with `Connect`, `Subscribe`, and `Send`. Use `deepgram-dotnet-audio-intelligence` for summaries/sentiment/topics overlays, `deepgram-dotnet-conversational-stt` for Flux-specific work, and `deepgram-dotnet-voice-agent` for full-duplex assistants."
 ---
 
 # Using Deepgram Speech-to-Text (.NET SDK)
@@ -105,38 +105,31 @@ bool connected = await liveClient.Connect(new LiveSchema()
     VadEvents = true,
 });
 
-if (connected)
+if (!connected)
 {
-    var microphone = new Microphone(liveClient.Send);
-    microphone.Start();
-    Console.ReadKey();
-    microphone.Stop();
-    await liveClient.Stop();
+    Console.Error.WriteLine("WebSocket connection failed — check API key and network.");
+    return;
 }
+
+var microphone = new Microphone(liveClient.Send);
+microphone.Start();
+Console.ReadKey();
+microphone.Stop();
+await liveClient.Stop();
 ```
 
 ## Key params
 
-REST `PreRecordedSchema`: `Model`, `Language`, `Encoding`, `SampleRate`, `Punctuate`, `SmartFormat`, `Keywords`, `Keyterm`, `Utterances`, `Paragraphs`, `Numerals`, `MultiChannel`, `Replace`, `Search`, `Tag`, `Version`.
+REST `PreRecordedSchema`: `Model`, `Language`, `Encoding`, `SampleRate`, `Punctuate`, `SmartFormat`, `Keyterm`, `Utterances`, `Paragraphs`. Full list in `Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs`.
 
-WebSocket `LiveSchema`: `Model`, `Encoding`, `SampleRate`, `Channels`, `InterimResults`, `UtteranceEnd`, `VadEvents`, `Punctuate`, `SmartFormat`, `Endpointing`, `Keywords`, `Keyterm`, `NoDelay`.
+WebSocket `LiveSchema`: `Model`, `Encoding`, `SampleRate`, `InterimResults`, `UtteranceEnd`, `VadEvents`, `Endpointing`, `Keyterm`. Full list in `Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs`.
 
-## API reference (layered)
+## References
 
-1. **In-repo source of truth**:
-   - `Deepgram/ClientFactory.cs`
-   - `Deepgram/Clients/Listen/v1/REST/Client.cs`
-   - `Deepgram/Clients/Listen/v2/WebSocket/Client.cs`
-   - `Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs`
-   - `Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs`
-2. **Canonical OpenAPI (REST)**: https://developers.deepgram.com/openapi.yaml
-3. **Canonical AsyncAPI (streaming / WSS)**: https://developers.deepgram.com/asyncapi.yaml
-4. **Context7**:
-   - repo mirror: `https://context7.com/deepgram/deepgram-dotnet-sdk`
-   - docs corpus: `/llmstxt/developers_deepgram_llms_txt`
-5. **Product docs**:
-   - https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded
-   - https://developers.deepgram.com/reference/speech-to-text/listen-streaming
+- In-repo: `Deepgram/Clients/Listen/v1/REST/Client.cs`, `Deepgram/Clients/Listen/v2/WebSocket/Client.cs`
+- OpenAPI (REST): https://developers.deepgram.com/openapi.yaml
+- AsyncAPI (WSS): https://developers.deepgram.com/asyncapi.yaml
+- Product docs: https://developers.deepgram.com/reference/speech-to-text/listen-pre-recorded, https://developers.deepgram.com/reference/speech-to-text/listen-streaming
 
 ## Gotchas
 
@@ -157,12 +150,4 @@ WebSocket `LiveSchema`: `Model`, `Encoding`, `SampleRate`, `Channels`, `InterimR
 - `examples/speech-to-text/websocket/microphone/Program.cs`
 - `tests/edge_cases/stt_v1_client_example/`
 
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+Cross-language product knowledge (API reference, recipes, MCP setup): `npx skills add deepgram/skills`.

--- a/.agents/skills/deepgram-dotnet-text-to-speech/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-text-to-speech/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deepgram-dotnet-text-to-speech
-description: Use when writing or reviewing C# code in this repo that calls Deepgram Text-to-Speech. Covers `ClientFactory.CreateSpeakRESTClient()` with `ToStream` / `ToFile`, and `ClientFactory.CreateSpeakWebSocketClient()` with `Connect`, `SpeakWithText`, `Flush`, and streaming `AudioResponse` events. Use `deepgram-dotnet-voice-agent` for full-duplex assistants instead of one-way synthesis.
+description: "Use when writing or reviewing C# code in this repo that calls Deepgram Text-to-Speech. Covers `ClientFactory.CreateSpeakRESTClient()` with `ToStream` / `ToFile`, and `ClientFactory.CreateSpeakWebSocketClient()` with `Connect`, `SpeakWithText`, `Flush`, and streaming `AudioResponse` events. Use `deepgram-dotnet-voice-agent` for full-duplex assistants instead of one-way synthesis."
 ---
 
 # Using Deepgram Text-to-Speech (.NET SDK)
@@ -81,13 +81,16 @@ bool connected = await speakClient.Connect(new SpeakSchema()
     SampleRate = 48000,
 });
 
-if (connected)
+if (!connected)
 {
-    speakClient.SpeakWithText("Hello World!");
-    speakClient.Flush();
-    Console.ReadKey();
-    await speakClient.Stop();
+    Console.Error.WriteLine("WebSocket connection failed — check API key and network.");
+    return;
 }
+
+speakClient.SpeakWithText("Hello World!");
+speakClient.Flush();
+Console.ReadKey();
+await speakClient.Stop();
 ```
 
 ## Key params
@@ -98,23 +101,12 @@ WebSocket `SpeakSchema`: `Model`, `BitRate`, `Encoding`, `SampleRate`.
 
 Streaming controls: `SpeakWithText`, `Flush`, `Clear`, `Close`, `SendMessageImmediately`.
 
-## API reference (layered)
+## References
 
-1. **In-repo source of truth**:
-   - `Deepgram/ClientFactory.cs`
-   - `Deepgram/Clients/Speak/v1/REST/Client.cs`
-   - `Deepgram/Clients/Speak/v2/WebSocket/Client.cs`
-   - `Deepgram/Models/Speak/v1/REST/SpeakSchema.cs`
-   - `Deepgram/Models/Speak/v2/WebSocket/SpeakSchema.cs`
-2. **Canonical OpenAPI (REST)**: https://developers.deepgram.com/openapi.yaml
-3. **Canonical AsyncAPI (streaming / WSS)**: https://developers.deepgram.com/asyncapi.yaml
-4. **Context7**:
-   - repo mirror: `https://context7.com/deepgram/deepgram-dotnet-sdk`
-   - docs corpus: `/llmstxt/developers_deepgram_llms_txt`
-5. **Product docs**:
-   - https://developers.deepgram.com/reference/text-to-speech/speak-request
-   - https://developers.deepgram.com/reference/text-to-speech/speak-streaming
-   - https://developers.deepgram.com/docs/tts-models
+- In-repo: `Deepgram/Clients/Speak/v1/REST/Client.cs`, `Deepgram/Clients/Speak/v2/WebSocket/Client.cs`, `Deepgram/Models/Speak/v1/REST/SpeakSchema.cs`, `Deepgram/Models/Speak/v2/WebSocket/SpeakSchema.cs`
+- OpenAPI (REST): https://developers.deepgram.com/openapi.yaml
+- AsyncAPI (WSS): https://developers.deepgram.com/asyncapi.yaml
+- Product docs: https://developers.deepgram.com/reference/text-to-speech/speak-request, https://developers.deepgram.com/docs/tts-models
 
 ## Gotchas
 
@@ -133,12 +125,4 @@ Streaming controls: `SpeakWithText`, `Flush`, `Clear`, `Close`, `SendMessageImme
 - `examples/text-to-speech/websocket/simple/Program.cs`
 - `tests/edge_cases/tts_v1_client_example/`
 
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+Cross-language product knowledge (API reference, recipes, MCP setup): `npx skills add deepgram/skills`.

--- a/.agents/skills/deepgram-dotnet-voice-agent/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-voice-agent/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: deepgram-dotnet-voice-agent
-description: Use when writing or reviewing C# code in this repo that builds an interactive Deepgram Voice Agent over WebSocket. Covers `ClientFactory.CreateAgentWebSocketClient()`, `SettingsSchema`, event subscriptions, microphone audio streaming, injected user messages, and function-call-related message types. Use `deepgram-dotnet-text-to-speech` for one-way synthesis and STT skills for transcription-only flows.
+description: "Use when writing or reviewing C# code in this repo that builds an interactive Deepgram Voice Agent over WebSocket. Covers `ClientFactory.CreateAgentWebSocketClient()`, `SettingsSchema`, event subscriptions, microphone audio streaming, injected user messages, and function-call-related message types. Use `deepgram-dotnet-text-to-speech` for one-way synthesis and STT skills for transcription-only flows."
 ---
 
 # Using Deepgram Voice Agent (.NET SDK)
 
 Full-duplex voice agent sessions over a single WebSocket.
-
-## When to use this product
-
-- You want a live assistant that listens, thinks, and speaks.
-- You want Deepgram-managed orchestration for STT + LLM + TTS.
-- You may need injected user messages or function-call message handling.
 
 **Use a different skill when:**
 - One-way transcription → `deepgram-dotnet-speech-to-text` or `deepgram-dotnet-conversational-stt`.
@@ -27,16 +21,10 @@ dotnet add package Deepgram.Microphone   # only if you need local mic capture
 
 ```csharp
 using Deepgram;
-using Deepgram.Models.Authenticate.v1;
 
 Deepgram.Library.Initialize();
-
-var options = new DeepgramWsClientOptions(null, null, true);
-// Pass a real API key here (or use CreateAgentWebSocketClient() with the DEEPGRAM_API_KEY
-// env var set). An empty string is shown only to make the signature explicit; the
-// underlying DeepgramWsClientOptions throws if neither apiKey/accessToken nor the
-// DEEPGRAM_API_KEY/DEEPGRAM_ACCESS_TOKEN env var is available.
-var agentClient = ClientFactory.CreateAgentWebSocketClient(apiKey: "", options: options);
+// Uses DEEPGRAM_API_KEY env var; pass apiKey: "..." to override
+var agentClient = ClientFactory.CreateAgentWebSocketClient();
 ```
 
 ## Quick start
@@ -55,12 +43,9 @@ await agentClient.Subscribe(new EventHandler<AudioResponse>((sender, e) =>
 {
     if (e.Stream != null)
     {
-        // WebSocket audio frames are raw linear16 PCM, not a WAV container.
-        // Save as .raw, or write a WAV header first (see examples/agent/websocket/no_mic/Program.cs).
-        using (var writer = new BinaryWriter(File.Open("output.raw", FileMode.Append)))
-        {
-            writer.Write(e.Stream.ToArray());
-        }
+        // Raw linear16 PCM — see examples/agent/websocket/no_mic/Program.cs for WAV header.
+        using var writer = new BinaryWriter(File.Open("output.raw", FileMode.Append));
+        writer.Write(e.Stream.ToArray());
     }
 }));
 
@@ -78,10 +63,17 @@ settings.Audio.Output.Encoding = "linear16";
 settings.Audio.Output.SampleRate = 24000;
 
 bool connected = await agentClient.Connect(settings);
-if (connected)
+if (!connected)
 {
-    await agentClient.SendInjectUserMessage("Say hello in one sentence.");
+    Console.Error.WriteLine("Agent WebSocket connection failed — check API key and network.");
+    return;
 }
+
+await agentClient.SendInjectUserMessage("Say hello in one sentence.");
+
+// Cleanup when done
+Console.ReadKey();
+await agentClient.Stop();
 ```
 
 ## Streaming microphone audio
@@ -99,6 +91,11 @@ var microphone = new Microphone(
     format: SampleFormat.Int16);
 
 microphone.Start();
+
+// Cleanup
+Console.ReadKey();
+microphone.Stop();
+await agentClient.Stop();
 ```
 
 ## Key params and events
@@ -126,24 +123,11 @@ Send helpers:
 - `SendBinaryImmediately(...)`
 - `SendKeepAlive()`
 
-## API reference (layered)
+## References
 
-1. **In-repo source of truth**:
-   - `Deepgram/ClientFactory.cs`
-   - `Deepgram/Clients/Agent/v2/Websocket/Client.cs`
-   - `Deepgram/Clients/Interfaces/v2/IAgentWebSocketClient.cs`
-   - `Deepgram/Models/Agent/v2/WebSocket/*.cs`
-   - `Deepgram.Microphone/Microphone.cs`
-2. **Canonical OpenAPI (REST)**: not applicable for the runtime socket in this repo
-3. **Canonical AsyncAPI (WSS)**: https://developers.deepgram.com/asyncapi.yaml
-4. **Context7**:
-   - repo mirror: `https://context7.com/deepgram/deepgram-dotnet-sdk`
-   - docs corpus: `/llmstxt/developers_deepgram_llms_txt`
-5. **Product docs**:
-   - https://developers.deepgram.com/reference/voice-agent/voice-agent
-   - https://developers.deepgram.com/docs/voice-agent
-   - https://developers.deepgram.com/docs/configure-voice-agent
-   - https://developers.deepgram.com/docs/voice-agent-message-flow
+- In-repo: `Deepgram/Clients/Agent/v2/Websocket/Client.cs`, `Deepgram/Clients/Interfaces/v2/IAgentWebSocketClient.cs`, `Deepgram/Models/Agent/v2/WebSocket/*.cs`, `Deepgram.Microphone/Microphone.cs`
+- AsyncAPI (WSS): https://developers.deepgram.com/asyncapi.yaml
+- Product docs: https://developers.deepgram.com/docs/voice-agent, https://developers.deepgram.com/docs/voice-agent-message-flow
 
 ## Gotchas
 
@@ -160,12 +144,4 @@ Send helpers:
 - `examples/agent/websocket/no_mic/Program.cs`
 - `examples/agent/websocket/arbitrary_keys/Program.cs`
 
-## Central product skills
-
-For cross-language Deepgram product knowledge — the consolidated API reference, documentation finder, focused runnable recipes, third-party integration examples, and MCP setup — install the central skills:
-
-```bash
-npx skills add deepgram/skills
-```
-
-This SDK ships language-idiomatic code skills; `deepgram/skills` ships cross-language product knowledge (see `api`, `docs`, `recipes`, `examples`, `starters`, `setup-mcp`).
+Cross-language product knowledge (API reference, recipes, MCP setup): `npx skills add deepgram/skills`.


### PR DESCRIPTION
Hey @deepgram 👋

I ran your skills through `tessl skill review` at work and found targeted improvements in your skills. Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| deepgram-dotnet-management-api | 89% | 100% | +11% |
| deepgram-dotnet-speech-to-text | 89% | 100% | +11% |
| deepgram-dotnet-conversational-stt | 76% | 95% | +19% |
| deepgram-dotnet-text-to-speech | 86% | 95% | +9% |
| deepgram-dotnet-voice-agent | 89% | 95% | +6% |

These were easy changes to bring the skill's structure and activation in line with what performs well against Anthropic's best practices. Added error handling, reconnection logic, cleanup/shutdown steps, condensed verbose sections.

In addition, I stress-tested your [`deepgram-dotnet-conversational-stt` skill against a few real-world scenarios](https://tessl.io/registry/skills/github/deepgram/deepgram-dotnet-sdk/deepgram-dotnet-conversational-stt/evals), and it held up really well. This means that your skill meaningfully improves agent steering and contributes to stronger output quality. Kudos for that!

Honest disclosure, I work at @tesslio where we build tooling around skills like these. Not a pitch, just saw room for improvement and wanted to contribute.

If you want to self-improve your skills, or define your own scenarios to pressure test, just ask your agent (Claude Code, Codex, etc.) to evaluate and optimize your skill with Tessl. Ping me [@rohan-tessl](https://github.com/rohan-tessl), if you hit any snags.