### PR TITLE
fix(http): migrate to Microsoft.Extensions.Http.Resilience on net8.0 (#359)

### DIFF
--- a/Deepgram/Deepgram.csproj
+++ b/Deepgram/Deepgram.csproj
@@ -64,10 +64,12 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.*" />     
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" /> 
      <PackageReference Include="System.Text.Json" Version="8.*" />
-    <PackageReference Include="System.Threading.Channels" Version="8.*" />   
+    <PackageReference Include="System.Threading.Channels" Version="8.*" />
+    <!-- Microsoft.Extensions.Http.Resilience does not support netstandard2.0, so this target
+         retains the Polly-based transient-error retry. See #359. -->
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.*" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
@@ -78,10 +80,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.*" />
-    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.Text.Json" Version="8.*" />
     <PackageReference Include="System.Threading.Channels" Version="8.*" />
+    <!-- Modern resilience stack (Polly v8) replacing the deprecated Polly.Extensions.Http. See #359. -->
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Deepgram/Factory/HttpClientFactory.cs
+++ b/Deepgram/Factory/HttpClientFactory.cs
@@ -3,6 +3,11 @@
 // SPDX-License-Identifier: MIT
 
 using Deepgram.Models.Authenticate.v1;
+#if NETSTANDARD2_0
+using Polly.Contrib.WaitAndRetry;
+#else
+using Microsoft.Extensions.Http.Resilience;
+#endif
 
 namespace Deepgram.Encapsulations;
 
@@ -19,9 +24,29 @@ internal class HttpClientFactory
         Log.Information("HttpClientFactory.Create", $"HttpClient ID: {httpId}");
 
         var services = new ServiceCollection();
+#if NETSTANDARD2_0
+        // Microsoft.Extensions.Http.Resilience does not support netstandard2.0, so this target
+        // keeps the Polly-based transient-error retry. See #359.
         services.AddHttpClient(httpId)
             .AddTransientHttpErrorPolicy(policyBuilder =>
             policyBuilder.WaitAndRetryAsync(Backoff.DecorrelatedJitterBackoffV2(TimeSpan.FromSeconds(1), 5)));
+#else
+        // Retry transient HTTP errors (5xx, 408, HttpRequestException) with exponential backoff +
+        // jitter. This is the Polly v8 equivalent of the previous AddTransientHttpErrorPolicy +
+        // DecorrelatedJitterBackoffV2(1s, 5) policy, now that Polly.Extensions.Http is deprecated.
+        // See #359.
+        services.AddHttpClient(httpId)
+            .AddResilienceHandler("deepgram-retry", builder =>
+            {
+                builder.AddRetry(new HttpRetryStrategyOptions
+                {
+                    MaxRetryAttempts = 5,
+                    BackoffType = DelayBackoffType.Exponential,
+                    UseJitter = true,
+                    Delay = TimeSpan.FromSeconds(1),
+                });
+            });
+#endif
         var sp = services.BuildServiceProvider();
 
         var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(httpId);

--- a/Deepgram/GlobalUsings.cs
+++ b/Deepgram/GlobalUsings.cs
@@ -16,4 +16,3 @@ global using Deepgram.Logger;
 global using Deepgram.Utilities;
 global using Microsoft.Extensions.DependencyInjection;
 global using Polly;
-global using Polly.Contrib.WaitAndRetry;


### PR DESCRIPTION
## Problem

#359: the SDK's HTTP retry uses `Polly.Extensions.Http` (pulled transitively via `Microsoft.Extensions.Http.Polly`), which has been unmaintained since 2019. The recommended replacement is [`Microsoft.Extensions.Http.Resilience`](https://www.nuget.org/packages/Microsoft.Extensions.Http.Resilience) (Polly v8).

## Constraint that shaped the fix

`Microsoft.Extensions.Http.Resilience` **does not support `netstandard2.0`** — it only restores via the .NET Framework fallback, which produces an assembly-version clash. The SDK still multi-targets `net8.0;netstandard2.0` for .NET Framework consumers, so a uniform swap isn't possible. The migration is therefore **per-TFM**:

- **net8.0** → `Microsoft.Extensions.Http.Resilience`:
  ```csharp
  .AddResilienceHandler("deepgram-retry", b => b.AddRetry(new HttpRetryStrategyOptions
  {
      MaxRetryAttempts = 5,
      BackoffType = DelayBackoffType.Exponential,
      UseJitter = true,
      Delay = TimeSpan.FromSeconds(1),
  }));
  ```
  This is the Polly v8 equivalent of the old `AddTransientHttpErrorPolicy` + `DecorrelatedJitterBackoffV2(1s, 5)` (same 5 attempts, exponential-with-jitter, same transient-error set: 5xx/408/`HttpRequestException`).
- **netstandard2.0** → retains the existing Polly-based retry, since there's no supported alternative on that target. The deprecated transitive dependency therefore remains **only** on the legacy target.

`Microsoft.Extensions.Http` is pinned to `8.0.1` on net8.0 to satisfy Resilience's assembly-version requirement.

## Verification

- Both TFMs build cleanly (no more NU1701 fallback warning). Full suite **280/280** on the .NET 8 baseline.
- **Live**: a real `TranscribeUrl` succeeds through the new net8.0 resilience handler (normal, non-retry path).

## Notes

- Per-TFM `PackageReference`s can't be added by `dotnet add package` (it can't target a conditional `ItemGroup`), so the csproj `ItemGroup`s were edited directly for this change.
- The issue also asks for **.NET 9 support** and bumping **all** packages; those are separate concerns and intentionally out of scope here. Happy to do .NET 9 as a follow-up.

Fixes #359

🤖 Generated with [Claude Code](https://claude.com/claude-code)