### PR TITLE
Fix SpeechStartedResponse.Channel mapped property

### DIFF
--- a/Deepgram/Models/Listen/v1/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/SpeechStartedResponse.cs
@@ -18,7 +18,7 @@ public record SpeechStartedResponse
     /// Channel index information
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("channel_index")]
+	[JsonPropertyName("channel")]
     public int[]? Channel { get; set; }
 
     /// <summary>

--- a/Deepgram/Models/Listen/v1/WebSocket/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/UtteranceEndResponse.cs
@@ -18,7 +18,7 @@ public record UtteranceEndResponse
     /// Channel index information
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("channel_index")]
+	[JsonPropertyName("channel")]
     public int[]? Channel { get; set; }
 
     /// <summary>

--- a/Deepgram/Models/Listen/v2/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/SpeechStartedResponse.cs
@@ -18,7 +18,7 @@ public record SpeechStartedResponse
     /// Channel index information
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("channel_index")]
+	[JsonPropertyName("channel")]
     public int[]? Channel { get; set; }
 
     /// <summary>

--- a/Deepgram/Models/Listen/v2/WebSocket/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/UtteranceEndResponse.cs
@@ -18,7 +18,7 @@ public record UtteranceEndResponse
     /// Channel index information
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-	[JsonPropertyName("channel_index")]
+	[JsonPropertyName("channel")]
     public int[]? Channel { get; set; }
 
     /// <summary>


### PR DESCRIPTION
## Proposed changes

The `SpeechStartedResponse` class is intended to represent the ListenV1SpeechStarted type from the [listen WebSocket endpoint](https://developers.deepgram.com/reference/speech-to-text/listen-streaming).

`SpeechStartedResponse.Channel` defines a JSON mapping of `[JsonPropertyName("channel_index")]`, but this is incorrect as the documentation defines this property as `channel` and data returned from the actual API aligns with the documentation.

This PR simply corrects the mapped JSON so that the `Channel` property is populated correctly.

## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
  - N/A there are no existing model serialization tests to update
- [ ] I have added necessary documentation (if appropriate)
  - N/A this change updates the code to match the existing documentation


