### PR TITLE
fix(websocket): flush buffered audio before Finalize (#358)

### DIFF
--- a/Deepgram.Tests/UnitTests/ClientTests/WebSocketFlushTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/WebSocketFlushTests.cs
@@ -1,0 +1,50 @@
+// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Abstractions.v2;
+using ListenV2 = Deepgram.Clients.Listen.v2.WebSocket;
+
+namespace Deepgram.Tests.UnitTests.ClientTests;
+
+public class WebSocketFlushTests
+{
+    [Test]
+    public void CreateFlushMarker_Should_Carry_The_Signal_And_No_Payload()
+    {
+        var tcs = new TaskCompletionSource<bool>();
+
+        var marker = WebSocketMessage.CreateFlushMarker(tcs);
+
+        using (new AssertionScope())
+        {
+            ((object?)marker.FlushSignal).Should().BeSameAs(tcs);
+            marker.Length.Should().Be(0);
+        }
+    }
+
+    [Test]
+    public void Normal_Message_Should_Not_Be_A_Flush_Marker()
+    {
+        var message = new WebSocketMessage(new byte[] { 1, 2, 3 }, System.Net.WebSockets.WebSocketMessageType.Binary);
+
+        using (new AssertionScope())
+        {
+            ((object?)message.FlushSignal).Should().BeNull();
+            message.Length.Should().Be(3);
+        }
+    }
+
+    [Test]
+    public async Task Flush_Should_Return_Immediately_When_Not_Connected()
+    {
+        var client = new ListenV2.Client("fake-key");
+
+        // Not connected: Flush must not enqueue-and-await forever; it returns right away.
+        var flush = client.Flush();
+        var completed = await Task.WhenAny(flush, Task.Delay(TimeSpan.FromSeconds(2)));
+
+        completed.Should().BeSameAs(flush, "Flush should short-circuit when the socket is not connected");
+        await flush; // observe any exception
+    }
+}

--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -279,10 +279,19 @@ public abstract class AbstractWebSocketClient : IDisposable
         var flushSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         EnqueueSendMessage(WebSocketMessage.CreateFlushMarker(flushSignal));
 
-        // Unblock if the connection is torn down before the marker is reached.
-        using (cts.Token.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false), flushSignal))
+        // Unblock if the connection is torn down before the marker is reached. Registering on an
+        // already-cancelled token runs the callback immediately; if the token was disposed by a
+        // concurrent teardown between the guard above and here, treat it as "connection gone".
+        try
         {
-            await flushSignal.Task.ConfigureAwait(false);
+            using (cts.Token.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false), flushSignal))
+            {
+                await flushSignal.Task.ConfigureAwait(false);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            Log.Debug("Flush", "Connection was torn down while flushing. Nothing to flush.");
         }
     }
 
@@ -712,6 +721,12 @@ public abstract class AbstractWebSocketClient : IDisposable
             if (_cancellationTokenSource != null)
             {
                 Log.Debug("Stop", "Disposing internal token...");
+                // Cancel before disposing (as Dispose() does): disposing alone does not run
+                // registered callbacks, which would leave a concurrent Flush() awaiter hung.
+                if (!_cancellationTokenSource.Token.IsCancellationRequested)
+                {
+                    _cancellationTokenSource.Cancel();
+                }
                 _cancellationTokenSource.Dispose();
                 _cancellationTokenSource = null;
             }
@@ -781,8 +796,10 @@ public abstract class AbstractWebSocketClient : IDisposable
     /// <summary>
     /// Handle channel options
     /// </summary> 
+    // SingleWriter is false: audio can be enqueued (SendBinary) concurrently with a flush marker
+    // (Flush/SendFinalize) from a different thread. A single background reader drains the queue.
     internal readonly Channel<WebSocketMessage> _sendChannel = System.Threading.Channels.Channel
-       .CreateUnbounded<WebSocketMessage>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = true, });
+       .CreateUnbounded<WebSocketMessage>(new UnboundedChannelOptions { SingleReader = true, SingleWriter = false, });
 
     internal void InvokeParallel<T>(EventHandler<T>? eventHandler, T e)
     {

--- a/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
+++ b/Deepgram/Abstractions/v2/AbstractWebSocketClient.cs
@@ -262,6 +262,31 @@ public abstract class AbstractWebSocketClient : IDisposable
     }
 
     /// <summary>
+    /// Waits until every message currently queued via <see cref="SendBinary"/> /
+    /// <see cref="SendMessage"/> has been written to the socket. Use this to guarantee buffered
+    /// audio has been flushed before sending a control message (for example Finalize or Close).
+    /// Returns immediately if the client is not connected.
+    /// </summary>
+    public async Task Flush()
+    {
+        var cts = _cancellationTokenSource;
+        if (!IsConnected() || cts == null)
+        {
+            Log.Debug("Flush", "WebSocket is not connected. Nothing to flush.");
+            return;
+        }
+
+        var flushSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        EnqueueSendMessage(WebSocketMessage.CreateFlushMarker(flushSignal));
+
+        // Unblock if the connection is torn down before the marker is reached.
+        using (cts.Token.Register(static state => ((TaskCompletionSource<bool>)state!).TrySetResult(false), flushSignal))
+        {
+            await flushSignal.Task.ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     /// This method sends a binary message over the WebSocket connection.
     /// </summary>
     /// <param name="data"></param>
@@ -381,6 +406,15 @@ public abstract class AbstractWebSocketClient : IDisposable
                 Log.Verbose("ProcessSendQueue", "Reading message off queue...");
                 while (_sendChannel.Reader.TryRead(out var message))
                 {
+                    // A flush marker carries no payload; reaching it in queue order means every
+                    // message enqueued before it has been sent, so just signal and move on.
+                    if (message.FlushSignal is not null)
+                    {
+                        Log.Verbose("ProcessSendQueue", "Reached flush marker; signaling flush.");
+                        message.FlushSignal.TrySetResult(true);
+                        continue;
+                    }
+
                     // TODO: Add logging for message capturing for possible playback
                     Log.Verbose("ProcessSendQueue", "Sending message...");
                     await _mutexSend.WaitAsync(_cancellationTokenSource.Token);
@@ -410,6 +444,15 @@ public abstract class AbstractWebSocketClient : IDisposable
             Log.Error("ProcessSendQueue", $"{ex.GetType()} thrown {ex.Message}");
             Log.Verbose("ProcessSendQueue", $"Exception: {ex}");
             Log.Verbose("AbstractWebSocketClient.ProcessSendQueue", "LEAVE");
+        }
+        finally
+        {
+            // The sender thread is stopping; unblock any callers awaiting a flush marker that
+            // will now never be reached, so Flush() cannot hang after a disconnect/teardown.
+            while (_sendChannel.Reader.TryRead(out var pending))
+            {
+                pending.FlushSignal?.TrySetResult(false);
+            }
         }
     }
 

--- a/Deepgram/Abstractions/v2/WebSocketMessage.cs
+++ b/Deepgram/Abstractions/v2/WebSocketMessage.cs
@@ -22,11 +22,33 @@ internal readonly struct WebSocketMessage
             Message = new ArraySegment<byte>(message, 0, message.Length);
         }
         MessageType = type;
+        FlushSignal = null;
     }
+
+    private WebSocketMessage(TaskCompletionSource<bool> flushSignal)
+    {
+        Message = new ArraySegment<byte>(Array.Empty<byte>());
+        MessageType = WebSocketMessageType.Binary;
+        FlushSignal = flushSignal;
+    }
+
+    /// <summary>
+    /// Creates a flush marker: a queue entry that carries no payload to send, and instead
+    /// completes <paramref name="flushSignal"/> once the sender thread reaches it — i.e. once
+    /// every message enqueued before it has been sent.
+    /// </summary>
+    public static WebSocketMessage CreateFlushMarker(TaskCompletionSource<bool> flushSignal) =>
+        new WebSocketMessage(flushSignal);
 
     public int Length => Message.Count;
 
     public ArraySegment<byte> Message { get; }
 
     public WebSocketMessageType MessageType { get; }
+
+    /// <summary>
+    /// When non-null, this entry is a flush marker rather than data to send. The sender thread
+    /// completes it in queue order instead of writing it to the socket.
+    /// </summary>
+    public TaskCompletionSource<bool>? FlushSignal { get; }
 }

--- a/Deepgram/Clients/Interfaces/v2/IListenWebSocketClient.cs
+++ b/Deepgram/Clients/Interfaces/v2/IListenWebSocketClient.cs
@@ -93,6 +93,13 @@ public interface IListenWebSocketClient
     public Task SendClose(bool nullByte = false, CancellationTokenSource? _cancellationToken = null);
 
     /// <summary>
+    /// Waits until every message queued via <see cref="Send"/> / <see cref="SendBinary"/> /
+    /// <see cref="SendMessage"/> has been written to the socket, so buffered audio is flushed
+    /// before a control message such as Finalize or Close. Returns immediately if not connected.
+    /// </summary>
+    public Task Flush();
+
+    /// <summary>
     /// Sends a binary message over the WebSocket connection.
     /// </summary>
     /// <param name="data">The data to be sent over the WebSocket.</param>

--- a/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
+++ b/Deepgram/Clients/Listen/v2/WebSocket/Client.cs
@@ -293,6 +293,11 @@ public class Client : AbstractWebSocketClient, IListenWebSocketClient
     /// </summary>
     public async Task SendFinalize()
     {
+        // Flush any buffered audio first so Finalize can't overtake audio still in the send
+        // queue (Finalize is sent immediately and would otherwise race ahead). See #358.
+        Log.Debug("SendFinalize", "Flushing buffered audio before Finalize...");
+        await Flush();
+
         Log.Debug("SendFinalize", "Sending Finalize Message Immediately...");
         ControlMessage message = new ControlMessage(Constants.Finalize);
         byte[] data = Encoding.ASCII.GetBytes(message.ToString());


### PR DESCRIPTION
## Problem

Reported in #358: `SendFinalize` uses the *immediate* send path, so it can overtake audio still buffered in the send queue. The server then finalizes before it has received all the audio, dropping the tail of the utterance.

## Fix

A **flush marker** through the existing send channel (which is FIFO, single-reader):

- `WebSocketMessage.CreateFlushMarker(tcs)` — a payload-less queue entry. When `ProcessSendQueue` reaches it *in order*, every message enqueued before it has already been written to the socket, so it just completes the `TaskCompletionSource` and moves on.
- **`Task Flush()`** on the WebSocket base client (and `IListenWebSocketClient`): enqueues a marker and awaits it. Returns immediately if not connected, and is unblocked if the connection tears down before the marker is reached (the sender thread drains and cancels pending markers on exit), so it can't hang.
- **`SendFinalize` (Listen v2)** now `await Flush()` before sending Finalize — buffered audio is guaranteed on the wire first.

This is the reporter's option 2 (a public flush) *and* fixes Finalize directly.

## Verification

- Unit tests: flush-marker shape, normal message is not a marker, and `Flush()` short-circuits when disconnected. Full suite **283/283** on the .NET 8 baseline.
- **Live**: streamed the sample WAV as raw linear16/44100/2ch, queued 379 chunks, then called `SendFinalize()` immediately. `Flush()` drained the queue, Finalize round-tripped, and a complete `from_finalize` transcript came back (“Yep. I said it before, and I’ll say it again. Life moves pretty fast…”, 28 words). Before this change, Finalize could have raced ahead of that audio.

## Compatibility note

`SendFinalize` now blocks until the send queue drains (the intended behavior). Adding `Flush()` to `IListenWebSocketClient` is source-breaking only for third parties who *implement* that interface themselves — not for SDK consumers.

Fixes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)