### PR TITLE
Reduce memory allocations in Listen happy path

### DIFF
--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -33,9 +33,12 @@ public abstract class AbstractWebSocketClient : IDisposable
         options ??= new DeepgramWsClientOptions(apiKey);
         _deepgramClientOptions = options;
 
-        Log.Debug("AbstractWebSocketClient", $"APIVersion: {options.APIVersion}");
-        Log.Debug("AbstractWebSocketClient", $"BaseAddress: {options.BaseAddress}");
-        Log.Debug("AbstractWebSocketClient", $"OnPrem: {options.OnPrem}");
+        if (Log.IsEnabled(LogLevel.Debug))
+        {
+            Log.Debug("AbstractWebSocketClient", $"APIVersion: {options.APIVersion}");
+            Log.Debug("AbstractWebSocketClient", $"BaseAddress: {options.BaseAddress}");
+            Log.Debug("AbstractWebSocketClient", $"OnPrem: {options.OnPrem}");
+        }
         Log.Verbose("AbstractWebSocketClient", "LEAVE");
     }
 
@@ -57,7 +60,10 @@ public abstract class AbstractWebSocketClient : IDisposable
     public async Task<bool> Connect(string uri, CancellationTokenSource? cancelToken = null, Dictionary<string, string>? headers = null)
     {
         Log.Verbose("AbstractWebSocketClient.Connect", "ENTER");
-        Log.Debug("Connect", $"headers: {headers}");
+        if (Log.IsEnabled(LogLevel.Debug))
+        {
+            Log.Debug("Connect", $"headers: {headers}");
+        }
 
         // check if the client is disposed
         if (_clientWebSocket != null)
@@ -112,9 +118,13 @@ public abstract class AbstractWebSocketClient : IDisposable
         try
         {
             var myUri = new Uri(uri);
-            Log.Debug("Connect", $"uri: {uri}");
 
-            Log.Debug("Connect", "Connecting to Deepgram API...");
+            if (Log.IsEnabled(LogLevel.Debug))
+            {
+                Log.Debug("Connect", $"uri: {uri}");
+
+                Log.Debug("Connect", "Connecting to Deepgram API...");
+            }
             await _clientWebSocket.ConnectAsync(myUri, cancelToken.Token).ConfigureAwait(false);
 
             if (!IsConnected())
@@ -443,7 +453,10 @@ public abstract class AbstractWebSocketClient : IDisposable
 
                     if (result.MessageType != WebSocketMessageType.Close)
                     {
-                        Log.Verbose("ProcessReceiveQueue", $"Received message: {result} / {ms}");
+                        if (Log.IsEnabled(LogLevel.Verbose))
+                        {
+                            Log.Verbose("ProcessReceiveQueue", $"Received message: {result} / {ms}");
+                        }
                         ProcessDataReceived(result, ms);
                     }
                 }
@@ -508,11 +521,17 @@ public abstract class AbstractWebSocketClient : IDisposable
 
         try
         {
-            Log.Verbose("ProcessTextMessage", $"raw response: {response}");
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessTextMessage", $"raw response: {response}");
+            }
             var data = JsonDocument.Parse(response);
             var val = Enum.Parse(typeof(WebSocketType), data.RootElement.GetProperty("type").GetString()!);
 
-            Log.Verbose("ProcessTextMessage", $"Type: {val}");
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessTextMessage", $"Type: {val}");
+            }
 
             switch (val)
             {
@@ -531,7 +550,10 @@ public abstract class AbstractWebSocketClient : IDisposable
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking OpenResponse. event: {openResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking OpenResponse. event: {openResponse}");
+                    }
                     InvokeParallel(_openReceived, openResponse);
                     break;
                 case WebSocketType.Error:
@@ -549,7 +571,10 @@ public abstract class AbstractWebSocketClient : IDisposable
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking ErrorResponse. event: {errorResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking ErrorResponse. event: {errorResponse}");
+                    }
                     InvokeParallel(_errorReceived, errorResponse);
                     break;
                 default:
@@ -564,7 +589,10 @@ public abstract class AbstractWebSocketClient : IDisposable
                     unhandledResponse.Type = WebSocketType.Unhandled;
                     unhandledResponse.Raw = response;
 
-                    Log.Debug("ProcessTextMessage", $"Invoking UnhandledResponse. event: {unhandledResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking UnhandledResponse. event: {unhandledResponse}");
+                    }
                     InvokeParallel(_unhandledReceived, unhandledResponse);
                     break;
             }
@@ -682,7 +710,10 @@ public abstract class AbstractWebSocketClient : IDisposable
         {
             return WebSocketState.None;
         }
-        Log.Debug("State", $"WebSocket State: {_clientWebSocket.State}");
+        if (Log.IsEnabled(LogLevel.Debug))
+        {
+            Log.Debug("State", $"WebSocket State: {_clientWebSocket.State}");
+        }
         return _clientWebSocket.State;
     }
 
@@ -697,7 +728,10 @@ public abstract class AbstractWebSocketClient : IDisposable
             return false;
         }
 
-        Log.Debug("State", $"WebSocket State: {_clientWebSocket.State}");
+        if (Log.IsEnabled(LogLevel.Debug))
+        {
+            Log.Debug("State", $"WebSocket State: {_clientWebSocket.State}");
+        }
         return _clientWebSocket.State == WebSocketState.Open;
     }
 

--- a/Deepgram/Clients/Listen/v1/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v1/WebSocket/Client.cs
@@ -540,7 +540,10 @@ public class Client : IDisposable, IListenWebSocketClient
                     var deltaTicks = DateTime.Now - _lastReceived;
                     if (deltaTicks < diffTicks)
                     {
-                        Log.Debug("ProcessAutoFlush", $"AutoFlush delta is less than threshold: {deltaTicks}. Skipping...");
+                        if (Log.IsEnabled(LogLevel.Debug))
+                        {
+                            Log.Debug("ProcessAutoFlush", $"AutoFlush delta is less than threshold: {deltaTicks}. Skipping...");
+                        }
                         continue;
                     }
 
@@ -652,12 +655,17 @@ public class Client : IDisposable, IListenWebSocketClient
 
         try
         {
-            Log.Verbose("ProcessDataReceived", $"raw response: {response}");
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessDataReceived", $"raw response: {response}");
+            }
             var data = JsonDocument.Parse(response);
             var val = Enum.Parse(typeof(ListenType), data.RootElement.GetProperty("type").GetString()!);
 
-            Log.Verbose("ProcessDataReceived", $"Type: {val}");
-
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessDataReceived", $"Type: {val}");
+            }
 
             if (_deepgramClientOptions.InspectListenMessage())
             {
@@ -682,7 +690,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking OpenResponse. event: {openResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking OpenResponse. event: {openResponse}");
+                    }
                     InvokeParallel(_openReceived, openResponse);
                     break;
                 case ListenType.Results:
@@ -700,7 +711,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking ResultsResponse. event: {resultResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking ResultsResponse. event: {resultResponse}");
+                    }
                     InvokeParallel(_resultsReceived, resultResponse);
                     break;
                 case ListenType.Metadata:
@@ -718,7 +732,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking MetadataResponse. event: {metadataResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking MetadataResponse. event: {metadataResponse}");
+                    }
                     InvokeParallel(_metadataReceived, metadataResponse);
                     break;
                 case ListenType.UtteranceEnd:
@@ -736,7 +753,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking UtteranceEndResponse. event: {utteranceEndResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking UtteranceEndResponse. event: {utteranceEndResponse}");
+                    }
                     InvokeParallel(_utteranceEndReceived, utteranceEndResponse);
                     break;
                 case ListenType.SpeechStarted:
@@ -754,7 +774,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking SpeechStartedResponse. event: {speechStartedResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking SpeechStartedResponse. event: {speechStartedResponse}");
+                    }
                     InvokeParallel(_speechStartedReceived, speechStartedResponse);
                     break;
                 case ListenType.Close:
@@ -772,7 +795,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking CloseResponse. event: {closeResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking CloseResponse. event: {closeResponse}");
+                    }
                     InvokeParallel(_closeReceived, closeResponse);
                     break;
                 case ListenType.Error:
@@ -790,7 +816,10 @@ public class Client : IDisposable, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessDataReceived", $"Invoking ErrorResponse. event: {errorResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking ErrorResponse. event: {errorResponse}");
+                    }
                     InvokeParallel(_errorReceived, errorResponse);
                     break;
                 default:
@@ -805,7 +834,10 @@ public class Client : IDisposable, IListenWebSocketClient
                     unhandledResponse.Type = ListenType.Unhandled;
                     unhandledResponse.Raw = response;
 
-                    Log.Debug("ProcessDataReceived", $"Invoking UnhandledResponse. event: {unhandledResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessDataReceived", $"Invoking UnhandledResponse. event: {unhandledResponse}");
+                    }
                     InvokeParallel(_unhandledReceived, unhandledResponse);
                     break;
             }

--- a/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
@@ -466,11 +466,17 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
 
         try
         {
-            Log.Verbose("ProcessTextMessage", $"raw response: {response}");
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessTextMessage", $"raw response: {response}");
+            }
             var data = JsonDocument.Parse(response);
             var val = Enum.Parse(typeof(ListenType), data.RootElement.GetProperty("type").GetString()!);
 
-            Log.Verbose("ProcessTextMessage", $"Type: {val}");
+            if (Log.IsEnabled(LogLevel.Verbose))
+            {
+                Log.Verbose("ProcessTextMessage", $"Type: {val}");
+            }
 
 
             if (_deepgramClientOptions.InspectListenMessage())
@@ -502,7 +508,10 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking ResultsResponse. event: {resultResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking ResultsResponse. event: {resultResponse}");
+                    }
                     InvokeParallel(_resultsReceived, resultResponse);
                     break;
                 case ListenType.Metadata:
@@ -520,7 +529,10 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking MetadataResponse. event: {metadataResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking MetadataResponse. event: {metadataResponse}");
+                    }
                     InvokeParallel(_metadataReceived, metadataResponse);
                     break;
                 case ListenType.UtteranceEnd:
@@ -538,7 +550,10 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking UtteranceEndResponse. event: {utteranceEndResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking UtteranceEndResponse. event: {utteranceEndResponse}");
+                    }
                     InvokeParallel(_utteranceEndReceived, utteranceEndResponse);
                     break;
                 case ListenType.SpeechStarted:
@@ -556,7 +571,10 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
                         return;
                     }
 
-                    Log.Debug("ProcessTextMessage", $"Invoking SpeechStartedResponse. event: {speechStartedResponse}");
+                    if (Log.IsEnabled(LogLevel.Debug))
+                    {
+                        Log.Debug("ProcessTextMessage", $"Invoking SpeechStartedResponse. event: {speechStartedResponse}");
+                    }
                     InvokeParallel(_speechStartedReceived, speechStartedResponse);
                     break;
                 default:

--- a/Deepgram/Logger/Log.cs
+++ b/Deepgram/Logger/Log.cs
@@ -58,6 +58,23 @@ public sealed class Log
     }
 
     /// <summary>
+    /// Returns whether a specific log level has been enabled
+    /// </summary>
+    public static bool IsEnabled(LogLevel level)
+    {
+         if (level == LogLevel.Disable)
+        {
+            // There is no equivalent of Disable
+            return false;
+        }
+
+        // This is safe because the values are directly referenced in LogLevel
+        LogEventLevel serilogLevel = (LogEventLevel)level;
+
+        return GetLogger().IsEnabled(serilogLevel);
+    }
+
+    /// <summary>
     /// Gets the logger instance
     /// </summary>
     public static Serilog.ILogger GetLogger()
@@ -74,6 +91,11 @@ public sealed class Log
     /// </summary>
     public static void Verbose(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Verbose))
+        {
+            return;
+        }
+
         GetLogger().Verbose($"{identifier}: {trace}");
     }
 
@@ -82,6 +104,11 @@ public sealed class Log
     /// </summary>
     public static void Debug(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Debug))
+        {
+            return;
+        }
+
         GetLogger().Debug($"{identifier}: {trace}");
     }
 
@@ -90,6 +117,11 @@ public sealed class Log
     /// </summary>
     public static void Information(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
         GetLogger().Information($"{identifier}: {trace}");
     }
 
@@ -98,6 +130,11 @@ public sealed class Log
     /// </summary>
     public static void Warning(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Warning))
+        {
+            return;
+        }
+
         GetLogger().Warning($"{identifier}: {trace}");
     }
 
@@ -106,6 +143,11 @@ public sealed class Log
     /// </summary>
     public static void Error(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Error))
+        {
+            return;
+        }
+
         GetLogger().Error($"{identifier}: {trace}");
     }
 
@@ -114,6 +156,11 @@ public sealed class Log
     /// </summary>
     public static void Fatal(string identifier, string trace)
     {
+        if (!IsEnabled(LogLevel.Fatal))
+        {
+            return;
+        }
+
         GetLogger().Fatal($"{identifier}: {trace}");
     }
 }


### PR DESCRIPTION
## Proposed changes

The library's internal logging facade was not designed to defer string interpolation, so strings are often interpolated by the caller even if that log level is not enabled. In a long-lived server environment, especially when Listen/WebSockets are in use, this leads to unnecessary pressure on the garbage collector.

This PR wraps the offending calls to Log in an `IsEnabled` condition so that they don't run unless necessary.

I've limited the changes to the Listen "happy path" since that will involve a lot of messages back and forth, but I've left the exception blocks alone.

## Types of changes

What types of changes does your code introduce to the community .NET SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
