### PR TITLE
fix(websocket): payload JSON corruption (#355/#393), Agent unknown-message crash (#395), and teardown-race NREs (#390)

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/AgentUnknownMessageTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/AgentUnknownMessageTests.cs
@@ -1,0 +1,83 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Bogus;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using System.Net.WebSockets;
+using System.Text;
+using Deepgram.Models.Authenticate.v1;
+using Deepgram.Clients.Agent.v2.WebSocket;
+using Deepgram.Models.Common.v2.WebSocket;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+/// <summary>
+/// Regression tests for #395: the Agent client parsed the message "type" with Enum.Parse, which
+/// threw ArgumentException for any message type unknown to this SDK version (e.g. the server's
+/// "History" and "Warning" messages). The client must instead route unknown types to the Unhandled
+/// event without throwing, keeping it forward-compatible with new server message types.
+/// </summary>
+public class AgentUnknownMessageTests
+{
+    private DeepgramWsClientOptions _options = null!;
+    private string _apiKey = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _apiKey = new Faker().Random.Guid().ToString();
+        _options = new DeepgramWsClientOptions(_apiKey) { OnPrem = true };
+    }
+
+    private static void FeedTextMessage(Client client, string json)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        using var ms = new MemoryStream(bytes);
+        var result = new WebSocketReceiveResult(bytes.Length, WebSocketMessageType.Text, true);
+        client.ProcessTextMessage(result, ms);
+    }
+
+    [TestCase("Warning")]
+    [TestCase("History")]
+    public async Task ProcessTextMessage_With_Unknown_Type_Should_Not_Throw_And_Surface_As_Unhandled(string unknownType)
+    {
+        var client = new Client(_apiKey, _options);
+
+        UnhandledResponse? unhandled = null;
+        await client.Subscribe(new EventHandler<UnhandledResponse>((_, e) => unhandled = e));
+
+        var json = $"{{\"type\":\"{unknownType}\",\"description\":\"something new from the server\"}}";
+
+        using (new AssertionScope())
+        {
+            // Before the fix this threw ArgumentException ("Requested value 'Warning' was not found.")
+            Action act = () => FeedTextMessage(client, json);
+            act.Should().NotThrow($"unknown Agent message type '{unknownType}' must not crash the receive loop");
+
+            // InvokeParallel dispatches synchronously (Parallel.ForEach), so the handler has already run.
+            unhandled.Should().NotBeNull($"unknown type '{unknownType}' must be surfaced via the Unhandled event");
+            unhandled!.Type.Should().Be(WebSocketType.Unhandled);
+            unhandled.Raw.Should().Contain(unknownType, "the raw payload must be preserved for the caller to inspect");
+        }
+    }
+
+    [Test]
+    public async Task ProcessTextMessage_With_Known_Type_Should_Still_Dispatch()
+    {
+        var client = new Client(_apiKey, _options);
+
+        Deepgram.Models.Agent.v2.WebSocket.WelcomeResponse? welcome = null;
+        await client.Subscribe(new EventHandler<Deepgram.Models.Agent.v2.WebSocket.WelcomeResponse>((_, e) => welcome = e));
+
+        var json = "{\"type\":\"Welcome\",\"request_id\":\"abc-123\"}";
+
+        using (new AssertionScope())
+        {
+            Action act = () => FeedTextMessage(client, json);
+            act.Should().NotThrow();
+            welcome.Should().NotBeNull("a known type must still be routed to its typed event after the TryParse change");
+        }
+    }
+}

--- a/Deepgram.Tests/UnitTests/ClientTests/SpeakLiveIntegrationTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/SpeakLiveIntegrationTests.cs
@@ -115,4 +115,50 @@ public class SpeakLiveIntegrationTests
                 $"iteration {i}: concurrent Stop()/Dispose() must not race on the token source (#390)");
         }
     }
+
+    [Test]
+    public async Task Live_Speak_WebSocket_Concurrent_Stop_NullByte_And_Dispose_Do_Not_Throw()
+    {
+        // End-to-end guard for the SendClose(nullByte:true) fast-path missed by the initial #390
+        // hardening. Stop(nullByte:true) routes through SendClose(true), which sends a raw null byte
+        // outside the base SendMessageImmediately helper; before the fix it dereferenced
+        // _clientWebSocket and _cancellationTokenSource.Token AFTER awaiting _mutexSend, so a
+        // concurrent Dispose() nulling those fields threw NullReferenceException. An NRE is not in
+        // Stop()'s benign catch set, so it escaped Stop(); the fix makes SendClose teardown-safe so
+        // any surviving exception is a benign cancellation that Stop() already absorbs.
+        var apiKey = ResolveApiKey();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Ignore("DEEPGRAM_API_KEY is not set. Skipping live Speak null-byte teardown-race test.");
+        }
+
+        for (var i = 0; i < 5; i++)
+        {
+            var client = ClientFactory.CreateSpeakWebSocketClient(apiKey!);
+
+            var connected = await client.Connect(new SpeakSchema
+            {
+                Model = "aura-2-thalia-en",
+                Encoding = "linear16",
+                SampleRate = 24000,
+            });
+            connected.Should().BeTrue();
+
+            client.SpeakWithText("Concurrent null-byte close test.");
+            client.Flush();
+
+            using var gate = new ManualResetEventSlim(false);
+            var teardowns = new List<Task>
+            {
+                Task.Run(() => { gate.Wait(); return client.Stop(nullByte: true); }),
+                Task.Run(() => { gate.Wait(); return client.Stop(nullByte: true); }),
+                Task.Run(() => { gate.Wait(); ((IDisposable)client).Dispose(); }),
+            };
+            gate.Set();
+
+            Func<Task> act = () => Task.WhenAll(teardowns);
+            await act.Should().NotThrowAsync(
+                $"iteration {i}: concurrent Stop(nullByte:true)/Dispose() must not NRE on the null-byte fast-path (#390)");
+        }
+    }
 }

--- a/Deepgram.Tests/UnitTests/ClientTests/SpeakLiveIntegrationTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/SpeakLiveIntegrationTests.cs
@@ -1,0 +1,118 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Deepgram.Models.Speak.v2.WebSocket;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+/// <summary>
+/// End-to-end test against the real Speak (TTS) websocket endpoint, proving the #355 fix: text
+/// containing quotation marks and backslashes must be sent as valid JSON so the server keeps the
+/// socket open and returns audio. Before the fix, Regex.Unescape corrupted the payload and the
+/// server closed the connection. Skipped unless DEEPGRAM_API_KEY is set, so CI never touches the network.
+/// </summary>
+public class SpeakLiveIntegrationTests
+{
+    private static string? ResolveApiKey()
+    {
+        return GlobalTestEnvironment.DeepgramApiKeyAtStartup
+            ?? Environment.GetEnvironmentVariable("DEEPGRAM_API_KEY");
+    }
+
+    [Test]
+    public async Task Live_Speak_WebSocket_With_Quoted_Text_Stays_Open_And_Returns_Audio()
+    {
+        var apiKey = ResolveApiKey();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Ignore("DEEPGRAM_API_KEY is not set. Skipping live Speak websocket test.");
+        }
+
+        var client = ClientFactory.CreateSpeakWebSocketClient(apiKey!);
+
+        var audioBytes = 0L;
+        var flushed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var closeReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var errors = new List<ErrorResponse>();
+
+        await client.Subscribe(new EventHandler<AudioResponse>((_, e) =>
+        {
+            if (e.Stream is not null)
+            {
+                Interlocked.Add(ref audioBytes, e.Stream.Length);
+            }
+        }));
+        await client.Subscribe(new EventHandler<FlushedResponse>((_, _) => flushed.TrySetResult(true)));
+        await client.Subscribe(new EventHandler<ErrorResponse>((_, e) => { lock (errors) { errors.Add(e); } }));
+        await client.Subscribe(new EventHandler<CloseResponse>((_, _) => closeReceived.TrySetResult(true)));
+
+        var connected = await client.Connect(new SpeakSchema
+        {
+            Model = "aura-2-thalia-en",
+            Encoding = "linear16",
+            SampleRate = 24000,
+        });
+        connected.Should().BeTrue("the client must connect to the live Speak endpoint");
+
+        // The crux of #355: quotes and backslashes in the text must not corrupt the wire payload.
+        client.SpeakWithText("She said \"hello\" to the CEO & left. Path: C:\\temp\\notes.");
+        client.Flush();
+
+        var flushedInTime = await Task.WhenAny(flushed.Task, Task.Delay(30000)) == flushed.Task;
+
+        await client.Stop();
+
+        using (new AssertionScope())
+        {
+            flushedInTime.Should().BeTrue("the server must acknowledge the flushed text instead of closing the socket");
+            audioBytes.Should().BeGreaterThan(0, "quoted/escaped text must still synthesize audio");
+            errors.Should().BeEmpty("no error should be raised for text containing quotes or backslashes");
+        }
+    }
+
+    [Test]
+    public async Task Live_Speak_WebSocket_Concurrent_Stop_And_Dispose_Do_Not_Throw()
+    {
+        // End-to-end guard for #390: on a real connection, a user Stop() overlapping the receive
+        // loop's server-close teardown (and an overlapping Dispose()) must not surface a
+        // NullReferenceException/ObjectDisposedException from the shared cancellation token source.
+        var apiKey = ResolveApiKey();
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            Assert.Ignore("DEEPGRAM_API_KEY is not set. Skipping live Speak teardown-race test.");
+        }
+
+        // Several connect/teardown cycles, each tearing down from multiple threads at once.
+        for (var i = 0; i < 5; i++)
+        {
+            var client = ClientFactory.CreateSpeakWebSocketClient(apiKey!);
+
+            var connected = await client.Connect(new SpeakSchema
+            {
+                Model = "aura-2-thalia-en",
+                Encoding = "linear16",
+                SampleRate = 24000,
+            });
+            connected.Should().BeTrue();
+
+            client.SpeakWithText("Concurrent teardown test.");
+            client.Flush();
+
+            using var gate = new ManualResetEventSlim(false);
+            var teardowns = new List<Task>
+            {
+                Task.Run(() => { gate.Wait(); return client.Stop(); }),
+                Task.Run(() => { gate.Wait(); return client.Stop(); }),
+                Task.Run(() => { gate.Wait(); ((IDisposable)client).Dispose(); }),
+            };
+            gate.Set();
+
+            Func<Task> act = () => Task.WhenAll(teardowns);
+            await act.Should().NotThrowAsync(
+                $"iteration {i}: concurrent Stop()/Dispose() must not race on the token source (#390)");
+        }
+    }
+}

--- a/Deepgram.Tests/UnitTests/ClientTests/WebSocketSerializationTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/WebSocketSerializationTests.cs
@@ -1,0 +1,100 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using FluentAssertions;
+using FluentAssertions.Execution;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using SpeakTextSourceV1 = Deepgram.Models.Speak.v1.WebSocket.TextSource;
+using SpeakTextSourceV2 = Deepgram.Models.Speak.v2.WebSocket.TextSource;
+using Deepgram.Models.Agent.v2.WebSocket;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+/// <summary>
+/// Regression tests for the payload-serialization bugs where model ToString() wrapped
+/// JsonSerializer.Serialize(...) in Regex.Unescape(...). That corrupted any payload whose
+/// text contained quotation marks or backslashes, producing invalid JSON on the wire and
+/// causing the server to close the socket (#355) or the client to throw while parsing its
+/// own settings (#393). ToString() must now always emit valid, round-trippable JSON.
+/// </summary>
+public class WebSocketSerializationTests
+{
+    // Text that previously broke the wire payload: embedded quotes, backslashes, unicode, '+', '&'.
+    private const string NastyText = "She said \"hello\" to the CEO & left. Path: C:\\temp\\file. 1+1=2. café ☕";
+
+    [Test]
+    public void SpeakV1_TextSource_ToString_Should_Be_Valid_Json_And_RoundTrip()
+    {
+        var source = new SpeakTextSourceV1(NastyText);
+
+        var json = source.ToString();
+
+        using (new AssertionScope())
+        {
+            // The bug produced invalid JSON here; Parse would throw.
+            Action parse = () => JsonDocument.Parse(json);
+            parse.Should().NotThrow("ToString() must emit valid JSON even when text contains quotes/backslashes");
+
+            var roundTripped = JsonSerializer.Deserialize<SpeakTextSourceV1>(json);
+            roundTripped!.Text.Should().Be(NastyText, "the exact text must survive a serialize/deserialize round-trip");
+            roundTripped.Type.Should().Be("Speak");
+        }
+    }
+
+    [Test]
+    public void SpeakV2_TextSource_ToString_Should_Be_Valid_Json_And_RoundTrip()
+    {
+        var source = new SpeakTextSourceV2(NastyText);
+
+        var json = source.ToString();
+
+        using (new AssertionScope())
+        {
+            Action parse = () => JsonDocument.Parse(json);
+            parse.Should().NotThrow("ToString() must emit valid JSON even when text contains quotes/backslashes");
+
+            var roundTripped = JsonSerializer.Deserialize<SpeakTextSourceV2>(json);
+            roundTripped!.Text.Should().Be(NastyText);
+        }
+    }
+
+    [Test]
+    public void Agent_UpdatePromptSchema_ToString_Should_Be_Parseable_By_JsonNode()
+    {
+        // Mirrors the Agent Connect path (#393): options.ToString() is fed straight into
+        // JsonNode.Parse(...). A prompt with quotes previously made that Parse throw.
+        var schema = new UpdatePromptSchema
+        {
+            Prompt = "You are \"Alex\". Reply in JSON like {\"ok\": true}. Use C:\\path when asked."
+        };
+
+        var json = schema.ToString();
+
+        using (new AssertionScope())
+        {
+            Action parse = () => JsonNode.Parse(json);
+            parse.Should().NotThrow("the Agent Connect path parses settings JSON with JsonNode.Parse");
+
+            var roundTripped = JsonSerializer.Deserialize<UpdatePromptSchema>(json);
+            roundTripped!.Prompt.Should().Be(schema.Prompt, "the prompt text must round-trip exactly");
+        }
+    }
+
+    [Test]
+    public void Plain_Ascii_Text_Should_Not_Be_Escaped()
+    {
+        // The relaxed encoder should keep readable characters literal (no \u002B / \u0026 noise).
+        var source = new SpeakTextSourceV2("a+b & c < d > e");
+
+        var json = source.ToString();
+
+        using (new AssertionScope())
+        {
+            json.Should().Contain("a+b & c < d > e", "the relaxed encoder must emit these characters literally");
+            json.Should().NotContain("\\u", "no unicode-escaped characters should appear for simple ASCII text");
+        }
+    }
+}

--- a/Deepgram.Tests/UnitTests/ClientTests/WebSocketTeardownRaceTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/WebSocketTeardownRaceTests.cs
@@ -1,0 +1,104 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Bogus;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Deepgram.Abstractions.v2;
+using Deepgram.Models.Authenticate.v1;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+/// <summary>
+/// Deterministic regression tests for the #390 teardown race. Stop() and Dispose() both cancel and
+/// dispose the shared internal CancellationTokenSource. A naive "if (field != null) { field.Cancel();
+/// field.Dispose(); field = null; }" is a check-then-act race: two concurrent teardown calls (a
+/// user Stop() overlapping the receive loop's server-close teardown, or Stop() racing Dispose()) can
+/// throw NullReferenceException (field nulled between re-reads) or ObjectDisposedException. The fix
+/// routes every teardown path through an Interlocked.Exchange claim so exactly one caller disposes.
+///
+/// These exercise the shared teardown directly and offline (no network), hammering the exact window
+/// many times. Against the old check-then-act code this fails with NRE/ODE; against the fix it passes.
+/// </summary>
+public class WebSocketTeardownRaceTests
+{
+    // Minimal concrete client that exposes the protected teardown surface for testing. All members
+    // used here are protected on AbstractWebSocketClient, so no reflection is needed.
+    private sealed class TestWebSocketClient : AbstractWebSocketClient
+    {
+        public TestWebSocketClient(string apiKey, IDeepgramClientOptions options) : base(apiKey, options) { }
+
+        public void SeedTokenSource() => _cancellationTokenSource = new CancellationTokenSource();
+
+        public CancellationTokenSource? CurrentTokenSource => _cancellationTokenSource;
+
+        public void InvokeTeardown() => DisposeCancellationTokenSource();
+    }
+
+    private static TestWebSocketClient NewClient()
+    {
+        var apiKey = new Faker().Random.Guid().ToString();
+        return new TestWebSocketClient(apiKey, new DeepgramWsClientOptions(apiKey) { OnPrem = true });
+    }
+
+    [Test]
+    public async Task Concurrent_Teardown_Never_Throws_And_Claims_Once()
+    {
+        const int iterations = 300;
+        const int concurrency = 8;
+
+        for (var i = 0; i < iterations; i++)
+        {
+            var client = NewClient();
+            client.SeedTokenSource();
+
+            // Release all workers at once to maximize contention on the token-cleanup window.
+            using var gate = new ManualResetEventSlim(false);
+            var tasks = Enumerable.Range(0, concurrency).Select(_ => Task.Run(() =>
+            {
+                gate.Wait();
+                client.InvokeTeardown();
+            })).ToArray();
+
+            gate.Set();
+
+            Func<Task> act = () => Task.WhenAll(tasks);
+            await act.Should().NotThrowAsync(
+                "concurrent teardown must not race on the shared cancellation token source (#390)");
+
+            client.CurrentTokenSource.Should().BeNull("the token source must be claimed and nulled exactly once");
+        }
+    }
+
+    [Test]
+    public void Repeated_Teardown_Is_Idempotent_And_Disposes_The_Source()
+    {
+        var client = NewClient();
+        client.SeedTokenSource();
+        var seeded = client.CurrentTokenSource!;
+
+        using (new AssertionScope())
+        {
+            client.Invoking(c => c.InvokeTeardown()).Should().NotThrow();
+            client.CurrentTokenSource.Should().BeNull("the first teardown claims and nulls the source");
+
+            // The claimed source must actually be disposed, not just dropped.
+            seeded.Invoking(s => _ = s.Token).Should().Throw<ObjectDisposedException>(
+                "the claimed token source must be disposed");
+
+            // Second and third teardowns are no-ops, never throwing on the now-null field.
+            client.Invoking(c => c.InvokeTeardown()).Should().NotThrow();
+            client.Invoking(c => c.InvokeTeardown()).Should().NotThrow();
+        }
+    }
+
+    [Test]
+    public void Teardown_With_No_Token_Source_Is_Safe()
+    {
+        var client = NewClient(); // never seeded; _cancellationTokenSource is null
+
+        client.Invoking(c => c.InvokeTeardown()).Should().NotThrow(
+            "teardown before any Connect() must be a safe no-op");
+    }
+}

--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -526,7 +526,15 @@ public abstract class AbstractWebSocketClient : IDisposable
                 Log.Verbose("ProcessTextMessage", $"raw response: {response}");
             }
             var data = JsonDocument.Parse(response);
-            var val = Enum.Parse(typeof(WebSocketType), data.RootElement.GetProperty("type").GetString()!);
+            var typeString = data.RootElement.GetProperty("type").GetString();
+            // Use TryParse so message types unknown to this SDK version are surfaced as
+            // Unhandled instead of throwing. This keeps the SDK forward-compatible with new
+            // server message types. See #395.
+            if (!Enum.TryParse<WebSocketType>(typeString, out var val))
+            {
+                Log.Debug("ProcessTextMessage", $"Unknown message type '{typeString}'. Treating as Unhandled.");
+                val = WebSocketType.Unhandled;
+            }
 
             if (Log.IsEnabled(LogLevel.Verbose))
             {

--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -279,16 +279,19 @@ public abstract class AbstractWebSocketClient : IDisposable
     /// </summary>, 
     public virtual async Task SendBinaryImmediately(byte[] data, int length = Constants.UseArrayLengthForSend, CancellationTokenSource? _cancellationToken = null)
     {
-        if (!IsConnected())
+        // Snapshot the socket so a concurrent Stop()/Dispose() nulling the field can't NRE the
+        // SendAsync below (this runs on the Stop -> SendClose path). See #390.
+        var socket = _clientWebSocket;
+        if (socket == null || !IsConnected())
         {
             Log.Debug("SendBinaryImmediately", "WebSocket is not connected. Exiting...");
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
+        // provide a cancellation token, or use the teardown-safe one in the class
+        var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
 
-        await _mutexSend.WaitAsync(_cancelToken.Token);
+        await _mutexSend.WaitAsync(token);
         try
         {
             Log.Verbose("SendBinaryImmediately", "Sending binary message immediately...");
@@ -296,7 +299,7 @@ public abstract class AbstractWebSocketClient : IDisposable
             {
                 length = data.Length;
             }
-            await _clientWebSocket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Binary, true, _cancelToken.Token)
+            await socket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Binary, true, token)
                 .ConfigureAwait(false);
         }
         finally
@@ -310,16 +313,19 @@ public abstract class AbstractWebSocketClient : IDisposable
     /// </summary>
     public virtual async Task SendMessageImmediately(byte[] data, int length = Constants.UseArrayLengthForSend, CancellationTokenSource? _cancellationToken = null)
     {
-        if (!IsConnected())
+        // Snapshot the socket so a concurrent Stop()/Dispose() nulling the field can't NRE the
+        // SendAsync below (this runs on the Stop -> SendClose path). See #390.
+        var socket = _clientWebSocket;
+        if (socket == null || !IsConnected())
         {
-            Log.Debug("SendBinaryImmediately", "WebSocket is not connected. Exiting...");
+            Log.Debug("SendMessageImmediately", "WebSocket is not connected. Exiting...");
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
+        // provide a cancellation token, or use the teardown-safe one in the class
+        var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
 
-        await _mutexSend.WaitAsync(_cancelToken.Token);
+        await _mutexSend.WaitAsync(token);
         try
         {
             Log.Verbose("SendMessageImmediately", "Sending text message immediately...");
@@ -327,7 +333,7 @@ public abstract class AbstractWebSocketClient : IDisposable
             {
                 length = data.Length;
             }
-            await _clientWebSocket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, _cancelToken.Token)
+            await socket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, token)
                 .ConfigureAwait(false);
         }
         finally
@@ -365,14 +371,19 @@ public abstract class AbstractWebSocketClient : IDisposable
 
         try
         {
-            while (await _sendChannel.Reader.WaitToReadAsync(_cancellationTokenSource.Token))
+            // snapshot the token to avoid a teardown race nulling the field mid-loop (#390);
+            // cancel-before-dispose guarantees a torn-down source is observed as cancelled here.
+            var token = GetInternalCancellationToken();
+            while (await _sendChannel.Reader.WaitToReadAsync(token))
             {
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                token = GetInternalCancellationToken();
+                if (token.IsCancellationRequested)
                 {
                     Log.Information("ProcessSendQueue", "ProcessSendQueue cancelled");
                     break;
                 }
-                if (!IsConnected())
+                var socket = _clientWebSocket;
+                if (socket == null || !IsConnected())
                 {
                     Log.Debug("ProcessSendQueue", "WebSocket is not connected. Exiting...");
                     break;
@@ -383,10 +394,10 @@ public abstract class AbstractWebSocketClient : IDisposable
                 {
                     // TODO: Add logging for message capturing for possible playback
                     Log.Verbose("ProcessSendQueue", "Sending message...");
-                    await _mutexSend.WaitAsync(_cancellationTokenSource.Token);
+                    await _mutexSend.WaitAsync(token);
                     try
                     {
-                        await _clientWebSocket.SendAsync(message.Message, message.MessageType, true, _cancellationTokenSource.Token)
+                        await socket.SendAsync(message.Message, message.MessageType, true, token)
                             .ConfigureAwait(false);
                     }
                     finally
@@ -421,14 +432,18 @@ public abstract class AbstractWebSocketClient : IDisposable
         {
             try
             {
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                // snapshot token and socket to avoid a teardown race nulling the fields mid-loop (#390)
+                var token = GetInternalCancellationToken();
+                var socket = _clientWebSocket;
+
+                if (token.IsCancellationRequested)
                 {
                     Log.Information("ProcessReceiveQueue", "ReceiveThread cancelled");
                     await Stop();
                     Log.Verbose("ProcessReceiveQueue", "LEAVE");
                     return;
                 }
-                if (!IsConnected())
+                if (socket == null || !IsConnected())
                 {
                     Log.Debug("ProcessReceiveQueue", "WebSocket is not connected. Exiting...");
                     return;
@@ -442,7 +457,7 @@ public abstract class AbstractWebSocketClient : IDisposable
                     do
                     {
                         // get the result of the receive operation
-                        result = await _clientWebSocket.ReceiveAsync(buffer, _cancellationTokenSource.Token);
+                        result = await socket.ReceiveAsync(buffer, token);
 
                         ms.Write(
                             buffer.Array ?? throw new InvalidOperationException("buffer cannot be null"),
@@ -644,10 +659,21 @@ public abstract class AbstractWebSocketClient : IDisposable
             cancelToken = new CancellationTokenSource(Constants.DefaultDisconnectTimeout);
         }
 
+        // Snapshot the socket so a concurrent Stop() (e.g. one triggered by a server-initiated
+        // Close while the caller also calls Stop) that nulls the field can't cause a
+        // NullReferenceException on the derefs after the awaits below. See #390.
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            Log.Information("Stop", "Client has already been disposed");
+            Log.Verbose("AbstractWebSocketClient.Stop", "LEAVE");
+            return true;
+        }
+
         try
         {
             // if websocket is open, send a close message
-            if (_clientWebSocket!.State == WebSocketState.Open)
+            if (socket.State == WebSocketState.Open)
             {
                 Log.Debug("Stop", "Sending Close message...");
                 await SendClose(nullByte, cancelToken);
@@ -665,21 +691,33 @@ public abstract class AbstractWebSocketClient : IDisposable
                 InvokeParallel(_closeReceived, data);
             }
 
-            // attempt to stop the connection
-            if (_clientWebSocket!.State != WebSocketState.Closed && _clientWebSocket!.State != WebSocketState.Aborted)
+            // attempt to stop the connection — serialize via the send mutex and re-check state so a
+            // concurrent Stop (user Stop racing the server-close-triggered Stop) can't issue two
+            // overlapping CloseOutputAsync calls on the same socket (ClientWebSocket allows only one
+            // outstanding send). See #390.
+            await _mutexSend.WaitAsync(cancelToken.Token).ConfigureAwait(false);
+            try
             {
-                Log.Debug("Stop", "Closing WebSocket connection...");
-                await _clientWebSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
-                    .ConfigureAwait(false);
+                // CloseOutputAsync is only valid from Open/CloseReceived; a positive check avoids an
+                // InvalidOperationException if Stop() runs while Connect() is still handshaking
+                // (socket in Connecting/None). See #390 (R1).
+                if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
+                {
+                    Log.Debug("Stop", "Closing WebSocket connection...");
+                    await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
+                        .ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                _mutexSend.Release();
             }
 
-            // clean up internal token
-            if (_cancellationTokenSource != null)
-            {
-                Log.Debug("Stop", "Disposing internal token...");
-                _cancellationTokenSource.Dispose();
-                _cancellationTokenSource = null;
-            }
+            // clean up internal token — cancel-before-dispose so background loops
+            // (keepalive/autoflush/send/receive) observe cancellation and exit cleanly, and
+            // atomic-claim so a concurrent Stop()/Dispose() can't race on the field. See #390.
+            Log.Debug("Stop", "Disposing internal token...");
+            DisposeCancellationTokenSource();
 
             // release the socket
             Log.Debug("Stop", "Disposing WebSocket socket...");
@@ -690,10 +728,24 @@ public abstract class AbstractWebSocketClient : IDisposable
 
             return true;
         }
-        catch (TaskCanceledException ex)
+        catch (OperationCanceledException ex)
         {
+            // Covers both Task.Delay's TaskCanceledException and CloseOutputAsync's bare
+            // OperationCanceledException if the disconnect-timeout token fires during teardown.
             Log.Debug("Stop", "Stop cancelled.");
             Log.Verbose("Stop", $"Stop cancelled. Info: {ex}");
+            Log.Verbose("AbstractWebSocketClient.Stop", "LEAVE");
+
+            return true;
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException || ex is WebSocketException)
+        {
+            // A concurrent Stop()/Dispose() already tore down the socket (disposed stream, or the
+            // remote closed without a handshake). The connection is gone, which is the goal of
+            // Stop, so treat it as an already-completed stop rather than a teardown-race error.
+            // Mirrors the Flux client's own Stop() catch set. See #390.
+            Log.Debug("Stop", "Stop raced with another teardown; already stopped.");
+            Log.Verbose("Stop", $"{ex.GetType().Name}: {ex}");
             Log.Verbose("AbstractWebSocketClient.Stop", "LEAVE");
 
             return true;
@@ -708,6 +760,68 @@ public abstract class AbstractWebSocketClient : IDisposable
     }
 
     #region Helpers
+    /// <summary>
+    /// Returns the current internal cancellation token in a way that is safe against
+    /// teardown races. Stop()/Dispose() null and dispose <see cref="_cancellationTokenSource"/>,
+    /// which previously caused NullReference/ObjectDisposedException in long-running background
+    /// loops (keepalive/autoflush). If the source has been torn down, an already-cancelled token
+    /// is returned so callers exit cleanly. See #390.
+    /// </summary>
+    protected CancellationToken GetInternalCancellationToken()
+    {
+        // Snapshot the reference to avoid it being nulled between the check and the read.
+        var cts = _cancellationTokenSource;
+        if (cts == null)
+        {
+            return new CancellationToken(true);
+        }
+
+        try
+        {
+            return cts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            return new CancellationToken(true);
+        }
+    }
+
+    /// <summary>
+    /// Cancels and disposes the internal cancellation token source exactly once, safely against
+    /// concurrent Stop()/Dispose() calls. A plain "if (field != null) { field.Cancel(); ... }" is a
+    /// check-then-act race: a second caller can null the field between the re-reads, throwing
+    /// NullReferenceException, or dispose it first, throwing ObjectDisposedException from .Token.
+    /// Interlocked.Exchange lets exactly one caller claim the instance; the loser gets null. See #390.
+    /// </summary>
+    protected void DisposeCancellationTokenSource()
+    {
+        var cts = Interlocked.Exchange(ref _cancellationTokenSource, null);
+        if (cts == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                cts.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // already disposed by a concurrent teardown; nothing to cancel
+        }
+        catch (AggregateException)
+        {
+            // a cancellation callback threw; the token is still cancelled, so dispose anyway
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+
     /// <summary>
     /// Retrieves the connection state of the WebSocket
     /// </summary>
@@ -808,19 +922,12 @@ public abstract class AbstractWebSocketClient : IDisposable
             return;
         }
 
-        if (_cancellationTokenSource != null)
-        {
-            if (!_cancellationTokenSource.Token.IsCancellationRequested)
-            {
-                _cancellationTokenSource.Cancel();
-            }
-            _cancellationTokenSource.Dispose();
-            _cancellationTokenSource = null;
-        }
+        // atomic-claim teardown; safe against a concurrent Stop()/Dispose(). See #390.
+        DisposeCancellationTokenSource();
 
         if (_sendChannel != null)
         {
-            _sendChannel.Writer.Complete();
+            _sendChannel.Writer.TryComplete(); // TryComplete: idempotent under concurrent Dispose() (#390 R3)
         }
 
         if (_clientWebSocket != null)

--- a/Deepgram/Clients/Agent/v2/Websocket/Client.cs
+++ b/Deepgram/Clients/Agent/v2/Websocket/Client.cs
@@ -518,17 +518,26 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
-
         Log.Debug("SendClose", "Sending Close Message Immediately...");
         if (nullByte)
         {
+            // Snapshot the socket and use the teardown-safe token: a concurrent Stop()/Dispose()
+            // nulls both _clientWebSocket and _cancellationTokenSource outside _mutexSend, so
+            // dereferencing the raw fields after the await could throw NRE - which is not in Stop()'s
+            // benign catch set and would escape (#390). Mirrors SendBinaryImmediately/SendMessageImmediately.
+            var socket = _clientWebSocket;
+            if (socket == null || !IsConnected())
+            {
+                Log.Debug("SendClose", "WebSocket is not connected. Exiting...");
+                return;
+            }
+            var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
+
             // send a close to Deepgram
-            await _mutexSend.WaitAsync(_cancelToken.Token);
+            await _mutexSend.WaitAsync(token);
             try
             {
-                await _clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                await socket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, token)
                     .ConfigureAwait(false);
             }
             finally

--- a/Deepgram/Clients/Agent/v2/Websocket/Client.cs
+++ b/Deepgram/Clients/Agent/v2/Websocket/Client.cs
@@ -639,7 +639,17 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
         {
             Log.Verbose("ProcessTextMessage", $"raw response: {response}");
             var data = JsonDocument.Parse(response);
-            var val = Enum.Parse(typeof(AgentType), data.RootElement.GetProperty("type").GetString()!);
+            var typeString = data.RootElement.GetProperty("type").GetString();
+            // Use TryParse so Agent message types unknown to this SDK version (e.g. new server
+            // messages like "History"/"Warning") are routed to the base handler and surfaced as
+            // Unhandled instead of throwing an ArgumentException. See #395.
+            if (!Enum.TryParse<AgentType>(typeString, out var val))
+            {
+                Log.Debug("ProcessTextMessage", $"Unknown Agent message type '{typeString}'. Routing to base handler...");
+                base.ProcessTextMessage(result, ms);
+                Log.Verbose("AgentWSClient.ProcessTextMessage", "LEAVE");
+                return;
+            }
 
             Log.Verbose("ProcessTextMessage", $"Type: {val}");
 

--- a/Deepgram/Clients/Agent/v2/Websocket/Client.cs
+++ b/Deepgram/Clients/Agent/v2/Websocket/Client.cs
@@ -552,10 +552,13 @@ public class Client : AbstractWebSocketClient, IAgentWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
-                await Task.Delay(5000, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
+                await Task.Delay(5000, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessKeepAlive", "KeepAliveThread cancelled");
                     break;

--- a/Deepgram/Clients/Flux/Speak/WebSocket/Client.cs
+++ b/Deepgram/Clients/Flux/Speak/WebSocket/Client.cs
@@ -385,16 +385,26 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
+        // Use the teardown-safe token: a concurrent Stop()/Dispose() nulls _cancellationTokenSource
+        // outside _mutexSend, so dereferencing the raw field after an await could throw NRE - which
+        // is not in Stop()'s benign catch set and would escape (#390).
+        var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
 
         Log.Debug("SendClose", "Sending Close Message Immediately...");
         if (nullByte)
         {
-            await _mutexSend.WaitAsync(_cancelToken.Token);
+            // Snapshot the socket too - a concurrent Dispose() can null it while we hold the mutex.
+            var socket = _clientWebSocket;
+            if (socket == null || !IsConnected())
+            {
+                Log.Debug("SendClose", "WebSocket is not connected. Exiting...");
+                return;
+            }
+
+            await _mutexSend.WaitAsync(token);
             try
             {
-                await _clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                await socket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, token)
                     .ConfigureAwait(false);
             }
             finally
@@ -420,10 +430,14 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
         try
         {
             var deadline = Constants.DefaultCloseGracePeriodMs;
-            while (deadline > 0 && _clientWebSocket != null && _clientWebSocket.State == WebSocketState.Open)
+            // Re-snapshot each iteration so a concurrent Dispose() nulling the field can't turn the
+            // condition into a check-then-act NRE (see #390).
+            var socket = _clientWebSocket;
+            while (deadline > 0 && socket != null && socket.State == WebSocketState.Open)
             {
-                await Task.Delay(50, _cancelToken.Token).ConfigureAwait(false);
+                await Task.Delay(50, token).ConfigureAwait(false);
                 deadline -= 50;
+                socket = _clientWebSocket;
             }
             Log.Debug("SendClose", deadline > 0 ? "Server closed the connection" : "Grace period elapsed");
         }

--- a/Deepgram/Clients/Flux/WebSocket/Client.cs
+++ b/Deepgram/Clients/Flux/WebSocket/Client.cs
@@ -344,17 +344,27 @@ public class Client : AbstractWebSocketClient, IFluxWebSocketClient
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
+        // Use the teardown-safe token: a concurrent Stop()/Dispose() nulls _cancellationTokenSource
+        // outside _mutexSend, so dereferencing the raw field after an await could throw NRE - which
+        // is not in Stop()'s benign catch set and would escape (#390).
+        var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
 
         Log.Debug("SendClose", "Sending Close Message Immediately...");
         if (nullByte)
         {
+            // Snapshot the socket too - a concurrent Dispose() can null it while we hold the mutex.
+            var socket = _clientWebSocket;
+            if (socket == null || !IsConnected())
+            {
+                Log.Debug("SendClose", "WebSocket is not connected. Exiting...");
+                return;
+            }
+
             // send a close to Deepgram
-            await _mutexSend.WaitAsync(_cancelToken.Token);
+            await _mutexSend.WaitAsync(token);
             try
             {
-                await _clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                await socket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, token)
                     .ConfigureAwait(false);
             }
             finally
@@ -379,10 +389,14 @@ public class Client : AbstractWebSocketClient, IFluxWebSocketClient
         try
         {
             var deadline = Constants.DefaultCloseStreamGracePeriodMs;
-            while (deadline > 0 && _clientWebSocket != null && _clientWebSocket.State == WebSocketState.Open)
+            // Re-snapshot each iteration so a concurrent Dispose() nulling the field can't turn the
+            // condition into a check-then-act NRE (see #390).
+            var socket = _clientWebSocket;
+            while (deadline > 0 && socket != null && socket.State == WebSocketState.Open)
             {
-                await Task.Delay(50, _cancelToken.Token).ConfigureAwait(false);
+                await Task.Delay(50, token).ConfigureAwait(false);
                 deadline -= 50;
+                socket = _clientWebSocket;
             }
             Log.Debug("SendClose", deadline > 0 ? "Server closed the connection" : "Grace period elapsed");
         }

--- a/Deepgram/Clients/Listen/v1/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v1/WebSocket/Client.cs
@@ -337,12 +337,15 @@ public class Client : IDisposable, IListenWebSocketClient
     public void SendClose(bool nullByte = false)
     {
         Log.Debug("SendFinalize", "Sending Close Message Immediately...");
-        if (nullByte && _clientWebSocket != null)
+        // snapshot socket + teardown-safe token so a concurrent Stop()/Dispose() can't NRE this
+        // (SendClose is called synchronously from Stop). See #390 (R2).
+        var socket = _clientWebSocket;
+        if (nullByte && socket != null)
         {
             // send a close to Deepgram
             lock (_mutexSend)
             {
-                _clientWebSocket.SendAsync(new ArraySegment<byte>([0]), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                socket.SendAsync(new ArraySegment<byte>([0]), WebSocketMessageType.Binary, true, GetInternalCancellationToken())
                     .ConfigureAwait(false);
             }
             return;
@@ -376,6 +379,12 @@ public class Client : IDisposable, IListenWebSocketClient
     /// </summary>
     public void SendBinaryImmediately(byte[] data, int length = Constants.UseArrayLengthForSend)
     {
+        // snapshot socket + teardown-safe token to avoid a concurrent-teardown NRE. See #390 (R2).
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            return;
+        }
         lock (_mutexSend)
         {
             Log.Verbose("SendBinaryImmediately", "Sending binary message immediately..");  // TODO: dump this message
@@ -383,7 +392,7 @@ public class Client : IDisposable, IListenWebSocketClient
             {
                 length = data.Length;
             }
-            _clientWebSocket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+            socket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Binary, true, GetInternalCancellationToken())
                 .ConfigureAwait(false);
         }
     }
@@ -393,6 +402,13 @@ public class Client : IDisposable, IListenWebSocketClient
     /// </summary>
     public void SendMessageImmediately(byte[] data, int length = Constants.UseArrayLengthForSend)
     {
+        // snapshot socket + teardown-safe token to avoid a concurrent-teardown NRE (called from
+        // Stop() via SendClose). See #390 (R2).
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            return;
+        }
         lock (_mutexSend)
         {
             Log.Verbose("SendBinaryImmediately", "Sending binary message immediately..");  // TODO: dump this message
@@ -400,7 +416,7 @@ public class Client : IDisposable, IListenWebSocketClient
             {
                 length = data.Length;
             }
-            _clientWebSocket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, _cancellationTokenSource.Token)
+            socket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, GetInternalCancellationToken())
                 .ConfigureAwait(false);
         }
     }
@@ -472,6 +488,63 @@ public class Client : IDisposable, IListenWebSocketClient
         }
     }
 
+    /// <summary>
+    /// Returns the current internal cancellation token in a way that is safe against teardown races.
+    /// Stop()/Dispose() null and dispose the source, which previously caused NullReference/
+    /// ObjectDisposedException in background loops. Returns an already-cancelled token if torn down. See #390.
+    /// </summary>
+    private CancellationToken GetInternalCancellationToken()
+    {
+        var cts = _cancellationTokenSource;
+        if (cts == null)
+        {
+            return new CancellationToken(true);
+        }
+
+        try
+        {
+            return cts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            return new CancellationToken(true);
+        }
+    }
+
+    /// <summary>
+    /// Cancels and disposes the internal cancellation token source exactly once, safely against
+    /// concurrent Stop()/Dispose() calls. Interlocked.Exchange lets one caller claim the instance;
+    /// the loser gets null, avoiding the check-then-act NRE/ODE on the shared field. See #390.
+    /// </summary>
+    private void DisposeCancellationTokenSource()
+    {
+        var cts = Interlocked.Exchange(ref _cancellationTokenSource, null);
+        if (cts == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                cts.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // already disposed by a concurrent teardown; nothing to cancel
+        }
+        catch (AggregateException)
+        {
+            // a cancellation callback threw; the token is still cancelled, so dispose anyway
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+
     internal async void ProcessKeepAlive()
     {
         Log.Verbose("ListenWSClient.ProcessKeepAlive", "ENTER");
@@ -480,10 +553,13 @@ public class Client : IDisposable, IListenWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
-                await Task.Delay(5000, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
+                await Task.Delay(5000, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessKeepAlive", "KeepAliveThread cancelled");
                     break;
@@ -520,10 +596,13 @@ public class Client : IDisposable, IListenWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
-                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
+                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessAutoFlush", "ProcessAutoFlush cancelled");
                     break;
@@ -881,10 +960,21 @@ public class Client : IDisposable, IListenWebSocketClient
             cancelToken = new CancellationTokenSource(Constants.DefaultDisconnectTimeout);
         }
 
+        // Snapshot the socket so a concurrent Stop() (e.g. one triggered by a server-initiated
+        // Close while the caller also calls Stop) that nulls the field can't cause a
+        // NullReferenceException on the derefs after the awaits below. See #390.
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            Log.Information("Stop", "Client has already been disposed");
+            Log.Verbose("ListenWSClient.Stop", "LEAVE");
+            return;
+        }
+
         try
         {
             // if websocket is open, send a close message
-            if (_clientWebSocket!.State == WebSocketState.Open)
+            if (socket.State == WebSocketState.Open)
             {
                 Log.Debug("Stop", "Sending Close message...");
                 SendClose(nullByte);
@@ -902,21 +992,25 @@ public class Client : IDisposable, IListenWebSocketClient
                 InvokeParallel(_closeReceived, data);
             }
 
-            // attempt to stop the connection
-            if (_clientWebSocket!.State != WebSocketState.Closed && _clientWebSocket!.State != WebSocketState.Aborted)
+            // attempt to stop the connection. NOTE: this v1 client guards its sends with
+            // lock(_mutexSend) (Monitor), not _mutexSend.WaitAsync (the semaphore count) as v2 does,
+            // so we cannot cleanly serialize this async CloseOutputAsync against an in-flight
+            // ProcessSendQueue send. A concurrent Stop or send can therefore overlap on the socket
+            // (ClientWebSocket allows one outstanding send) and surface an InvalidOperationException;
+            // that is handled as benign teardown by the catch below rather than prevented. See #390.
+            // CloseOutputAsync is only valid from Open/CloseReceived; a positive check avoids an
+            // InvalidOperationException if Stop() runs while Connect() is still handshaking. See #390 (R1).
+            if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
             {
                 Log.Debug("Stop", "Closing WebSocket connection...");
-                await _clientWebSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
+                await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
                     .ConfigureAwait(false);
             }
 
-            // clean up internal token
-            if (_cancellationTokenSource != null)
-            {
-                Log.Debug("Stop", "Disposing internal token...");
-                _cancellationTokenSource.Dispose();
-                _cancellationTokenSource = null;
-            }
+            // clean up internal token — cancel-before-dispose so background loops observe
+            // cancellation, and atomic-claim so a concurrent Stop()/Dispose() can't race. See #390.
+            Log.Debug("Stop", "Disposing internal token...");
+            DisposeCancellationTokenSource();
 
             // release the socket
             Log.Debug("Stop", "Disposing WebSocket socket...");
@@ -925,10 +1019,21 @@ public class Client : IDisposable, IListenWebSocketClient
             Log.Debug("Stop", "Succeeded");
             Log.Verbose("ListenWSClient.Stop", "LEAVE");
         }
-        catch (TaskCanceledException ex)
+        catch (OperationCanceledException ex)
         {
+            // Covers Task.Delay's TaskCanceledException and CloseOutputAsync's bare
+            // OperationCanceledException if the disconnect-timeout token fires.
             Log.Debug("Stop", "Stop cancelled.");
             Log.Verbose("Stop", $"Stop cancelled. Info: {ex}");
+            Log.Verbose("ListenWSClient.Stop", "LEAVE");
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException || ex is WebSocketException || ex is InvalidOperationException)
+        {
+            // A concurrent Stop()/Dispose() or an in-flight send already tore down / is racing the
+            // socket (disposed stream, remote closed without handshake, or overlapping send). The
+            // connection is gone, which is the goal of Stop. Mirrors the Flux client's catch set. See #390.
+            Log.Debug("Stop", "Stop raced with another teardown; already stopped.");
+            Log.Verbose("Stop", $"{ex.GetType().Name}: {ex}");
             Log.Verbose("ListenWSClient.Stop", "LEAVE");
         }
         catch (Exception ex)
@@ -1116,19 +1221,12 @@ public class Client : IDisposable, IListenWebSocketClient
             return;
         }
 
-        if (_cancellationTokenSource != null)
-        {
-            if (!_cancellationTokenSource.Token.IsCancellationRequested)
-            {
-                _cancellationTokenSource.Cancel();
-            }
-            _cancellationTokenSource.Dispose();
-            _cancellationTokenSource = null;
-        }
+        // atomic-claim teardown; safe against a concurrent Stop()/Dispose(). See #390.
+        DisposeCancellationTokenSource();
 
         if (_sendChannel != null)
         {
-            _sendChannel.Writer.Complete();
+            _sendChannel.Writer.TryComplete(); // TryComplete: idempotent under concurrent Dispose() (#390 R3)
         }
 
         if (_clientWebSocket != null)

--- a/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
@@ -350,10 +350,13 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
-                await Task.Delay(5000, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessKeepAlive", "Waiting for KeepAlive...");
+                await Task.Delay(5000, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessKeepAlive", "KeepAliveThread cancelled");
                     break;
@@ -394,10 +397,13 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
-                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
+                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessAutoFlush", "ProcessAutoFlush cancelled");
                     break;

--- a/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
@@ -316,17 +316,26 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
-
         Log.Debug("SendClose", "Sending Close Message Immediately...");
         if (nullByte)
         {
+            // Snapshot the socket and use the teardown-safe token: a concurrent Stop()/Dispose()
+            // nulls both _clientWebSocket and _cancellationTokenSource outside _mutexSend, so
+            // dereferencing the raw fields after the await could throw NRE - which is not in Stop()'s
+            // benign catch set and would escape (#390). Mirrors SendBinaryImmediately/SendMessageImmediately.
+            var socket = _clientWebSocket;
+            if (socket == null || !IsConnected())
+            {
+                Log.Debug("SendClose", "WebSocket is not connected. Exiting...");
+                return;
+            }
+            var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
+
             // send a close to Deepgram
-            await _mutexSend.WaitAsync(_cancelToken.Token);
+            await _mutexSend.WaitAsync(token);
             try
             {
-                await _clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                await socket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, token)
                     .ConfigureAwait(false);
             }
             finally

--- a/Deepgram/Clients/Speak/v1/WebSocket/Client.cs
+++ b/Deepgram/Clients/Speak/v1/WebSocket/Client.cs
@@ -356,12 +356,15 @@ public class Client : IDisposable, ISpeakWebSocketClient
     public void Close(bool nullByte = false)
     {
         Log.Debug("SendFinalize", "Sending Close Message Immediately...");
-        if (nullByte && _clientWebSocket != null)
+        // snapshot socket + teardown-safe token so a concurrent Stop()/Dispose() can't NRE this
+        // (Close is called synchronously from Stop). See #390 (R2).
+        var socket = _clientWebSocket;
+        if (nullByte && socket != null)
         {
             // send a close to Deepgram
             lock (_mutexSend)
             {
-                _clientWebSocket.SendAsync(new ArraySegment<byte>([0]), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                socket.SendAsync(new ArraySegment<byte>([0]), WebSocketMessageType.Binary, true, GetInternalCancellationToken())
                     .ConfigureAwait(false);
             }
             return;
@@ -453,6 +456,13 @@ public class Client : IDisposable, ISpeakWebSocketClient
             }
         }
 
+        // snapshot socket + teardown-safe token to avoid a concurrent-teardown NRE (called from
+        // Stop() via Close). See #390 (R2).
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            return;
+        }
         lock (_mutexSend)
         {
             Log.Verbose("SendBinaryImmediately", "Sending text message immediately..");  // TODO: dump this message
@@ -460,7 +470,7 @@ public class Client : IDisposable, ISpeakWebSocketClient
             {
                 length = data.Length;
             }
-            _clientWebSocket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, _cancellationTokenSource.Token)
+            socket.SendAsync(new ArraySegment<byte>(data, 0, length), WebSocketMessageType.Text, true, GetInternalCancellationToken())
                 .ConfigureAwait(false);
         }
     }
@@ -532,6 +542,63 @@ public class Client : IDisposable, ISpeakWebSocketClient
         }
     }
 
+    /// <summary>
+    /// Returns the current internal cancellation token in a way that is safe against teardown races.
+    /// Stop()/Dispose() null and dispose the source, which previously caused NullReference/
+    /// ObjectDisposedException in background loops. Returns an already-cancelled token if torn down. See #390.
+    /// </summary>
+    private CancellationToken GetInternalCancellationToken()
+    {
+        var cts = _cancellationTokenSource;
+        if (cts == null)
+        {
+            return new CancellationToken(true);
+        }
+
+        try
+        {
+            return cts.Token;
+        }
+        catch (ObjectDisposedException)
+        {
+            return new CancellationToken(true);
+        }
+    }
+
+    /// <summary>
+    /// Cancels and disposes the internal cancellation token source exactly once, safely against
+    /// concurrent Stop()/Dispose() calls. Interlocked.Exchange lets one caller claim the instance;
+    /// the loser gets null, avoiding the check-then-act NRE/ODE on the shared field. See #390.
+    /// </summary>
+    private void DisposeCancellationTokenSource()
+    {
+        var cts = Interlocked.Exchange(ref _cancellationTokenSource, null);
+        if (cts == null)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!cts.IsCancellationRequested)
+            {
+                cts.Cancel();
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // already disposed by a concurrent teardown; nothing to cancel
+        }
+        catch (AggregateException)
+        {
+            // a cancellation callback threw; the token is still cancelled, so dispose anyway
+        }
+        finally
+        {
+            cts.Dispose();
+        }
+    }
+
     internal async void ProcessAutoFlush()
     {
         Log.Verbose("LiveClient.ProcessAutoFlush", "ENTER");
@@ -542,10 +609,13 @@ public class Client : IDisposable, ISpeakWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
-                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
+                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessAutoFlush", "ProcessAutoFlush cancelled");
                     break;
@@ -898,10 +968,21 @@ public class Client : IDisposable, ISpeakWebSocketClient
             cancelToken = new CancellationTokenSource(Constants.DefaultDisconnectTimeout);
         }
 
+        // Snapshot the socket so a concurrent Stop() (e.g. one triggered by a server-initiated
+        // Close while the caller also calls Stop) that nulls the field can't cause a
+        // NullReferenceException on the derefs after the awaits below. See #390.
+        var socket = _clientWebSocket;
+        if (socket == null)
+        {
+            Log.Information("Stop", "Client has already been disposed");
+            Log.Verbose("SpeakWSClient.Stop", "LEAVE");
+            return;
+        }
+
         try
         {
             // if websocket is open, send a close message
-            if (_clientWebSocket!.State == WebSocketState.Open)
+            if (socket.State == WebSocketState.Open)
             {
                 Log.Debug("Stop", "Sending Close message...");
                 Close(nullByte);
@@ -919,21 +1000,25 @@ public class Client : IDisposable, ISpeakWebSocketClient
                 InvokeParallel(_closeReceived, data);
             }
 
-            // attempt to stop the connection
-            if (_clientWebSocket!.State != WebSocketState.Closed && _clientWebSocket!.State != WebSocketState.Aborted)
+            // attempt to stop the connection. NOTE: this v1 client guards its sends with
+            // lock(_mutexSend) (Monitor), not _mutexSend.WaitAsync (the semaphore count) as v2 does,
+            // so we cannot cleanly serialize this async CloseOutputAsync against an in-flight
+            // ProcessSendQueue send. A concurrent Stop or send can therefore overlap on the socket
+            // (ClientWebSocket allows one outstanding send) and surface an InvalidOperationException;
+            // that is handled as benign teardown by the catch below rather than prevented. See #390.
+            // CloseOutputAsync is only valid from Open/CloseReceived; a positive check avoids an
+            // InvalidOperationException if Stop() runs while Connect() is still handshaking. See #390 (R1).
+            if (socket.State == WebSocketState.Open || socket.State == WebSocketState.CloseReceived)
             {
                 Log.Debug("Stop", "Closing WebSocket connection...");
-                await _clientWebSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
+                await socket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, string.Empty, cancelToken.Token)
                     .ConfigureAwait(false);
             }
 
-            // clean up internal token
-            if (_cancellationTokenSource != null)
-            {
-                Log.Debug("Stop", "Disposing internal token...");
-                _cancellationTokenSource.Dispose();
-                _cancellationTokenSource = null;
-            }
+            // clean up internal token — cancel-before-dispose so background loops observe
+            // cancellation, and atomic-claim so a concurrent Stop()/Dispose() can't race. See #390.
+            Log.Debug("Stop", "Disposing internal token...");
+            DisposeCancellationTokenSource();
 
             // release the socket
             Log.Debug("Stop", "Disposing WebSocket socket...");
@@ -942,10 +1027,21 @@ public class Client : IDisposable, ISpeakWebSocketClient
             Log.Debug("Stop", "Succeeded");
             Log.Verbose("SpeakWSClient.Stop", "LEAVE");
         }
-        catch (TaskCanceledException ex)
+        catch (OperationCanceledException ex)
         {
+            // Covers Task.Delay's TaskCanceledException and CloseOutputAsync's bare
+            // OperationCanceledException if the disconnect-timeout token fires.
             Log.Debug("Stop", "Stop cancelled.");
             Log.Verbose("Stop", $"Stop cancelled. Info: {ex}");
+            Log.Verbose("SpeakWSClient.Stop", "LEAVE");
+        }
+        catch (Exception ex) when (ex is ObjectDisposedException || ex is WebSocketException || ex is InvalidOperationException)
+        {
+            // A concurrent Stop()/Dispose() or an in-flight send already tore down / is racing the
+            // socket (disposed stream, remote closed without handshake, or overlapping send). The
+            // connection is gone, which is the goal of Stop. Mirrors the Flux client's catch set. See #390.
+            Log.Debug("Stop", "Stop raced with another teardown; already stopped.");
+            Log.Verbose("Stop", $"{ex.GetType().Name}: {ex}");
             Log.Verbose("SpeakWSClient.Stop", "LEAVE");
         }
         catch (Exception ex)
@@ -1083,19 +1179,12 @@ public class Client : IDisposable, ISpeakWebSocketClient
             return;
         }
 
-        if (_cancellationTokenSource != null)
-        {
-            if (!_cancellationTokenSource.Token.IsCancellationRequested)
-            {
-                _cancellationTokenSource.Cancel();
-            }
-            _cancellationTokenSource.Dispose();
-            _cancellationTokenSource = null;
-        }
+        // atomic-claim teardown; safe against a concurrent Stop()/Dispose(). See #390.
+        DisposeCancellationTokenSource();
 
         if (_sendChannel != null)
         {
-            _sendChannel.Writer.Complete();
+            _sendChannel.Writer.TryComplete(); // TryComplete: idempotent under concurrent Dispose() (#390 R3)
         }
 
         if (_clientWebSocket != null)

--- a/Deepgram/Clients/Speak/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Speak/v2/WebSocket/Client.cs
@@ -408,10 +408,13 @@ public class Client : AbstractWebSocketClient, ISpeakWebSocketClient
         {
             while (true)
             {
-                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
-                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancellationTokenSource.Token);
+                // snapshot the token each iteration to avoid a teardown race (#390)
+                var _cancelToken = GetInternalCancellationToken();
 
-                if (_cancellationTokenSource.Token.IsCancellationRequested)
+                Log.Verbose("ProcessAutoFlush", "Waiting for AutoFlush...");
+                await Task.Delay(Constants.DefaultFlushPeriodInMs, _cancelToken);
+
+                if (_cancelToken.IsCancellationRequested)
                 {
                     Log.Information("ProcessAutoFlush", "ProcessAutoFlush cancelled");
                     break;

--- a/Deepgram/Clients/Speak/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Speak/v2/WebSocket/Client.cs
@@ -341,17 +341,26 @@ public class Client : AbstractWebSocketClient, ISpeakWebSocketClient
             return;
         }
 
-        // provide a cancellation token, or use the one in the class
-        var _cancelToken = _cancellationToken ?? _cancellationTokenSource;
-
         Log.Debug("SendClose", "Sending Close Message Immediately...");
         if (nullByte)
         {
+            // Snapshot the socket and use the teardown-safe token: a concurrent Stop()/Dispose()
+            // nulls both _clientWebSocket and _cancellationTokenSource outside _mutexSend, so
+            // dereferencing the raw fields after the await could throw NRE - which is not in Stop()'s
+            // benign catch set and would escape (#390). Mirrors SendBinaryImmediately/SendMessageImmediately.
+            var socket = _clientWebSocket;
+            if (socket == null || !IsConnected())
+            {
+                Log.Debug("SendClose", "WebSocket is not connected. Exiting...");
+                return;
+            }
+            var token = _cancellationToken?.Token ?? GetInternalCancellationToken();
+
             // send a close to Deepgram
-            await _mutexSend.WaitAsync(_cancelToken.Token);
+            await _mutexSend.WaitAsync(token);
             try
             {
-                await _clientWebSocket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, _cancellationTokenSource.Token)
+                await socket.SendAsync(new ArraySegment<byte>(new byte[1] { 0 }), WebSocketMessageType.Binary, true, token)
                     .ConfigureAwait(false);
             }
             finally
@@ -363,7 +372,9 @@ public class Client : AbstractWebSocketClient, ISpeakWebSocketClient
 
         ControlMessage controlMessage = new ControlMessage(Constants.Close);
         byte[] data = Encoding.UTF8.GetBytes(controlMessage.ToString());
-        await SendMessageImmediately(data, Constants.UseArrayLengthForSend, _cancelToken);
+        // Pass the caller token through; when null, SendMessageImmediately falls back to the
+        // teardown-safe GetInternalCancellationToken() rather than a possibly-disposed field.
+        await SendMessageImmediately(data, Constants.UseArrayLengthForSend, _cancellationToken);
     }
 
     /// <summary>

--- a/Deepgram/Models/Agent/v2/WebSocket/Agent.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Agent.cs
@@ -37,7 +37,7 @@ public record Agent
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/AgentAudioDoneResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/AgentAudioDoneResponse.cs
@@ -19,6 +19,6 @@ public record AgentAudioDoneResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/AgentStartedSpeakingResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/AgentStartedSpeakingResponse.cs
@@ -34,6 +34,6 @@ public record AgentStartedSpeakingResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/AgentThinkingResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/AgentThinkingResponse.cs
@@ -23,6 +23,6 @@ public record AgentThinkingResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Audio.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Audio.cs
@@ -20,6 +20,6 @@ public record Audio
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/CartesiaVoice.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/CartesiaVoice.cs
@@ -19,6 +19,6 @@ public record CartesiaVoice
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/ControlMessage.cs
@@ -18,7 +18,7 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Agent/v2/WebSocket/ConversationTextResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/ConversationTextResponse.cs
@@ -27,6 +27,6 @@ public record ConversationTextResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Endpoint.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Endpoint.cs
@@ -19,6 +19,6 @@ public record Endpoint
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Function.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Function.cs
@@ -27,6 +27,6 @@ public record Function
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/FunctionCallRequestResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/FunctionCallRequestResponse.cs
@@ -21,6 +21,6 @@ public record FunctionCallRequestResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/FunctionCallResponseSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/FunctionCallResponseSchema.cs
@@ -26,6 +26,6 @@ public class FunctionCallResponseSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/FunctionEndpoint.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/FunctionEndpoint.cs
@@ -23,6 +23,6 @@ public record FunctionEndpoint
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Header.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Header.cs
@@ -19,6 +19,6 @@ public record Header
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/InjectAgentMessageSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/InjectAgentMessageSchema.cs
@@ -22,6 +22,6 @@ public class InjectAgentMessageSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/InjectUserMessageSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/InjectUserMessageSchema.cs
@@ -25,6 +25,6 @@ public class InjectUserMessageSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/InjectionRefusedResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/InjectionRefusedResponse.cs
@@ -19,6 +19,6 @@ public record InjectionRefusedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Input.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Input.cs
@@ -19,6 +19,6 @@ public record Input
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Item.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Item.cs
@@ -19,6 +19,6 @@ public record Item
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/KeepAliveSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/KeepAliveSchema.cs
@@ -18,6 +18,6 @@ public class KeepAliveSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Listen.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Listen.cs
@@ -18,6 +18,6 @@ public record Listen
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Output.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Output.cs
@@ -27,6 +27,6 @@ public record Output
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/PromptUpdatedResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/PromptUpdatedResponse.cs
@@ -19,6 +19,6 @@ public record PromptUpdatedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Properties.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Properties.cs
@@ -16,6 +16,6 @@ public record Properties
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Provider.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Provider.cs
@@ -63,6 +63,6 @@ public class Provider: DynamicObject
 
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Settings.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Settings.cs
@@ -47,6 +47,6 @@ public class SettingsSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/SettingsAppliedResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/SettingsAppliedResponse.cs
@@ -19,6 +19,6 @@ public record SettingsAppliedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Speak.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Speak.cs
@@ -37,7 +37,7 @@ public record Speak
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 
@@ -65,6 +65,6 @@ public record SpeakProviderConfig
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/SpeakUpdatedResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/SpeakUpdatedResponse.cs
@@ -19,6 +19,6 @@ public record SpeakUpdatedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/Think.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Think.cs
@@ -42,6 +42,6 @@ public record Think
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/UpdatePromptSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/UpdatePromptSchema.cs
@@ -22,6 +22,6 @@ public class UpdatePromptSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/UpdateSpeakSchema.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/UpdateSpeakSchema.cs
@@ -21,6 +21,6 @@ public class UpdateSpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/UserStartedSpeakingResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/UserStartedSpeakingResponse.cs
@@ -19,6 +19,6 @@ public record UserStartedSpeakingResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Agent/v2/WebSocket/WelcomeResponse.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/WelcomeResponse.cs
@@ -23,6 +23,6 @@ public record WelcomeResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
+++ b/Deepgram/Models/Analyze/v1/AnalyzeSchema.cs
@@ -88,7 +88,7 @@ public class AnalyzeSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/AsyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/AsyncResponse.cs
@@ -19,7 +19,7 @@ public record AsyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/Average.cs
+++ b/Deepgram/Models/Analyze/v1/Average.cs
@@ -25,6 +25,6 @@ public record Average
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/Intent.cs
+++ b/Deepgram/Models/Analyze/v1/Intent.cs
@@ -25,7 +25,7 @@ public record Intent
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/IntentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/IntentGroup.cs
@@ -19,6 +19,6 @@ public record IntentGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/IntentsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/IntentsInfo.cs
@@ -32,7 +32,7 @@ public record IntentsInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/Metadata.cs
+++ b/Deepgram/Models/Analyze/v1/Metadata.cs
@@ -60,6 +60,6 @@ public record Metadata
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/Results.cs
+++ b/Deepgram/Models/Analyze/v1/Results.cs
@@ -39,7 +39,7 @@ public record Results
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/Segment.cs
+++ b/Deepgram/Models/Analyze/v1/Segment.cs
@@ -60,6 +60,6 @@ public record Segment
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/SentimentGroup.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentGroup.cs
@@ -25,7 +25,7 @@ public record SentimentGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/SentimentInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SentimentInfo.cs
@@ -32,7 +32,7 @@ public record SentimentInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/Summary.cs
+++ b/Deepgram/Models/Analyze/v1/Summary.cs
@@ -18,7 +18,7 @@ public record Summary
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/SummaryInfo.cs
+++ b/Deepgram/Models/Analyze/v1/SummaryInfo.cs
@@ -32,6 +32,6 @@ public record SummaryInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/SyncResponse.cs
+++ b/Deepgram/Models/Analyze/v1/SyncResponse.cs
@@ -25,6 +25,6 @@ public record SyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Analyze/v1/TextSource.cs
+++ b/Deepgram/Models/Analyze/v1/TextSource.cs
@@ -18,7 +18,7 @@ public class TextSource(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/Topic.cs
+++ b/Deepgram/Models/Analyze/v1/Topic.cs
@@ -25,7 +25,7 @@ public record Topic
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/TopicGroup.cs
+++ b/Deepgram/Models/Analyze/v1/TopicGroup.cs
@@ -18,7 +18,7 @@ public record TopicGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/TopicsInfo.cs
+++ b/Deepgram/Models/Analyze/v1/TopicsInfo.cs
@@ -32,7 +32,7 @@ public record TopicsInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Analyze/v1/UrlSource.cs
+++ b/Deepgram/Models/Analyze/v1/UrlSource.cs
@@ -18,7 +18,7 @@ public class UrlSource(string url)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Auth/v1/GrantTokenResponse.cs
+++ b/Deepgram/Models/Auth/v1/GrantTokenResponse.cs
@@ -25,6 +25,6 @@ public record GrantTokenResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Auth/v1/GrantTokenSchema.cs
+++ b/Deepgram/Models/Auth/v1/GrantTokenSchema.cs
@@ -21,6 +21,6 @@ public record GrantTokenSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Common/v2/WebSocket/CloseResponse.cs
+++ b/Deepgram/Models/Common/v2/WebSocket/CloseResponse.cs
@@ -32,6 +32,6 @@ public record CloseResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Common/v2/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Common/v2/WebSocket/ErrorResponse.cs
@@ -56,6 +56,6 @@ public record ErrorResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Common/v2/WebSocket/OpenResponse.cs
+++ b/Deepgram/Models/Common/v2/WebSocket/OpenResponse.cs
@@ -32,6 +32,6 @@ public record OpenResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Common/v2/WebSocket/UnhandledResponse.cs
+++ b/Deepgram/Models/Common/v2/WebSocket/UnhandledResponse.cs
@@ -40,6 +40,6 @@ public record UnhandledResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/REST/AsyncResponse.cs
+++ b/Deepgram/Models/Flux/Speak/REST/AsyncResponse.cs
@@ -22,6 +22,6 @@ public record AsyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/REST/SpeakSchema.cs
+++ b/Deepgram/Models/Flux/Speak/REST/SpeakSchema.cs
@@ -93,6 +93,6 @@ public class SpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/REST/SyncResponse.cs
+++ b/Deepgram/Models/Flux/Speak/REST/SyncResponse.cs
@@ -77,6 +77,6 @@ public record SyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/REST/TextSource.cs
+++ b/Deepgram/Models/Flux/Speak/REST/TextSource.cs
@@ -22,6 +22,6 @@ public class TextSource(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/ConnectedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ConnectedResponse.cs
@@ -52,6 +52,6 @@ public record ConnectedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ControlMessage.cs
@@ -22,6 +22,6 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/ControlsApplied.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ControlsApplied.cs
@@ -31,6 +31,6 @@ public record ControlsApplied
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ErrorResponse.cs
@@ -38,6 +38,6 @@ public record ErrorResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/FlushedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/FlushedResponse.cs
@@ -31,6 +31,6 @@ public record FlushedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SessionMetadataResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SessionMetadataResponse.cs
@@ -44,6 +44,6 @@ public record SessionMetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeakMessage.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeakMessage.cs
@@ -30,6 +30,6 @@ public class SpeakMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeakSchema.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeakSchema.cs
@@ -59,6 +59,6 @@ public class SpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeechMetadataResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeechMetadataResponse.cs
@@ -59,6 +59,6 @@ public record SpeechMetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeechStartedResponse.cs
@@ -31,6 +31,6 @@ public record SpeechStartedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/WarningResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/WarningResponse.cs
@@ -39,6 +39,6 @@ public record WarningResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ConfigureFailureResponse.cs
+++ b/Deepgram/Models/Flux/WebSocket/ConfigureFailureResponse.cs
@@ -54,6 +54,6 @@ public record ConfigureFailureResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ConfigureSchema.cs
+++ b/Deepgram/Models/Flux/WebSocket/ConfigureSchema.cs
@@ -47,6 +47,6 @@ public class ConfigureSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ConfigureSuccessResponse.cs
+++ b/Deepgram/Models/Flux/WebSocket/ConfigureSuccessResponse.cs
@@ -62,6 +62,6 @@ public record ConfigureSuccessResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ConfigureThresholds.cs
+++ b/Deepgram/Models/Flux/WebSocket/ConfigureThresholds.cs
@@ -40,6 +40,6 @@ public record ConfigureThresholds
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ConnectedResponse.cs
+++ b/Deepgram/Models/Flux/WebSocket/ConnectedResponse.cs
@@ -37,6 +37,6 @@ public record ConnectedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Flux/WebSocket/ControlMessage.cs
@@ -23,6 +23,6 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Flux/WebSocket/ErrorResponse.cs
@@ -46,6 +46,6 @@ public record ErrorResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/FluxSchema.cs
+++ b/Deepgram/Models/Flux/WebSocket/FluxSchema.cs
@@ -106,6 +106,6 @@ public class FluxSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/TurnInfoResponse.cs
+++ b/Deepgram/Models/Flux/WebSocket/TurnInfoResponse.cs
@@ -123,6 +123,6 @@ public record TurnInfoResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Flux/WebSocket/Word.cs
+++ b/Deepgram/Models/Flux/WebSocket/Word.cs
@@ -44,6 +44,6 @@ public record Word
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Alternative.cs
+++ b/Deepgram/Models/Listen/v1/REST/Alternative.cs
@@ -72,6 +72,6 @@ public record Alternative
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/AsyncResponse.cs
+++ b/Deepgram/Models/Listen/v1/REST/AsyncResponse.cs
@@ -19,7 +19,7 @@ public record AsyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Average.cs
+++ b/Deepgram/Models/Listen/v1/REST/Average.cs
@@ -25,6 +25,6 @@ public record Average
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Channel.cs
+++ b/Deepgram/Models/Listen/v1/REST/Channel.cs
@@ -40,6 +40,6 @@ public record Channel
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Entity.cs
+++ b/Deepgram/Models/Listen/v1/REST/Entity.cs
@@ -47,6 +47,6 @@ public record Entity
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Hit.cs
+++ b/Deepgram/Models/Listen/v1/REST/Hit.cs
@@ -40,6 +40,6 @@ public record Hit
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Intent.cs
+++ b/Deepgram/Models/Listen/v1/REST/Intent.cs
@@ -25,7 +25,7 @@ public record Intent
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/IntentGroup.cs
+++ b/Deepgram/Models/Listen/v1/REST/IntentGroup.cs
@@ -19,6 +19,6 @@ public record IntentGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/IntentsInfo.cs
+++ b/Deepgram/Models/Listen/v1/REST/IntentsInfo.cs
@@ -32,7 +32,7 @@ public record IntentsInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Metadata.cs
+++ b/Deepgram/Models/Listen/v1/REST/Metadata.cs
@@ -112,6 +112,6 @@ public record Metadata
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/ModelInfo.cs
+++ b/Deepgram/Models/Listen/v1/REST/ModelInfo.cs
@@ -32,6 +32,6 @@ public record ModelInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Paragraph.cs
+++ b/Deepgram/Models/Listen/v1/REST/Paragraph.cs
@@ -60,7 +60,7 @@ public record Paragraph
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/ParagraphGroup.cs
+++ b/Deepgram/Models/Listen/v1/REST/ParagraphGroup.cs
@@ -25,7 +25,7 @@ public record ParagraphGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs
+++ b/Deepgram/Models/Listen/v1/REST/PreRecordedSchema.cs
@@ -334,6 +334,6 @@ public class PreRecordedSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Results.cs
+++ b/Deepgram/Models/Listen/v1/REST/Results.cs
@@ -53,7 +53,7 @@ public record Results
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Search.cs
+++ b/Deepgram/Models/Listen/v1/REST/Search.cs
@@ -25,7 +25,7 @@ public record Search
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Segment.cs
+++ b/Deepgram/Models/Listen/v1/REST/Segment.cs
@@ -60,6 +60,6 @@ public record Segment
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Sentence.cs
+++ b/Deepgram/Models/Listen/v1/REST/Sentence.cs
@@ -46,7 +46,7 @@ public record Sentence
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/SentimentGroup.cs
+++ b/Deepgram/Models/Listen/v1/REST/SentimentGroup.cs
@@ -25,7 +25,7 @@ public record SentimentGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/SentimentInfo.cs
+++ b/Deepgram/Models/Listen/v1/REST/SentimentInfo.cs
@@ -32,7 +32,7 @@ public record SentimentInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Summary.cs
+++ b/Deepgram/Models/Listen/v1/REST/Summary.cs
@@ -25,7 +25,7 @@ public record Summary // aka SummaryV2
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/SummaryInfo.cs
+++ b/Deepgram/Models/Listen/v1/REST/SummaryInfo.cs
@@ -32,6 +32,6 @@ public record SummaryInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/SummaryObsolete.cs
+++ b/Deepgram/Models/Listen/v1/REST/SummaryObsolete.cs
@@ -30,7 +30,7 @@ public record SummaryObsolete // aka SummaryV1
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/SyncResponse.cs
+++ b/Deepgram/Models/Listen/v1/REST/SyncResponse.cs
@@ -25,6 +25,6 @@ public record SyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/REST/Topic.cs
+++ b/Deepgram/Models/Listen/v1/REST/Topic.cs
@@ -25,7 +25,7 @@ public record Topic
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/TopicGroup.cs
+++ b/Deepgram/Models/Listen/v1/REST/TopicGroup.cs
@@ -18,7 +18,7 @@ public record TopicGroup
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/TopicsInfo.cs
+++ b/Deepgram/Models/Listen/v1/REST/TopicsInfo.cs
@@ -32,7 +32,7 @@ public record TopicsInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Translation.cs
+++ b/Deepgram/Models/Listen/v1/REST/Translation.cs
@@ -25,7 +25,7 @@ public record Translation
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/UrlSource.cs
+++ b/Deepgram/Models/Listen/v1/REST/UrlSource.cs
@@ -18,7 +18,7 @@ public class UrlSource(string url)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Utterance.cs
+++ b/Deepgram/Models/Listen/v1/REST/Utterance.cs
@@ -83,7 +83,7 @@ public record Utterance
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Warning.cs
+++ b/Deepgram/Models/Listen/v1/REST/Warning.cs
@@ -50,7 +50,7 @@ public record Warning
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/REST/Word.cs
+++ b/Deepgram/Models/Listen/v1/REST/Word.cs
@@ -82,7 +82,7 @@ public record Word
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/WebSocket/Alternative.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Alternative.cs
@@ -38,6 +38,6 @@ public record Alternative
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Average.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Average.cs
@@ -25,6 +25,6 @@ public record Average
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Channel.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Channel.cs
@@ -25,6 +25,6 @@ public record Channel
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/CloseResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/CloseResponse.cs
@@ -19,6 +19,6 @@ public record CloseResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/ErrorResponse.cs
@@ -40,6 +40,6 @@ public record ErrorResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Hit.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Hit.cs
@@ -40,6 +40,6 @@ public record Hit
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/LiveSchema.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/LiveSchema.cs
@@ -257,6 +257,6 @@ public class LiveSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Metadata.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Metadata.cs
@@ -41,6 +41,6 @@ public record MetaData
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/MetadataResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/MetadataResponse.cs
@@ -84,6 +84,6 @@ public record MetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/ModelInfo.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/ModelInfo.cs
@@ -32,6 +32,6 @@ public record ModelInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/OpenResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/OpenResponse.cs
@@ -19,6 +19,6 @@ public record OpenResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/ResultResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/ResultResponse.cs
@@ -81,6 +81,6 @@ public record ResultResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Search.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Search.cs
@@ -25,7 +25,7 @@ public record Search
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v1/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/SpeechStartedResponse.cs
@@ -33,6 +33,6 @@ public record SpeechStartedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/UnhandledResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/UnhandledResponse.cs
@@ -26,6 +26,6 @@ public record UnhandledResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/UtteranceEndResponse.cs
@@ -33,6 +33,6 @@ public record UtteranceEndResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v1/WebSocket/Word.cs
+++ b/Deepgram/Models/Listen/v1/WebSocket/Word.cs
@@ -60,6 +60,6 @@ public record Word
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Alternative.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Alternative.cs
@@ -38,6 +38,6 @@ public record Alternative
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Average.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Average.cs
@@ -25,6 +25,6 @@ public record Average
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Channel.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Channel.cs
@@ -25,6 +25,6 @@ public record Channel
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/ControlMessage.cs
@@ -18,7 +18,7 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v2/WebSocket/Hit.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Hit.cs
@@ -40,6 +40,6 @@ public record Hit
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/LiveSchema.cs
@@ -265,6 +265,6 @@ public class LiveSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Metadata.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Metadata.cs
@@ -41,6 +41,6 @@ public record MetaData
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/MetadataResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/MetadataResponse.cs
@@ -84,6 +84,6 @@ public record MetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/ModelInfo.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/ModelInfo.cs
@@ -32,6 +32,6 @@ public record ModelInfo
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/ResultResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/ResultResponse.cs
@@ -81,6 +81,6 @@ public record ResultResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Search.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Search.cs
@@ -25,7 +25,7 @@ public record Search
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Listen/v2/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/SpeechStartedResponse.cs
@@ -33,6 +33,6 @@ public record SpeechStartedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/UtteranceEndResponse.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/UtteranceEndResponse.cs
@@ -33,6 +33,6 @@ public record UtteranceEndResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Listen/v2/WebSocket/Word.cs
+++ b/Deepgram/Models/Listen/v2/WebSocket/Word.cs
@@ -60,6 +60,6 @@ public record Word
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/BalanceResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalanceResponse.cs
@@ -39,6 +39,6 @@ public record BalanceResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/BalancesResponse.cs
+++ b/Deepgram/Models/Manage/v1/BalancesResponse.cs
@@ -18,6 +18,6 @@ public record BalancesResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Callback.cs
+++ b/Deepgram/Models/Manage/v1/Callback.cs
@@ -32,6 +32,6 @@ public record Callback
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Config.cs
+++ b/Deepgram/Models/Manage/v1/Config.cs
@@ -126,6 +126,6 @@ public record Config
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Details.cs
+++ b/Deepgram/Models/Manage/v1/Details.cs
@@ -81,6 +81,6 @@ public record Details
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Invite.cs
+++ b/Deepgram/Models/Manage/v1/Invite.cs
@@ -25,6 +25,6 @@ public record Invite
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/InviteSchema.cs
+++ b/Deepgram/Models/Manage/v1/InviteSchema.cs
@@ -25,6 +25,6 @@ public class InviteSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/InvitesResponse.cs
+++ b/Deepgram/Models/Manage/v1/InvitesResponse.cs
@@ -18,6 +18,6 @@ public record InvitesResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Key.cs
+++ b/Deepgram/Models/Manage/v1/Key.cs
@@ -60,7 +60,7 @@ public record Key
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Manage/v1/KeyResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyResponse.cs
@@ -11,7 +11,7 @@ public record KeyResponse : Key
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Manage/v1/KeySchema.cs
+++ b/Deepgram/Models/Manage/v1/KeySchema.cs
@@ -47,6 +47,6 @@ public class KeySchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeyScopeResponse.cs
@@ -25,6 +25,6 @@ public record KeyScopeResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/KeysResponse.cs
+++ b/Deepgram/Models/Manage/v1/KeysResponse.cs
@@ -18,6 +18,6 @@ public record KeysResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Member.cs
+++ b/Deepgram/Models/Manage/v1/Member.cs
@@ -47,6 +47,6 @@ public record Member
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopeSchema.cs
@@ -18,6 +18,6 @@ public class MemberScopeSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
+++ b/Deepgram/Models/Manage/v1/MemberScopesResponse.cs
@@ -18,6 +18,6 @@ public record MemberScopesResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/MembersResponse.cs
+++ b/Deepgram/Models/Manage/v1/MembersResponse.cs
@@ -18,6 +18,6 @@ public record MembersResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/MessageResponse.cs
+++ b/Deepgram/Models/Manage/v1/MessageResponse.cs
@@ -18,6 +18,6 @@ public record MessageResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Model.cs
+++ b/Deepgram/Models/Manage/v1/Model.cs
@@ -39,7 +39,7 @@ public record Model
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Manage/v1/ModelSchema.cs
+++ b/Deepgram/Models/Manage/v1/ModelSchema.cs
@@ -18,6 +18,6 @@ public class ModelSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Project.cs
+++ b/Deepgram/Models/Manage/v1/Project.cs
@@ -32,6 +32,6 @@ public record Project
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/ProjectResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectResponse.cs
@@ -11,6 +11,6 @@ public record ProjectResponse : Project
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/ProjectSchema.cs
+++ b/Deepgram/Models/Manage/v1/ProjectSchema.cs
@@ -25,6 +25,6 @@ public class ProjectSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/ProjectsResponse.cs
+++ b/Deepgram/Models/Manage/v1/ProjectsResponse.cs
@@ -18,6 +18,6 @@ public record ProjectsResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Resolution.cs
+++ b/Deepgram/Models/Manage/v1/Resolution.cs
@@ -25,6 +25,6 @@ public record Resolution
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Response.cs
+++ b/Deepgram/Models/Manage/v1/Response.cs
@@ -39,6 +39,6 @@ public record Response
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/Result.cs
+++ b/Deepgram/Models/Manage/v1/Result.cs
@@ -53,7 +53,7 @@ public record Result
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Manage/v1/Token.cs
+++ b/Deepgram/Models/Manage/v1/Token.cs
@@ -25,6 +25,6 @@ public record Token
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/TokenDetails.cs
+++ b/Deepgram/Models/Manage/v1/TokenDetails.cs
@@ -39,6 +39,6 @@ public record TokenDetails
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsResponse.cs
@@ -47,6 +47,6 @@ public record UsageFieldsResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageFieldsSchema.cs
@@ -25,6 +25,6 @@ public class UsageFieldsSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequest.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequest.cs
@@ -68,6 +68,6 @@ public record UsageRequest
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestResponse.cs
@@ -11,6 +11,6 @@ public record UsageRequestResponse : UsageRequest
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsResponse.cs
@@ -32,6 +32,6 @@ public record UsageRequestsResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageRequestsSchema.cs
@@ -47,6 +47,6 @@ public class UsageRequestsSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummaryResponse.cs
@@ -39,6 +39,6 @@ public record UsageSummaryResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
+++ b/Deepgram/Models/Manage/v1/UsageSummarySchema.cs
@@ -218,6 +218,6 @@ public class UsageSummarySchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/CredentialResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialResponse.cs
@@ -25,6 +25,6 @@ public record CredentialResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/CredentialsResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialsResponse.cs
@@ -18,6 +18,6 @@ public record CredentialsResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/CredentialsSchema.cs
+++ b/Deepgram/Models/SelfHosted/v1/CredentialsSchema.cs
@@ -32,6 +32,6 @@ public class CredentialsSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/DistributionCredentials.cs
+++ b/Deepgram/Models/SelfHosted/v1/DistributionCredentials.cs
@@ -46,6 +46,6 @@ public record DistributionCredentials
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/Member.cs
+++ b/Deepgram/Models/SelfHosted/v1/Member.cs
@@ -25,6 +25,6 @@ public record Member
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/SelfHosted/v1/MessageResponse.cs
+++ b/Deepgram/Models/SelfHosted/v1/MessageResponse.cs
@@ -18,6 +18,6 @@ public record MessageResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/REST/AsyncResponse.cs
+++ b/Deepgram/Models/Speak/v1/REST/AsyncResponse.cs
@@ -19,7 +19,7 @@ public record AsyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v1/REST/SpeakSchema.cs
+++ b/Deepgram/Models/Speak/v1/REST/SpeakSchema.cs
@@ -69,6 +69,6 @@ public class SpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/REST/SyncResponse.cs
+++ b/Deepgram/Models/Speak/v1/REST/SyncResponse.cs
@@ -70,6 +70,6 @@ public record SyncResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/REST/TextSource.cs
+++ b/Deepgram/Models/Speak/v1/REST/TextSource.cs
@@ -18,7 +18,7 @@ public class TextSource(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v1/WebSocket/ClearedResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/ClearedResponse.cs
@@ -26,6 +26,6 @@ public record ClearedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/CloseResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/CloseResponse.cs
@@ -19,6 +19,6 @@ public record CloseResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/ControlMessage.cs
@@ -18,7 +18,7 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v1/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/ErrorResponse.cs
@@ -40,6 +40,6 @@ public record ErrorResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/FlushedResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/FlushedResponse.cs
@@ -26,6 +26,6 @@ public record FlushedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/MetadataResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/MetadataResponse.cs
@@ -26,6 +26,6 @@ public record MetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/OpenResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/OpenResponse.cs
@@ -19,6 +19,6 @@ public record OpenResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/SpeakSchema.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/SpeakSchema.cs
@@ -51,6 +51,6 @@ public class SpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/TextSource.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/TextSource.cs
@@ -25,7 +25,7 @@ public class TextSource(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v1/WebSocket/UnhandledResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/UnhandledResponse.cs
@@ -26,6 +26,6 @@ public record UnhandledResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v1/WebSocket/WarningResponse.cs
+++ b/Deepgram/Models/Speak/v1/WebSocket/WarningResponse.cs
@@ -40,6 +40,6 @@ public record WarningResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v2/WebSocket/ClearedResponse.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/ClearedResponse.cs
@@ -26,6 +26,6 @@ public record ClearedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v2/WebSocket/ControlMessage.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/ControlMessage.cs
@@ -18,7 +18,7 @@ public class ControlMessage(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v2/WebSocket/FlushedResponse.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/FlushedResponse.cs
@@ -26,6 +26,6 @@ public record FlushedResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v2/WebSocket/MetadataResponse.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/MetadataResponse.cs
@@ -26,6 +26,6 @@ public record MetadataResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v2/WebSocket/SpeakSchema.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/SpeakSchema.cs
@@ -51,6 +51,6 @@ public class SpeakSchema
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Models/Speak/v2/WebSocket/TextSource.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/TextSource.cs
@@ -25,7 +25,7 @@ public class TextSource(string text)
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }
 

--- a/Deepgram/Models/Speak/v2/WebSocket/WarningResponse.cs
+++ b/Deepgram/Models/Speak/v2/WebSocket/WarningResponse.cs
@@ -40,6 +40,6 @@ public record WarningResponse
     /// </summary>
     public override string ToString()
     {
-        return Regex.Unescape(JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions));
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
     }
 }

--- a/Deepgram/Utilities/JsonSerializeOptions.cs
+++ b/Deepgram/Utilities/JsonSerializeOptions.cs
@@ -2,12 +2,20 @@
 // Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 // SPDX-License-Identifier: MIT
 
+using System.Text.Encodings.Web;
+
 namespace Deepgram.Utilities;
 
 internal class JsonSerializeOptions
 {
     public static JsonSerializerOptions DefaultOptions => new(JsonSerializerDefaults.Web)
     {
-        WriteIndented = true
+        WriteIndented = true,
+        // Use the relaxed encoder so characters like '+', '&', '<', '>' and non-ASCII
+        // are emitted literally instead of as \uXXXX escapes. This keeps payloads readable
+        // while still producing valid JSON (quotes and backslashes remain escaped). It
+        // replaces the previous Regex.Unescape(...) hack that corrupted payloads containing
+        // quotation marks or backslashes. See issues #355, #393.
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
     };
 }


### PR DESCRIPTION
## Summary

Fixes four confirmed open issues across the WebSocket clients, in three logical commits:

| Issue | Problem | Fix |
|---|---|---|
| **#355 / #393** | Every model `ToString()` wrapped `JsonSerializer.Serialize(...)` in `Regex.Unescape(...)`, corrupting any payload containing quotation marks or backslashes → invalid JSON on the wire (server closed the socket, #355) and `JsonNode.Parse` threw while serializing Agent settings (#393). | Removed the `Regex.Unescape` hack across all 212 models and switched the shared serializer to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`. Happy-path ASCII output is byte-identical. |
| **#395** | The Agent client *and* the base `ProcessTextMessage` parsed the message `type` with `Enum.Parse`, which throws on any message type unknown to this SDK version. The Voice Agent server now emits `History`/`Warning`, so every one threw `ArgumentException`. | `Enum.TryParse` in both layers; unknown types route to the existing **Unhandled** event (tolerant-reader pattern). Known types still dispatch. |
| **#390** | Stopping a client while background loops ran — or a user `Stop()` overlapping the receive loop's server-close teardown — threw `NullReferenceException`/`ObjectDisposedException` and spammed logs. | Comprehensive teardown-race hardening (below), applied consistently across the base + Listen/Speak v1 & v2 + Agent clients. |

## Teardown hardening (#390)

- **Cancellation-token race:** loops snapshot the token via a teardown-safe `GetInternalCancellationToken()`; `Stop()`/`Dispose()` claim the source atomically with `Interlocked.Exchange`, cancel-before-dispose, dispose in a `finally`.
- **Socket race:** all post-`await` uses of `_clientWebSocket` go through a local snapshot so a concurrent `Dispose()` can't null it mid-use.
- **Concurrent `Stop()`:** `CloseOutputAsync` is serialized (v2, via `_mutexSend`) or guarded by a positive `Open`/`CloseReceived` state check, so two `Stop`s can't issue overlapping close frames.
- **Benign-teardown catch:** `Stop()` now treats `OperationCanceledException`, `ObjectDisposedException`, `WebSocketException` (and `InvalidOperationException` in v1) as an already-completed stop — matching the Flux client's own catch set.
- **`Dispose()`** uses `_sendChannel.Writer.TryComplete()` for idempotency under concurrent dispose.

**Net result:** no `NRE`/`ODE`/`WebSocketException`/`InvalidOperationException`/`OperationCanceledException` escapes any `Stop()` or `Dispose()` in any WebSocket client.

## Testing

- New `WebSocketSerializationTests` (quote/backslash/unicode round-trips), `AgentUnknownMessageTests` (`History`/`Warning` → Unhandled, known types still dispatch), `WebSocketTeardownRaceTests` (deterministic, offline: 300×8 concurrent teardowns + idempotency), and a gated live Speak WS test proving both the quoted-text fix and concurrent `Stop()`/`Dispose()`.
- **292/292 pass** on the .NET 8 baseline, including live tests exercised against a real API key. Verified stable across multiple full-suite runs and 20+ live concurrent-teardown runs.

## Notes for review

- The serializer encoder change (`UnsafeRelaxedJsonEscaping`) is global — it also affects REST request bodies. Verified valid JSON on all paths; correct for a JSON API client (the "Unsafe" label only disables HTML-context escaping).
- The teardown fixes touch the v1 Listen/Speak clients, which carry `[Obsolete]`/"frozen" banners. The changes are defensive teardown hardening only (no API or happy-path behavior change); flagging since "frozen" is an explicit marker.
- The fixes went through two independent concurrency-specialist review passes; several escaping paths surfaced by the **live** stress test (not static review) were closed as part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
