### PR TITLE
docs(agent): clarify multi-parameter function calls; deprecate vestigial models (#367)

### DIFF
--- a/Deepgram.Tests/UnitTests/ModelTests/AgentFunctionTests.cs
+++ b/Deepgram.Tests/UnitTests/ModelTests/AgentFunctionTests.cs
@@ -1,0 +1,48 @@
+// Copyright 2021-2024 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+using Deepgram.Models.Agent.v2.WebSocket;
+
+namespace Deepgram.Tests.UnitTests.ModelTests;
+
+public class AgentFunctionTests
+{
+    [Test]
+    public void Function_Parameters_Should_Support_Multiple_Named_Properties()
+    {
+        // Regression coverage for #367: a function definition must be able to declare more than
+        // one parameter, with arbitrary names, via the JSON-Schema dictionary on Parameters.
+        var function = new Function
+        {
+            Name = "get_weather",
+            Description = "Get the weather for a city on a date",
+            Parameters = new Dictionary<string, object>
+            {
+                ["type"] = "object",
+                ["properties"] = new Dictionary<string, object>
+                {
+                    ["city"] = new Dictionary<string, object> { ["type"] = "string", ["description"] = "City name" },
+                    ["date"] = new Dictionary<string, object> { ["type"] = "string", ["description"] = "ISO 8601 date" },
+                    ["units"] = new Dictionary<string, object> { ["type"] = "string", ["description"] = "metric or imperial" },
+                },
+                ["required"] = new List<string> { "city", "date" },
+            },
+        };
+
+        var json = JsonSerializer.Serialize(function);
+        using var doc = JsonDocument.Parse(json);
+        var properties = doc.RootElement.GetProperty("parameters").GetProperty("properties");
+
+        using (new AssertionScope())
+        {
+            properties.EnumerateObject().Select(p => p.Name)
+                .Should().BeEquivalentTo(new[] { "city", "date", "units" });
+            properties.GetProperty("city").GetProperty("type").GetString().Should().Be("string");
+            properties.GetProperty("units").GetProperty("description").GetString().Should().Be("metric or imperial");
+            doc.RootElement.GetProperty("parameters").GetProperty("required")
+                .EnumerateArray().Select(e => e.GetString())
+                .Should().BeEquivalentTo(new[] { "city", "date" });
+        }
+    }
+}

--- a/Deepgram/Models/Agent/v2/WebSocket/Item.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Item.cs
@@ -4,6 +4,12 @@
 
 namespace Deepgram.Models.Agent.v2.WebSocket;
 
+/// <summary>
+/// Vestigial type from an older function-parameter model. It is not used by <see cref="Function"/>,
+/// whose <c>Parameters</c> is a <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/> you
+/// populate with a JSON Schema (see #367). Kept only for source compatibility.
+/// </summary>
+[Obsolete("Function.Parameters is a Dictionary<string, object>; build a JSON Schema there with as many named properties as you need. See #367.")]
 public record Item
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/Deepgram/Models/Agent/v2/WebSocket/Properties.cs
+++ b/Deepgram/Models/Agent/v2/WebSocket/Properties.cs
@@ -4,11 +4,20 @@
 
 namespace Deepgram.Models.Agent.v2.WebSocket;
 
+/// <summary>
+/// Vestigial type from an older function-parameter model that only allowed a single hardcoded
+/// <c>item</c> property. It is not used by <see cref="Function"/>, whose <c>Parameters</c> is a
+/// <see cref="System.Collections.Generic.Dictionary{TKey,TValue}"/> you populate with a JSON Schema
+/// containing as many named properties as you need (see #367). Kept only for source compatibility.
+/// </summary>
+[Obsolete("Function.Parameters is a Dictionary<string, object>; build a JSON Schema there with as many named properties as you need. See #367.")]
 public record Properties
 {
+#pragma warning disable CS0618 // Item is obsolete; this vestigial type still references it.
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("item")]
     public Item? Item { get; set; }
+#pragma warning restore CS0618
 
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -505,6 +505,31 @@ For a complete implementation, you would need to:
 3. Handle any function calls if your agent uses them
 4. Add proper error handling and connection management
 
+### Defining function-call parameters
+
+`Function.Parameters` is a JSON Schema expressed as a `Dictionary<string, object>`, so a function
+can declare **any number of parameters** with custom names — set `properties` to a dictionary keyed
+by each parameter name:
+
+```csharp
+var function = new Function
+{
+    Name = "get_weather",
+    Description = "Get the weather for a city on a date",
+    Parameters = new Dictionary<string, object>
+    {
+        ["type"] = "object",
+        ["properties"] = new Dictionary<string, object>
+        {
+            ["city"]  = new Dictionary<string, object> { ["type"] = "string", ["description"] = "City name" },
+            ["date"]  = new Dictionary<string, object> { ["type"] = "string", ["description"] = "ISO 8601 date" },
+            ["units"] = new Dictionary<string, object> { ["type"] = "string", ["description"] = "metric or imperial" },
+        },
+        ["required"] = new List<string> { "city", "date" },
+    },
+};
+```
+
 ## Text to Speech REST
 
 Convert text into speech using the REST API.


### PR DESCRIPTION
## Problem

#367: the reporter couldn't declare a function with multiple / custom-named parameters — the model seemed to allow only a single hardcoded `item`. (The linked example 404s, and a commenter confirmed the dead link.)

## Findings (reproduced)

The report was against an older function-parameter model (`Parameters` → `Properties` → `Item`). In the **current v2 model**, `Function.Parameters` is already a `Dictionary<string, object>` — i.e. a free-form JSON Schema — so a function can declare **any number of custom-named parameters** today. I verified by serializing a 3-parameter function:

```json
"parameters": {
  "type": "object",
  "properties": {
    "city":  { "type": "string", "description": "City name" },
    "date":  { "type": "string", "description": "ISO 8601 date" },
    "units": { "type": "string", "description": "metric or imperial" }
  },
  "required": ["city", "date"]
}
```

So the reported limitation no longer exists — but two things kept it confusing, which this PR fixes.

## Changes

1. **README** — a snippet under *Voice Agent* showing how to define multiple named parameters via the `Parameters` dictionary (there was no example of setting function parameters anywhere).
2. **Regression test** — asserts a multi-parameter function serializes to the expected JSON Schema.
3. **Deprecate the vestigial `Properties` and `Item` records** — they're unused (they can't even be assigned to `Function.Parameters`) and were the source of the confusion. Marked `[Obsolete]` with a message pointing to the dictionary, rather than removed, to preserve source compatibility.

## Verification

Full suite **281/281** on the .NET 8 baseline; the multi-parameter serialization is covered by the new test.

Fixes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)