### PR TITLE
feat: add diarize_model option to pre-recorded transcription

### DIFF
--- a/.agents/skills/deepgram-dotnet-audio-intelligence/SKILL.md
+++ b/.agents/skills/deepgram-dotnet-audio-intelligence/SKILL.md
@@ -96,7 +96,7 @@ await liveClient.Connect(new LiveSchema()
 
 ## Key params
 
-REST (`PreRecordedSchema`): `Summarize`, `Topics`, `Intents`, `Sentiment`, `DetectLanguage`, `DetectEntities`, `CustomTopic`, `CustomTopicMode`, `CustomIntent`, `CustomIntentMode`, `Diarize`, `DiarizeVersion`, `Redact`, `Utterances`, plus the regular STT knobs.
+REST (`PreRecordedSchema`): `Summarize`, `Topics`, `Intents`, `Sentiment`, `DetectLanguage`, `DetectEntities`, `CustomTopic`, `CustomTopicMode`, `CustomIntent`, `CustomIntentMode`, `Diarize`, `DiarizeVersion`, `DiarizeModel`, `Redact`, `Utterances`, plus the regular STT knobs.
 
 Live (`LiveSchema`): `Diarize`, `Redact`, `UtteranceEnd`, `VadEvents`, `Punctuate`, `SmartFormat`, plus normal streaming STT settings.
 

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -182,4 +182,33 @@ public class QueryParameterUtilTests
         result.Should().Be($"https://{Defaults.DEFAULT_URI}");
     }
 
+    [Test]
+    public void GetParameters_Should_Return_String_When_Passing_DiarizeModel_Parameter()
+    {
+        // Input and Output - DiarizeModel surfaces Batch Diarization v2 (enum: latest, v1, v2)
+        var obj = new Deepgram.Models.Listen.v1.REST.PreRecordedSchema() { DiarizeModel = "v2" };
+        var expected = "diarize_model=v2";
+
+        //Act
+        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, obj);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Should().Contain(expected);
+    }
+
+    [Test]
+    public void GetParameters_Should_Omit_DiarizeModel_When_Not_Set()
+    {
+        // Input and Output - additive/non-breaking: absent unless explicitly set
+        var obj = new Deepgram.Models.Listen.v1.REST.PreRecordedSchema() { Model = "nova-2" };
+
+        //Act
+        var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, obj);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.Should().NotContain("diarize_model");
+    }
+
 }

--- a/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
+++ b/Deepgram.Tests/UnitTests/UtilitiesTests/QueryParameterUtilTests.cs
@@ -182,12 +182,15 @@ public class QueryParameterUtilTests
         result.Should().Be($"https://{Defaults.DEFAULT_URI}");
     }
 
-    [Test]
-    public void GetParameters_Should_Return_String_When_Passing_DiarizeModel_Parameter()
+    // DiarizeModel surfaces Batch Diarization v2; the API spec enum is latest, v1, v2.
+    [TestCase("v2")]
+    [TestCase("v1")]
+    [TestCase("latest")]
+    public void GetParameters_Should_Return_String_When_Passing_DiarizeModel_Parameter(string diarizeModel)
     {
-        // Input and Output - DiarizeModel surfaces Batch Diarization v2 (enum: latest, v1, v2)
-        var obj = new Deepgram.Models.Listen.v1.REST.PreRecordedSchema() { DiarizeModel = "v2" };
-        var expected = "diarize_model=v2";
+        // Input and Output
+        var obj = new Deepgram.Models.Listen.v1.REST.PreRecordedSchema() { DiarizeModel = diarizeModel };
+        var expected = $"diarize_model={diarizeModel}";
 
         //Act
         var result = QueryParameterUtil.FormatURL(Defaults.DEFAULT_URI, obj);

--- a/Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs
+++ b/Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs
@@ -91,6 +91,17 @@ public class PreRecordedSchema
 	[JsonPropertyName("diarize")]
     public bool? Diarize { get; set; }
 
+    /// <summary>
+    /// Select and enable a specific batch diarization model version, e.g. "latest", "v1", or "v2".
+    /// Supersedes the deprecated <see cref="Diarize"/> boolean; if set, do not also set Diarize.
+    /// Batch/pre-recorded only - not accepted on streaming requests.
+    /// <see href="https://developers.deepgram.com/docs/diarization">
+    /// default is null
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+	[JsonPropertyName("diarize_model")]
+    public string? DiarizeModel { get; set; }
+
     // <summary>
     /// <see href="https://developers.deepgram.com/docs/diarization">
     /// default is null, only applies if Diarize is set to true

--- a/Deepgram/README.md
+++ b/Deepgram/README.md
@@ -293,6 +293,7 @@ also see [TranscribeSchema] which LiveSchema is derived from for more options
 | Callback               | string?                   | Callback URL to provide if you would like your submitted audio to be processed asynchronously                          |
 | Diarize                | bool?                     | Indicates whether to recognize speaker changes                                                                         |
 | DiarizeVersion         | string?                   |                                                                                                                        |
+| DiarizeModel           | string?                   | Batch diarization model version to use (latest, v1, v2). Supersedes the deprecated Diarize boolean                     |
 | Extra                  | Dictonary<string,string>? |  additonal values you want echoing bac                                                                                 |                                                                                                                        |
 | FillerWords            | int?                      | Whether to include words like "uh" and "um" in transcription output.                                                   |
 | Keywords               | List<string>?             | Keywords to which the model should pay particular attention to boosting or suppressing to help it understand context   |


### PR DESCRIPTION
## What changed
- Added `string? DiarizeModel` to the canonical `PreRecordedSchema` (`Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs`), with `[JsonPropertyName("diarize_model")]` + `[JsonIgnore(WhenWritingNull)]`, so it serializes to the `diarize_model` query param on `POST /v1/listen`. Accepts `latest` / `v1` / `v2` (typed as `string` to mirror existing `model`/`diarize_version` properties and stay forward-compatible). The deprecated `PreRecorded.v1.PreRecordedSchema` subclass inherits it automatically.
- Added unit tests asserting `diarize_model=v2` appears in the outgoing query string and is omitted when unset. `dotnet build` 0 errors; full unit suite 165/165 on .NET 8.

## Why
The playground needs to surface Diarization v2, and .NET is a playground-supported SDK whose spec-driven regen isn't ready yet. This hand-written change bridges the gap; the regenerated SDK will pick up `diarize_model` natively later.

## Non-breaking
Additive only. The deprecated `diarize` boolean is untouched and the property is omitted when null. Batch-only: intentionally not added to the streaming `LiveSchema`, since the API rejects `diarize_model` on streaming requests.