### PR TITLE
feat(flux-tts): GA controls — Interrupt barge-in, Configure speed, speed/expressivity params

### DIFF
--- a/Deepgram.Tests/Fixtures/FluxSpeak/frames-ga.json
+++ b/Deepgram.Tests/Fixtures/FluxSpeak/frames-ga.json
@@ -1,0 +1,10 @@
+{
+  "_provenance": "Hand-authored from developers.deepgram.com/reference/text-to-speech/speak-flux, 2026-08-13 [verify: replace with a staging/production capture when available]. Unlike frames.json (a verbatim capture of the EA Speak/Flush/Close surface), this fixture exercises the GA-only additions: Configure/ConfigureSuccess and Interrupt/SpeechInterrupted. The sequence models a client that connects, adjusts speed mid-session, starts a turn, and barges in on itself before the turn completes.",
+  "frames": [
+    { "type": "Connected", "request_id": "550e8400-e29b-41d4-a716-446655440000", "model_name": "flux-alexis-en", "model_version": "2026.06.01", "model_uuids": ["b3e47c20-9f81-4a2e-bd15-8d7c6e2a1f09"] },
+    { "type": "ConfigureSuccess", "applied": { "speed": 1.05 } },
+    { "type": "SpeechStarted", "speech_id": "dg_sp_a1b2c3d4e5f6" },
+    { "type": "SpeechInterrupted", "audio_played_ms": 2340, "text_spoken": "Sure, I can help you cancel your subscription.", "text_remaining": " Let me pull up your account.", "metadata": { "speech_id": "dg_sp_a1b2c3d4e5f6", "audio_duration_ms": 2340, "input_character_count": 75, "billable_character_count": 75, "controls_applied": { "pronunciations_applied": 0, "breaks_applied": 0, "pronunciation_warnings": 0 } } },
+    { "type": "SessionMetadata", "total_audio_duration_ms": 2340, "total_input_character_count": 75, "total_billable_character_count": 75 }
+  ]
+}

--- a/Deepgram.Tests/Fixtures/FluxSpeak/frames-ga.json
+++ b/Deepgram.Tests/Fixtures/FluxSpeak/frames-ga.json
@@ -1,10 +1,11 @@
 {
-  "_provenance": "Hand-authored from developers.deepgram.com/reference/text-to-speech/speak-flux, 2026-08-13 [verify: replace with a staging/production capture when available]. Unlike frames.json (a verbatim capture of the EA Speak/Flush/Close surface), this fixture exercises the GA-only additions: Configure/ConfigureSuccess and Interrupt/SpeechInterrupted. The sequence models a client that connects, adjusts speed mid-session, starts a turn, and barges in on itself before the turn completes.",
+  "_provenance": "Verbatim JSON control frames captured 2026-08-13 from the live wss://api.deepgram.com/v2/speak?model=flux-alexis-en&encoding=linear16&sample_rate=24000 endpoint (client sent Configure -> Speak -> Interrupt -> Close). Captured via a standalone raw-WebSocket script independent of the SDK's own parser (see the Flux TTS GA delta PR). Exercises the GA-only additions: Configure/ConfigureSuccess and Interrupt/SpeechInterrupted.",
+  "audio_total_bytes": 30432,
   "frames": [
-    { "type": "Connected", "request_id": "550e8400-e29b-41d4-a716-446655440000", "model_name": "flux-alexis-en", "model_version": "2026.06.01", "model_uuids": ["b3e47c20-9f81-4a2e-bd15-8d7c6e2a1f09"] },
-    { "type": "ConfigureSuccess", "applied": { "speed": 1.05 } },
-    { "type": "SpeechStarted", "speech_id": "dg_sp_a1b2c3d4e5f6" },
-    { "type": "SpeechInterrupted", "audio_played_ms": 2340, "text_spoken": "Sure, I can help you cancel your subscription.", "text_remaining": " Let me pull up your account.", "metadata": { "speech_id": "dg_sp_a1b2c3d4e5f6", "audio_duration_ms": 2340, "input_character_count": 75, "billable_character_count": 75, "controls_applied": { "pronunciations_applied": 0, "breaks_applied": 0, "pronunciation_warnings": 0 } } },
-    { "type": "SessionMetadata", "total_audio_duration_ms": 2340, "total_input_character_count": 75, "total_billable_character_count": 75 }
+    {"type":"Connected","request_id":"019ffcda-bebd-7273-a625-66fa54f1f101","model_name":"alexis","model_version":"2026-08-11.0","model_uuids":["9c3cc12c-c0a2-4966-8676-f9fa22ab5401","9c3cc12c-c0a2-4966-8676-f9fa22ab5401"]},
+    {"type":"ConfigureSuccess","applied":{"speed":1.05}},
+    {"type":"SpeechStarted","speech_id":"dg_sp_c78f63c65fa2"},
+    {"type":"SpeechInterrupted","audio_played_ms":554,"text_spoken":"Sure,","text_remaining":" I can help you cancel your subscription. Let me pull up your account and check on that for you right away.","metadata":{"speech_id":"dg_sp_c78f63c65fa2","audio_duration_ms":554,"input_character_count":112,"billable_character_count":46,"controls_applied":{"pronunciations_applied":0,"breaks_applied":0,"pronunciation_warnings":0}}},
+    {"type":"SessionMetadata","total_audio_duration_ms":554,"total_input_character_count":46,"total_billable_character_count":46}
   ]
 }

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakClientTests.cs
@@ -170,6 +170,39 @@ public class FluxSpeakClientTests
 
         query.Should().Be("model=flux-alexis-en");
     }
+
+    [Test]
+    public void BuildQueryString_Should_Format_Speed_And_Expressivity_Under_Comma_Decimal_Culture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var schema = new SpeakSchema { Model = "flux-alexis-en", Speed = 1.05, Expressivity = -2 };
+
+            var query = Client.BuildQueryString(schema);
+
+            query.Should().Contain("speed=1.05");
+            query.Should().Contain("expressivity=-2");
+            query.Should().NotContain("1,05");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Test]
+    public void BuildQueryString_Should_Omit_Speed_And_Expressivity_When_Null()
+    {
+        var schema = new SpeakSchema { Model = "flux-alexis-en" };
+
+        var query = Client.BuildQueryString(schema);
+
+        query.Should().NotContain("speed=");
+        query.Should().NotContain("expressivity=");
+    }
     #endregion
 
     #region Client -> server message serialization
@@ -210,6 +243,77 @@ public class FluxSpeakClientTests
     }
 
     [Test]
+    public void InterruptSchema_Bare_Should_Serialize_To_Type_Only_Json()
+    {
+        var interrupt = new InterruptSchema();
+
+        using var doc = JsonDocument.Parse(interrupt.ToString());
+
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Interrupt");
+        // The server rejects unknown fields on Interrupt; a bare interrupt must carry no extra keys.
+        doc.RootElement.EnumerateObject().Count().Should().Be(1);
+    }
+
+    [Test]
+    public void InterruptSchema_With_PlaybackOffset_Should_Serialize_Nested_Object()
+    {
+        var interrupt = new InterruptSchema { PlaybackOffset = new PlaybackOffset(1500) };
+
+        using var doc = JsonDocument.Parse(interrupt.ToString());
+
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Interrupt");
+        var offset = doc.RootElement.GetProperty("playback_offset");
+        offset.GetProperty("type").GetString().Should().Be("time_ms");
+        offset.GetProperty("value").GetInt64().Should().Be(1500);
+    }
+
+    [Test]
+    public void ConfigureSchema_Should_Serialize_Speed()
+    {
+        var configure = new ConfigureSchema { Speed = 1.05 };
+
+        using var doc = JsonDocument.Parse(configure.ToString());
+
+        doc.RootElement.GetProperty("type").GetString().Should().Be("Configure");
+        doc.RootElement.GetProperty("speed").GetDouble().Should().Be(1.05);
+        doc.RootElement.EnumerateObject().Count().Should().Be(2);
+    }
+
+    [Test]
+    public void ConfigureSchema_Should_Serialize_Speed_Under_Comma_Decimal_Culture()
+    {
+        var originalCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
+
+            var configure = new ConfigureSchema { Speed = 1.05 };
+
+            using var doc = JsonDocument.Parse(configure.ToString());
+
+            doc.RootElement.GetProperty("speed").GetDouble().Should().Be(1.05);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
+    }
+
+    [Test]
+    public void ConfigureSchema_With_OutOfRange_Speed_Should_Serialize_Without_Throwing()
+    {
+        // Pins "no local range-check": the SDK sends whatever is set and lets the server reject it
+        // via ConfigureFailure (e.g. SPEED_OUT_OF_RANGE).
+        var configure = new ConfigureSchema { Speed = 9.0 };
+
+        var act = () => configure.ToString();
+
+        act.Should().NotThrow();
+        using var doc = JsonDocument.Parse(configure.ToString());
+        doc.RootElement.GetProperty("speed").GetDouble().Should().Be(9.0);
+    }
+
+    [Test]
     public async Task SendText_Should_Send_Speak_Message()
     {
         var client = Substitute.For<Client>(_apiKey, _options);
@@ -234,6 +338,57 @@ public class FluxSpeakClientTests
     }
 
     [Test]
+    public async Task SendInterrupt_Bare_Should_Send_Interrupt_Message()
+    {
+        var client = Substitute.For<Client>(_apiKey, _options);
+        client.When(x => x.SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>()))
+              .DoNotCallBase();
+
+        await client.SendInterrupt();
+
+        await client.Received(1).SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>());
+    }
+
+    [Test]
+    public async Task SendInterrupt_With_PlaybackOffsetMs_Overload_Should_Produce_Same_Frame_As_Explicit_Schema()
+    {
+        byte[]? viaOverload = null;
+        byte[]? viaSchema = null;
+
+        var client = Substitute.For<Client>(_apiKey, _options);
+        client.When(x => x.SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>()))
+              .Do(call => viaOverload = call.Arg<byte[]>());
+        await client.SendInterrupt(1500L);
+
+        var client2 = Substitute.For<Client>(_apiKey, _options);
+        client2.When(x => x.SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>()))
+              .Do(call => viaSchema = call.Arg<byte[]>());
+        await client2.SendInterrupt(new InterruptSchema { PlaybackOffset = new PlaybackOffset(1500) });
+
+        Encoding.UTF8.GetString(viaOverload!).Should().Be(Encoding.UTF8.GetString(viaSchema!));
+    }
+
+    [Test]
+    public async Task SendConfigure_Should_Send_Configure_Message()
+    {
+        var client = Substitute.For<Client>(_apiKey, _options);
+        client.When(x => x.SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>()))
+              .DoNotCallBase();
+
+        await client.SendConfigure(new ConfigureSchema { Speed = 1.05 });
+
+        await client.Received(1).SendMessageImmediately(Arg.Any<byte[]>(), Arg.Any<int>(), Arg.Any<CancellationTokenSource>());
+    }
+
+    [Test]
+    public void SendConfigure_With_Null_Should_Throw_ArgumentNullException()
+    {
+        var client = new FluxSpeakWebSocketClient(_apiKey, _options);
+
+        Assert.ThrowsAsync<ArgumentNullException>(async () => await client.SendConfigure(null!));
+    }
+
+    [Test]
     public void SendText_With_Null_Should_Throw_ArgumentNullException()
     {
         var client = new FluxSpeakWebSocketClient(_apiKey, _options);
@@ -247,6 +402,19 @@ public class FluxSpeakClientTests
         var client = new FluxSpeakWebSocketClient(_apiKey, _options);
 
         await client.SendClose();
+    }
+
+    [Test]
+    public async Task SendInterrupt_And_SendConfigure_When_Not_Connected_Should_Not_Throw()
+    {
+        // Mirrors SendFlush/SendClose: SendMessageImmediately no-ops (logs and returns) when the
+        // socket is not connected, rather than throwing. SendInterrupt/SendConfigure must behave
+        // identically - no bespoke pre-connect validation was introduced for the GA additions.
+        var client = new FluxSpeakWebSocketClient(_apiKey, _options);
+
+        await client.SendInterrupt();
+        await client.SendInterrupt(1000L);
+        await client.SendConfigure(new ConfigureSchema { Speed = 1.0 });
     }
     #endregion
 
@@ -316,6 +484,141 @@ public class FluxSpeakClientTests
             response.ControlsApplied!.PronunciationsApplied.Should().Be(0);
             response.ControlsApplied.PronunciationWarnings.Should().Be(0);
         }
+    }
+
+    [Test]
+    public void SpeechMetadataResponse_Should_Deserialize_BreaksApplied_When_Present()
+    {
+        var json = """
+        {
+            "type": "SpeechMetadata",
+            "speech_id": "s",
+            "controls_applied": { "pronunciations_applied": 2, "pronunciation_warnings": 0, "breaks_applied": 1 }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<SpeechMetadataResponse>(json);
+
+        response!.ControlsApplied!.BreaksApplied.Should().Be(1);
+    }
+
+    [Test]
+    public void SpeechMetadataResponse_Should_Tolerate_Missing_BreaksApplied()
+    {
+        // Older (EA-era) frames omit breaks_applied entirely; it must parse as null, not throw.
+        var json = """
+        {
+            "type": "SpeechMetadata",
+            "speech_id": "s",
+            "controls_applied": { "pronunciations_applied": 0, "pronunciation_warnings": 0 }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<SpeechMetadataResponse>(json);
+
+        response!.ControlsApplied!.BreaksApplied.Should().BeNull();
+    }
+
+    [Test]
+    public void SpeechInterruptedResponse_Should_Deserialize_With_Offset_And_Text_Split()
+    {
+        var json = """
+        {
+            "type": "SpeechInterrupted",
+            "audio_played_ms": 2340,
+            "text_spoken": "Sure, I can help you cancel your subscription.",
+            "text_remaining": " Let me pull up your account.",
+            "metadata": {
+                "speech_id": "dg_sp_a1b2c3d4e5f6",
+                "audio_duration_ms": 2340,
+                "input_character_count": 75,
+                "billable_character_count": 75,
+                "controls_applied": { "pronunciations_applied": 0, "pronunciation_warnings": 0, "breaks_applied": 0 }
+            }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<SpeechInterruptedResponse>(json);
+
+        using (new AssertionScope())
+        {
+            response!.Type.Should().Be(SpeakType.SpeechInterrupted);
+            response.AudioPlayedMs.Should().Be(2340);
+            response.TextSpoken.Should().Be("Sure, I can help you cancel your subscription.");
+            response.TextRemaining.Should().Be(" Let me pull up your account.");
+            response.Metadata.Should().NotBeNull();
+            response.Metadata!.SpeechId.Should().Be("dg_sp_a1b2c3d4e5f6");
+            response.Metadata.ControlsApplied!.BreaksApplied.Should().Be(0);
+        }
+    }
+
+    [Test]
+    public void SpeechInterruptedResponse_Without_PlaybackOffset_Should_Omit_Text_Split()
+    {
+        // When the Interrupt carried no playback_offset, the server cannot compute the split.
+        var json = """
+        {
+            "type": "SpeechInterrupted",
+            "audio_played_ms": 4000,
+            "metadata": { "speech_id": "s", "audio_duration_ms": 4000 }
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<SpeechInterruptedResponse>(json);
+
+        using (new AssertionScope())
+        {
+            response!.TextSpoken.Should().BeNull();
+            response.TextRemaining.Should().BeNull();
+            response.AudioPlayedMs.Should().Be(4000);
+        }
+    }
+
+    [Test]
+    public void ConfigureSuccessResponse_Should_Deserialize_Applied_Speed()
+    {
+        var response = JsonSerializer.Deserialize<ConfigureSuccessResponse>(
+            """{ "type": "ConfigureSuccess", "applied": { "speed": 1.05 } }""");
+
+        using (new AssertionScope())
+        {
+            response!.Type.Should().Be(SpeakType.ConfigureSuccess);
+            response.Applied!.Speed.Should().Be(1.05);
+        }
+    }
+
+    [Test]
+    public void ConfigureFailureResponse_Should_Deserialize_Known_Shape()
+    {
+        var json = """
+        {
+            "type": "ConfigureFailure",
+            "code": "SPEED_OUT_OF_RANGE",
+            "description": "speed must be between 0.85 and 1.15 in 0.05 increments",
+            "field": "speed",
+            "value": 3.5
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize<ConfigureFailureResponse>(json);
+
+        using (new AssertionScope())
+        {
+            response!.Type.Should().Be(SpeakType.ConfigureFailure);
+            response.Code.Should().Be("SPEED_OUT_OF_RANGE");
+            response.Field.Should().Be("speed");
+            response.Value!.Value.GetDouble().Should().Be(3.5);
+        }
+    }
+
+    [Test]
+    public void ConfigureFailureResponse_Should_Tolerate_Unknown_Future_Code()
+    {
+        // Code is an open set - a code the SDK has never seen must still parse cleanly.
+        var response = JsonSerializer.Deserialize<ConfigureFailureResponse>(
+            """{ "type": "ConfigureFailure", "code": "SOME-FUTURE-CODE", "description": "d" }""");
+
+        response!.Code.Should().Be("SOME-FUTURE-CODE");
     }
 
     [Test]
@@ -458,6 +761,24 @@ public class FluxSpeakClientTests
     }
 
     [Test]
+    public async Task ProcessTextMessage_Should_Raise_SpeechInterrupted_Event()
+    {
+        var client = new FluxSpeakWebSocketClient(_apiKey, _options);
+        SpeechInterruptedResponse? received = null;
+        await client.Subscribe(new EventHandler<SpeechInterruptedResponse>((sender, e) => received = e));
+
+        client.ProcessTextMessage(_webSocketReceiveResult, ToStream(
+            """{ "type": "SpeechInterrupted", "audio_played_ms": 1200, "text_spoken": "Hello there", "text_remaining": "how are you?" }"""));
+
+        using (new AssertionScope())
+        {
+            received.Should().NotBeNull();
+            received!.AudioPlayedMs.Should().Be(1200);
+            received.TextSpoken.Should().Be("Hello there");
+        }
+    }
+
+    [Test]
     public async Task ProcessTextMessage_Should_Raise_Flushed_Event()
     {
         var client = new FluxSpeakWebSocketClient(_apiKey, _options);
@@ -497,6 +818,42 @@ public class FluxSpeakClientTests
 
         received.Should().NotBeNull();
         received!.Code.Should().Be("NO_ACTIVE_SPEECH");
+    }
+
+    [Test]
+    public async Task ProcessTextMessage_Should_Raise_ConfigureSuccess_Event()
+    {
+        var client = new FluxSpeakWebSocketClient(_apiKey, _options);
+        ConfigureSuccessResponse? received = null;
+        await client.Subscribe(new EventHandler<ConfigureSuccessResponse>((sender, e) => received = e));
+
+        client.ProcessTextMessage(_webSocketReceiveResult, ToStream(
+            """{ "type": "ConfigureSuccess", "applied": { "speed": 1.1 } }"""));
+
+        received.Should().NotBeNull();
+        received!.Applied!.Speed.Should().Be(1.1);
+    }
+
+    [Test]
+    public async Task ProcessTextMessage_Should_Raise_ConfigureFailure_Event_Not_Error_Event()
+    {
+        // ConfigureFailure is non-fatal (like Warning) and must never route to the fatal Error
+        // handler.
+        var client = new FluxSpeakWebSocketClient(_apiKey, _options);
+        ConfigureFailureResponse? failure = null;
+        ErrorResponse? error = null;
+        await client.Subscribe(new EventHandler<ConfigureFailureResponse>((sender, e) => failure = e));
+        await client.Subscribe(new EventHandler<ErrorResponse>((sender, e) => error = e));
+
+        client.ProcessTextMessage(_webSocketReceiveResult, ToStream(
+            """{ "type": "ConfigureFailure", "code": "SPEED_OUT_OF_RANGE", "description": "d", "field": "speed", "value": 9.0 }"""));
+
+        using (new AssertionScope())
+        {
+            failure.Should().NotBeNull();
+            failure!.Code.Should().Be("SPEED_OUT_OF_RANGE");
+            error.Should().BeNull("ConfigureFailure is non-fatal and must not route to the Error event");
+        }
     }
 
     [Test]
@@ -589,9 +946,12 @@ public class FluxSpeakClientTests
             """{ "type": "Connected", "request_id": "r", "model_name": "m", "model_version": "v", "model_uuids": [] }""",
             """{ "type": "SpeechStarted", "speech_id": "s" }""",
             """{ "type": "SpeechMetadata", "speech_id": "s" }""",
+            """{ "type": "SpeechInterrupted", "audio_played_ms": 1 }""",
             """{ "type": "Flushed", "speech_id": "s" }""",
             """{ "type": "SessionMetadata" }""",
             """{ "type": "Warning", "code": "X", "description": "y" }""",
+            """{ "type": "ConfigureSuccess", "applied": { "speed": 1.0 } }""",
+            """{ "type": "ConfigureFailure", "code": "X", "description": "y" }""",
             """{ "type": "Error", "code": "X", "description": "y" }""",
             """{ "type": "SomethingElse" }""",
             """{ "no_type": true }""",
@@ -632,27 +992,30 @@ public class FluxSpeakClientTests
     }
     #endregion
 
-    #region EA surface guarantees
+    #region GA surface guarantees
     [Test]
-    public void FluxSpeakClient_Should_Not_Expose_GA_Only_Or_V1_Members()
+    public void FluxSpeakClient_Should_Expose_GA_Members_But_Not_V1_Members()
     {
-        // KeepAlive/Finalize are v1-only; Interrupt/Configure/speed are GA-only. None are part of
-        // the EA text-to-speech surface.
+        // KeepAlive/Finalize are v1 (classic Speak)-only and never apply to Flux TTS.
+        // Interrupt/Configure/speed/expressivity are the GA additions this client must expose.
         using (new AssertionScope())
         {
             typeof(Client).GetMethod("SendKeepAlive").Should().BeNull();
             typeof(Client).GetMethod("SendFinalize").Should().BeNull();
-            typeof(Client).GetMethod("SendInterrupt").Should().BeNull();
-            typeof(Client).GetMethod("SendConfigure").Should().BeNull();
+            typeof(Client).GetMethod("SendInterrupt", new[] { typeof(InterruptSchema) }).Should().NotBeNull();
+            typeof(Client).GetMethod("SendInterrupt", new[] { typeof(long) }).Should().NotBeNull();
+            typeof(Client).GetMethod("SendConfigure").Should().NotBeNull();
 
             var iface = typeof(Deepgram.Clients.Interfaces.v2.IFluxSpeakWebSocketClient);
             iface.GetMethod("SendKeepAlive").Should().BeNull();
             iface.GetMethod("SendFinalize").Should().BeNull();
-            iface.GetMethod("SendInterrupt").Should().BeNull();
-            iface.GetMethod("SendConfigure").Should().BeNull();
+            iface.GetMethod("SendInterrupt", new[] { typeof(InterruptSchema) }).Should().NotBeNull();
+            iface.GetMethod("SendInterrupt", new[] { typeof(long) }).Should().NotBeNull();
+            iface.GetMethod("SendConfigure").Should().NotBeNull();
 
-            // No speed parameter on the streaming schema.
-            typeof(SpeakSchema).GetProperty("Speed").Should().BeNull();
+            // speed/expressivity are on the streaming schema.
+            typeof(SpeakSchema).GetProperty("Speed").Should().NotBeNull();
+            typeof(SpeakSchema).GetProperty("Expressivity").Should().NotBeNull();
         }
     }
 
@@ -776,7 +1139,15 @@ public class FluxSpeakClientTests
         var session = new SessionMetadataResponse { TotalAudioDurationMs = 1, TotalInputCharacterCount = 2, TotalBillableCharacterCount = 3 };
         var warning = new WarningResponse { Code = "X", Description = "y" };
         var error = new ErrorResponse { Code = "MESSAGE-0000", Description = "z" };
-        var schema = new SpeakSchema { Model = "flux-alexis-en", Encoding = "linear16", SampleRate = 44100, Tag = new List<string> { "a" } };
+        var schema = new SpeakSchema { Model = "flux-alexis-en", Encoding = "linear16", SampleRate = 44100, Speed = 1.05, Expressivity = 1, Tag = new List<string> { "a" } };
+        var speechInterrupted = new SpeechInterruptedResponse
+        {
+            AudioPlayedMs = 1200,
+            TextSpoken = "Hello there",
+            Metadata = new SpeechInterruptedMetadata { SpeechId = "s", ControlsApplied = new ControlsApplied { BreaksApplied = 1 } },
+        };
+        var configureSuccess = new ConfigureSuccessResponse { Applied = new ConfigureApplied { Speed = 1.1 } };
+        var configureFailure = new ConfigureFailureResponse { Code = "SPEED_OUT_OF_RANGE", Field = "speed" };
 
         using (new AssertionScope())
         {
@@ -787,6 +1158,10 @@ public class FluxSpeakClientTests
             JsonSerializer.Deserialize<WarningResponse>(warning.ToString())!.Code.Should().Be("X");
             JsonSerializer.Deserialize<ErrorResponse>(error.ToString())!.Code.Should().Be("MESSAGE-0000");
             JsonSerializer.Deserialize<SpeakSchema>(schema.ToString())!.SampleRate.Should().Be(44100);
+            JsonSerializer.Deserialize<SpeakSchema>(schema.ToString())!.Speed.Should().Be(1.05);
+            JsonSerializer.Deserialize<SpeechInterruptedResponse>(speechInterrupted.ToString())!.Metadata!.ControlsApplied!.BreaksApplied.Should().Be(1);
+            JsonSerializer.Deserialize<ConfigureSuccessResponse>(configureSuccess.ToString())!.Applied!.Speed.Should().Be(1.1);
+            JsonSerializer.Deserialize<ConfigureFailureResponse>(configureFailure.ToString())!.Field.Should().Be("speed");
         }
     }
     #endregion

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakLiveIntegrationTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakLiveIntegrationTests.cs
@@ -40,6 +40,9 @@ public class FluxSpeakLiveIntegrationTests
 
         var connectedReceived = new TaskCompletionSource<ConnectedResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
         var turnComplete = new TaskCompletionSource<SpeechMetadataResponse>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var configureAcked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondTurnStarted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var interruptAcked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var closeReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         var audioBytes = 0L;
         var speechStartedCount = 0;
@@ -47,7 +50,13 @@ public class FluxSpeakLiveIntegrationTests
         var errors = new List<ErrorResponse>();
 
         await client.Subscribe(new EventHandler<ConnectedResponse>((s, e) => connectedReceived.TrySetResult(e)));
-        await client.Subscribe(new EventHandler<SpeechStartedResponse>((s, e) => Interlocked.Increment(ref speechStartedCount)));
+        await client.Subscribe(new EventHandler<SpeechStartedResponse>((s, e) =>
+        {
+            if (Interlocked.Increment(ref speechStartedCount) == 2)
+            {
+                secondTurnStarted.TrySetResult(true);
+            }
+        }));
         await client.Subscribe(new EventHandler<AudioResponse>((s, e) =>
         {
             if (e.Stream is not null)
@@ -56,6 +65,14 @@ public class FluxSpeakLiveIntegrationTests
             }
         }));
         await client.Subscribe(new EventHandler<SpeechMetadataResponse>((s, e) => turnComplete.TrySetResult(e)));
+        await client.Subscribe(new EventHandler<ConfigureSuccessResponse>((s, e) => configureAcked.TrySetResult(true)));
+        await client.Subscribe(new EventHandler<ConfigureFailureResponse>((s, e) => configureAcked.TrySetResult(true)));
+        // Barge-in tolerance: a generation-based offset (see the streaming example's honesty note)
+        // may not have advanced past the server's own audio-generation position, in which case the
+        // server answers with a Warning (e.g. INVALID_INTERRUPT_OFFSET) instead of SpeechInterrupted.
+        // Either response proves the round-trip works; that is all this live smoke test asserts.
+        await client.Subscribe(new EventHandler<SpeechInterruptedResponse>((s, e) => interruptAcked.TrySetResult(true)));
+        await client.Subscribe(new EventHandler<WarningResponse>((s, e) => interruptAcked.TrySetResult(true)));
         await client.Subscribe(new EventHandler<ErrorResponse>((s, e) => { lock (errors) { errors.Add(e); } }));
         await client.Subscribe(new EventHandler<CloseResponse>((s, e) =>
         {
@@ -79,6 +96,23 @@ public class FluxSpeakLiveIntegrationTests
             "the server must send a Connected message");
         (await Task.WhenAny(turnComplete.Task, Task.Delay(30000))).Should().Be(turnComplete.Task,
             "the flushed turn must produce a SpeechMetadata once its audio has been sent");
+
+        // GA: mid-stream Configure, acked by ConfigureSuccess or ConfigureFailure.
+        await client.SendConfigure(new ConfigureSchema { Speed = 1.1 });
+        (await Task.WhenAny(configureAcked.Task, Task.Delay(10000))).Should().Be(configureAcked.Task,
+            "Configure must be acknowledged with ConfigureSuccess or ConfigureFailure");
+
+        // GA: barge-in on a second, deliberately long turn.
+        var audioBeforeSecondTurn = Interlocked.Read(ref audioBytes);
+        await client.SendText(
+            "This sentence is deliberately long so that audio is still streaming when the interrupt is sent, " +
+            "which is what makes the barge-in observable in a live end-to-end run against the real endpoint.");
+        (await Task.WhenAny(secondTurnStarted.Task, Task.Delay(10000))).Should().Be(secondTurnStarted.Task,
+            "the second turn must start before the interrupt is sent");
+        var playbackOffsetMs = (Interlocked.Read(ref audioBytes) - audioBeforeSecondTurn) / 48; // 24kHz mono linear16
+        await client.SendInterrupt(Math.Max(playbackOffsetMs, 1));
+        (await Task.WhenAny(interruptAcked.Task, Task.Delay(10000))).Should().Be(interruptAcked.Task,
+            "Interrupt must be acknowledged with SpeechInterrupted or a Warning");
 
         // Clean shutdown: sends {"type":"Close"} and drains any remaining audio.
         await client.Stop();

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakLiveIntegrationTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakLiveIntegrationTests.cs
@@ -48,6 +48,8 @@ public class FluxSpeakLiveIntegrationTests
         var speechStartedCount = 0;
         var closeCount = 0;
         var errors = new List<ErrorResponse>();
+        var interruptSent = false;
+        var interruptRejectionCodes = new[] { "NO_AUDIO_GENERATED", "INTERRUPT_IN_PROGRESS", "INVALID_INTERRUPT_OFFSET", "NO_ACTIVE_SPEECH" };
 
         await client.Subscribe(new EventHandler<ConnectedResponse>((s, e) => connectedReceived.TrySetResult(e)));
         await client.Subscribe(new EventHandler<SpeechStartedResponse>((s, e) =>
@@ -67,12 +69,18 @@ public class FluxSpeakLiveIntegrationTests
         await client.Subscribe(new EventHandler<SpeechMetadataResponse>((s, e) => turnComplete.TrySetResult(e)));
         await client.Subscribe(new EventHandler<ConfigureSuccessResponse>((s, e) => configureAcked.TrySetResult(true)));
         await client.Subscribe(new EventHandler<ConfigureFailureResponse>((s, e) => configureAcked.TrySetResult(true)));
-        // Barge-in tolerance: a generation-based offset (see the streaming example's honesty note)
-        // may not have advanced past the server's own audio-generation position, in which case the
-        // server answers with a Warning (e.g. INVALID_INTERRUPT_OFFSET) instead of SpeechInterrupted.
-        // Either response proves the round-trip works; that is all this live smoke test asserts.
+        // Barge-in tolerance: an offset that doesn't advance far enough may still draw a documented
+        // rejection warning instead of SpeechInterrupted. Either response proves the round-trip
+        // works; that is all this live smoke test asserts. Gate on interruptSent + the documented
+        // code allowlist so an unrelated warning elsewhere in the session can't false-positive this.
         await client.Subscribe(new EventHandler<SpeechInterruptedResponse>((s, e) => interruptAcked.TrySetResult(true)));
-        await client.Subscribe(new EventHandler<WarningResponse>((s, e) => interruptAcked.TrySetResult(true)));
+        await client.Subscribe(new EventHandler<WarningResponse>((s, e) =>
+        {
+            if (interruptSent && interruptRejectionCodes.Contains(e.Code))
+            {
+                interruptAcked.TrySetResult(true);
+            }
+        }));
         await client.Subscribe(new EventHandler<ErrorResponse>((s, e) => { lock (errors) { errors.Add(e); } }));
         await client.Subscribe(new EventHandler<CloseResponse>((s, e) =>
         {
@@ -103,13 +111,16 @@ public class FluxSpeakLiveIntegrationTests
             "Configure must be acknowledged with ConfigureSuccess or ConfigureFailure");
 
         // GA: barge-in on a second, deliberately long turn.
-        var audioBeforeSecondTurn = Interlocked.Read(ref audioBytes);
         await client.SendText(
             "This sentence is deliberately long so that audio is still streaming when the interrupt is sent, " +
             "which is what makes the barge-in observable in a live end-to-end run against the real endpoint.");
         (await Task.WhenAny(secondTurnStarted.Task, Task.Delay(10000))).Should().Be(secondTurnStarted.Task,
             "the second turn must start before the interrupt is sent");
-        var playbackOffsetMs = (Interlocked.Read(ref audioBytes) - audioBeforeSecondTurn) / 48; // 24kHz mono linear16
+        // The offset is the SESSION total (24kHz mono linear16 = 48 bytes/ms), not this turn's -
+        // it must keep growing across turns, or a later interrupt would fail the server's
+        // "must advance past the previous interrupt" check. Do not subtract a per-turn baseline.
+        var playbackOffsetMs = Interlocked.Read(ref audioBytes) / 48;
+        interruptSent = true;
         await client.SendInterrupt(Math.Max(playbackOffsetMs, 1));
         (await Task.WhenAny(interruptAcked.Task, Task.Delay(10000))).Should().Be(interruptAcked.Task,
             "Interrupt must be acknowledged with SpeechInterrupted or a Warning");

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakParityTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakParityTests.cs
@@ -99,6 +99,68 @@ public class FluxSpeakParityTests
         }
     }
 
+    // ---- GA additions replay (Configure/ConfigureSuccess, Interrupt/SpeechInterrupted) ---------
+    //
+    // frames.json/golden.json above are EA captures and stay untouched as a regression fixture.
+    // frames-ga.json is a separate, hand-authored (not yet staging-captured - see its
+    // _provenance field) sequence exercising the GA-only messages this change adds.
+
+    private static List<string> LoadGaFrames()
+    {
+        var path = Path.Combine(FixtureDir, "frames-ga.json");
+        using var doc = JsonDocument.Parse(File.ReadAllText(path));
+        var frames = new List<string>();
+        foreach (var el in doc.RootElement.GetProperty("frames").EnumerateArray())
+        {
+            frames.Add(el.GetRawText());
+        }
+        return frames;
+    }
+
+    [Test]
+    public async Task GA_Frames_Should_Replay_Through_The_Client_In_Order()
+    {
+        var client = new FluxSpeakWebSocketClient(new Faker().Random.Guid().ToString(),
+            new DeepgramWsClientOptions(new Faker().Random.Guid().ToString()) { OnPrem = true });
+
+        var events = new List<object>();
+        await client.Subscribe(new EventHandler<ConnectedResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<ConfigureSuccessResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<SpeechStartedResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<SpeechInterruptedResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<SessionMetadataResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<ConfigureFailureResponse>((_, e) => events.Add(e)));
+        await client.Subscribe(new EventHandler<ErrorResponse>((_, e) => events.Add(e)));
+
+        var wsr = new WebSocketReceiveResult(1, WebSocketMessageType.Text, true);
+        foreach (var frame in LoadGaFrames())
+        {
+            client.ProcessTextMessage(wsr, ToStream(frame));
+        }
+
+        using (new AssertionScope())
+        {
+            events.Select(e => e.GetType().Name).Should().Equal(
+                nameof(ConnectedResponse),
+                nameof(ConfigureSuccessResponse),
+                nameof(SpeechStartedResponse),
+                nameof(SpeechInterruptedResponse),
+                nameof(SessionMetadataResponse));
+
+            ((ConfigureSuccessResponse)events[1]).Applied!.Speed.Should().Be(1.05);
+            ((SpeechStartedResponse)events[2]).SpeechId.Should().Be("dg_sp_a1b2c3d4e5f6");
+
+            var interrupted = (SpeechInterruptedResponse)events[3];
+            interrupted.AudioPlayedMs.Should().Be(2340);
+            interrupted.TextSpoken.Should().Be("Sure, I can help you cancel your subscription.");
+            interrupted.TextRemaining.Should().Be(" Let me pull up your account.");
+            interrupted.Metadata!.ControlsApplied!.BreaksApplied.Should().Be(0);
+
+            var session = (SessionMetadataResponse)events[4];
+            session.TotalAudioDurationMs.Should().Be(2340);
+        }
+    }
+
     [Test]
     public void Captured_Audio_Byte_Count_Matches_Reported_Duration()
     {

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakParityTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakParityTests.cs
@@ -102,8 +102,11 @@ public class FluxSpeakParityTests
     // ---- GA additions replay (Configure/ConfigureSuccess, Interrupt/SpeechInterrupted) ---------
     //
     // frames.json/golden.json above are EA captures and stay untouched as a regression fixture.
-    // frames-ga.json is a separate, hand-authored (not yet staging-captured - see its
-    // _provenance field) sequence exercising the GA-only messages this change adds.
+    // frames-ga.json is a separate, verbatim capture (see its _provenance field) exercising the
+    // GA-only messages this change adds: Configure/ConfigureSuccess and Interrupt/SpeechInterrupted,
+    // against the live production endpoint. Captured via a standalone raw-WebSocket script kept
+    // independent of the SDK's own parser (so this replay is checked against reality, not just
+    // against itself) - see the Flux TTS GA delta PR for the capture script.
 
     private static List<string> LoadGaFrames()
     {
@@ -147,17 +150,25 @@ public class FluxSpeakParityTests
                 nameof(SpeechInterruptedResponse),
                 nameof(SessionMetadataResponse));
 
+            var connected = (ConnectedResponse)events[0];
+            connected.ModelName.Should().Be("alexis", "the wire model_name is the bare voice name, not the full flux-{voice}-{lang} string");
+            connected.ModelUuids.Should().HaveCount(2, "the wire delivered model_uuids as a plural array, matching the EA capture's shape");
+
             ((ConfigureSuccessResponse)events[1]).Applied!.Speed.Should().Be(1.05);
-            ((SpeechStartedResponse)events[2]).SpeechId.Should().Be("dg_sp_a1b2c3d4e5f6");
+            ((SpeechStartedResponse)events[2]).SpeechId.Should().Be("dg_sp_c78f63c65fa2");
 
             var interrupted = (SpeechInterruptedResponse)events[3];
-            interrupted.AudioPlayedMs.Should().Be(2340);
-            interrupted.TextSpoken.Should().Be("Sure, I can help you cancel your subscription.");
-            interrupted.TextRemaining.Should().Be(" Let me pull up your account.");
+            interrupted.AudioPlayedMs.Should().Be(554);
+            interrupted.TextSpoken.Should().Be("Sure,");
+            interrupted.TextRemaining.Should().Be(" I can help you cancel your subscription. Let me pull up your account and check on that for you right away.");
             interrupted.Metadata!.ControlsApplied!.BreaksApplied.Should().Be(0);
 
             var session = (SessionMetadataResponse)events[4];
-            session.TotalAudioDurationMs.Should().Be(2340);
+            session.TotalAudioDurationMs.Should().Be(554);
+            // Real-capture curiosity, not asserted here as "correct": for this interrupted turn the
+            // server's SessionMetadata.total_input_character_count (46) matched the turn's
+            // billable_character_count, not its full input_character_count (112). Left as observed
+            // behavior; a server-side accounting question, not something this client controls.
         }
     }
 

--- a/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakRestClientTests.cs
+++ b/Deepgram.Tests/UnitTests/ClientTests/FluxSpeakRestClientTests.cs
@@ -126,6 +126,34 @@ public class FluxSpeakRestClientTests
     }
 
     [Test]
+    public void Request_Url_Should_Contain_Speed_And_Expressivity_When_Set()
+    {
+        var schema = new SpeakSchema { Model = "flux-alexis-en", Speed = 1.05, Expressivity = -1 };
+
+        var url = QueryParameterUtil.FormatURL(Client.GetUri(_options), schema);
+
+        using (new AssertionScope())
+        {
+            url.Should().Contain("speed=1.05");
+            url.Should().Contain("expressivity=-1");
+        }
+    }
+
+    [Test]
+    public void Request_Url_Should_Omit_Speed_And_Expressivity_When_Null()
+    {
+        var schema = new SpeakSchema { Model = "flux-alexis-en" };
+
+        var url = QueryParameterUtil.FormatURL(Client.GetUri(_options), schema);
+
+        using (new AssertionScope())
+        {
+            url.Should().NotContain("speed=");
+            url.Should().NotContain("expressivity=");
+        }
+    }
+
+    [Test]
     public void TextSource_Should_Serialize_To_Text_Body()
     {
         var source = new TextSource("Your appointment is confirmed for 3pm tomorrow.");
@@ -200,11 +228,15 @@ public class FluxSpeakRestClientTests
     }
     #endregion
 
-    #region EA surface guarantees & factory
+    #region GA surface guarantees & factory
     [Test]
-    public void FluxSpeak_Rest_Schema_Should_Not_Expose_Speed()
+    public void FluxSpeak_Rest_Schema_Should_Expose_Speed_And_Expressivity()
     {
-        typeof(SpeakSchema).GetProperty("Speed").Should().BeNull();
+        using (new AssertionScope())
+        {
+            typeof(SpeakSchema).GetProperty("Speed").Should().NotBeNull();
+            typeof(SpeakSchema).GetProperty("Expressivity").Should().NotBeNull();
+        }
     }
 
     [Test]

--- a/Deepgram/ClientFactory.cs
+++ b/Deepgram/ClientFactory.cs
@@ -51,7 +51,7 @@ public static class ClientFactory
     }
 
     /// <summary>
-    /// (PREVIEW) Create a new FluxSpeakWebSocketClient for streaming, turn-based text-to-speech
+    /// Create a new FluxSpeakWebSocketClient for streaming, turn-based text-to-speech
     /// using the Flux (v2 speak) API
     /// </summary>
     /// <param name="apiKey"></param>
@@ -63,7 +63,7 @@ public static class ClientFactory
     }
 
     /// <summary>
-    /// (PREVIEW) Create a new FluxSpeakRESTClient for batch (single-request) text-to-speech
+    /// Create a new FluxSpeakRESTClient for batch (single-request) text-to-speech
     /// using the Flux (v2 speak) API
     /// </summary>
     /// <param name="apiKey"></param>

--- a/Deepgram/Clients/Flux/Speak/REST/Client.cs
+++ b/Deepgram/Clients/Flux/Speak/REST/Client.cs
@@ -10,7 +10,7 @@ using Deepgram.Models.Flux.Speak.REST;
 namespace Deepgram.Clients.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) Implements the Flux (v2 speak) batch text-to-speech REST Client (POST /v2/speak):
+/// Implements the Flux (v2 speak) batch text-to-speech REST Client (POST /v2/speak):
 /// synthesize a complete block of text into a single audio response. Supply a callback URL to have
 /// the request processed asynchronously.
 /// </summary>

--- a/Deepgram/Clients/Flux/Speak/REST/Constants.cs
+++ b/Deepgram/Clients/Flux/Speak/REST/Constants.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Clients.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) Response headers of interest from the Deepgram Flux (v2 speak) batch REST API.
+/// Response headers of interest from the Deepgram Flux (v2 speak) batch REST API.
 /// </summary>
 // [verify] The exact /v2/speak response header set is not enumerated in the OpenAPI spec; these
 // mirror /v1/speak (the batch handler reuses v1's audio-format machinery) and are confirmed or

--- a/Deepgram/Clients/Flux/Speak/REST/UriSegments.cs
+++ b/Deepgram/Clients/Flux/Speak/REST/UriSegments.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Clients.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) URI segments for the Flux (v2 speak) batch text-to-speech REST client.
+/// URI segments for the Flux (v2 speak) batch text-to-speech REST client.
 /// </summary>
 public static class UriSegments
 {

--- a/Deepgram/Clients/Flux/Speak/WebSocket/Client.cs
+++ b/Deepgram/Clients/Flux/Speak/WebSocket/Client.cs
@@ -14,17 +14,17 @@ using Deepgram.Models.Exceptions.v1;
 namespace Deepgram.Clients.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Implements the Flux (v2 speak) text-to-speech WebSocket Client: stream text in and
+/// Implements the Flux (v2 speak) text-to-speech WebSocket Client: stream text in and
 /// receive synthesized audio out, turn by turn, for voice-agent pipelines.
 ///
-/// The Early Access surface sends exactly three client messages — Speak, Flush, and Close.
+/// Sends five client messages — Speak, Flush, Interrupt, Configure, and Close.
 /// Audio arrives as interleaved binary chunks (the Audio event) alongside JSON control messages
-/// (Connected, SpeechStarted, SpeechMetadata, Flushed, SessionMetadata, Warning, Error). There is
-/// no speed/Interrupt/Configure surface yet (GA-only).
+/// (Connected, SpeechStarted, SpeechMetadata, SpeechInterrupted, Flushed, ConfigureSuccess,
+/// ConfigureFailure, SessionMetadata, Warning, Error).
 ///
 /// Note: event handlers are invoked from the receive loop; a slow handler delays delivery of
 /// subsequent messages, including audio chunks. Keep handlers fast and offload heavy work.
-/// <see href="https://developers.deepgram.com/docs/flux/quickstart"/>
+/// <see href="https://developers.deepgram.com/docs/flux-tts/quickstart"/>
 /// </summary>
 public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
 {
@@ -59,9 +59,12 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
     private event EventHandler<ConnectedResponse>? _connectedReceived;
     private event EventHandler<SpeechStartedResponse>? _speechStartedReceived;
     private event EventHandler<SpeechMetadataResponse>? _speechMetadataReceived;
+    private event EventHandler<SpeechInterruptedResponse>? _speechInterruptedReceived;
     private event EventHandler<FlushedResponse>? _flushedReceived;
     private event EventHandler<SessionMetadataResponse>? _sessionMetadataReceived;
     private event EventHandler<WarningResponse>? _warningReceived;
+    private event EventHandler<ConfigureSuccessResponse>? _configureSuccessReceived;
+    private event EventHandler<ConfigureFailureResponse>? _configureFailureReceived;
     private event EventHandler<ErrorResponse>? _speakErrorReceived;
     private event EventHandler<UnhandledResponse>? _speakUnhandledReceived;
     #endregion
@@ -220,6 +223,25 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
     }
 
     /// <summary>
+    /// Subscribe to a SpeechInterrupted event from the Deepgram API, sent in response to a client
+    /// Interrupt.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public async Task<bool> Subscribe(EventHandler<SpeechInterruptedResponse> eventHandler)
+    {
+        await _mutexSubscribe.WaitAsync();
+        try
+        {
+            _speechInterruptedReceived += (sender, e) => eventHandler(sender, e);
+        }
+        finally
+        {
+            _mutexSubscribe.Release();
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Subscribe to a Flushed event from the Deepgram API
     /// </summary>
     /// <returns>True if successful</returns>
@@ -266,6 +288,44 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
         try
         {
             _warningReceived += (sender, e) => eventHandler(sender, e);
+        }
+        finally
+        {
+            _mutexSubscribe.Release();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Subscribe to a ConfigureSuccess event from the Deepgram API, acknowledging a client
+    /// Configure message.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public async Task<bool> Subscribe(EventHandler<ConfigureSuccessResponse> eventHandler)
+    {
+        await _mutexSubscribe.WaitAsync();
+        try
+        {
+            _configureSuccessReceived += (sender, e) => eventHandler(sender, e);
+        }
+        finally
+        {
+            _mutexSubscribe.Release();
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Subscribe to a ConfigureFailure event from the Deepgram API, rejecting a client
+    /// Configure message. Non-fatal — the connection stays open.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public async Task<bool> Subscribe(EventHandler<ConfigureFailureResponse> eventHandler)
+    {
+        await _mutexSubscribe.WaitAsync();
+        try
+        {
+            _configureFailureReceived += (sender, e) => eventHandler(sender, e);
         }
         finally
         {
@@ -366,6 +426,60 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
         var message = new ControlMessage(Constants.Flush);
         Log.Debug("SendFlush", "Sending Flush Message Immediately...");
         byte[] data = Encoding.UTF8.GetBytes(message.ToString());
+        await SendMessageImmediately(data);
+    }
+
+    /// <summary>
+    /// Sends an Interrupt message to cancel the currently active turn (barge-in). Stopping local
+    /// audio playback is the caller's responsibility - Interrupt is for reconciling the server's
+    /// record of what was spoken, not for stopping audio. The server replies with
+    /// SpeechInterrupted, or a Warning if it cannot act on the interrupt (no audio generated yet,
+    /// an earlier interrupt still in flight, a non-advancing offset, or no active turn).
+    /// </summary>
+    /// <param name="interrupt">
+    /// The interrupt to send. Include <see cref="InterruptSchema.PlaybackOffset"/> so the server
+    /// can compute the text_spoken/text_remaining split; omit it (or pass null for a bare
+    /// interrupt) and the turn still cancels, but that split comes back empty.
+    /// </param>
+    public async Task SendInterrupt(InterruptSchema? interrupt = null)
+    {
+        interrupt ??= new InterruptSchema();
+        interrupt.Type ??= Constants.Interrupt;
+
+        Log.Debug("SendInterrupt", $"Sending Interrupt Message Immediately... {interrupt}");
+        byte[] data = Encoding.UTF8.GetBytes(interrupt.ToString());
+        await SendMessageImmediately(data);
+    }
+
+    /// <summary>
+    /// Sends an Interrupt message carrying a playback offset. Convenience overload of
+    /// <see cref="SendInterrupt(InterruptSchema?)"/> for the common case.
+    /// </summary>
+    /// <param name="playbackOffsetMs">
+    /// Milliseconds of audio played, cumulative from the start of the session (not the current
+    /// turn). Each interrupt's offset must advance past the position established by the previous
+    /// interrupt. Report your audio player's actual position - not bytes received, which arrive
+    /// much faster than realtime.
+    /// </param>
+    public Task SendInterrupt(long playbackOffsetMs) =>
+        SendInterrupt(new InterruptSchema { PlaybackOffset = new PlaybackOffset(playbackOffsetMs) });
+
+    /// <summary>
+    /// Sends a Configure message to change the speaking rate mid-session, without reconnecting.
+    /// The server responds with ConfigureSuccess (echoing what it applied) or ConfigureFailure
+    /// (e.g. code SPEED_OUT_OF_RANGE) - speed is not range-checked client-side.
+    /// </summary>
+    /// <param name="configure">The configuration update to send</param>
+    public async Task SendConfigure(ConfigureSchema configure)
+    {
+        if (configure is null)
+        {
+            throw new ArgumentNullException(nameof(configure));
+        }
+        configure.Type ??= Constants.Configure;
+
+        Log.Debug("SendConfigure", $"Sending Configure Message Immediately... {configure}");
+        byte[] data = Encoding.UTF8.GetBytes(configure.ToString());
         await SendMessageImmediately(data);
     }
 
@@ -654,6 +768,22 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
                     }
                     InvokeParallel(_speechMetadataReceived, speechMetadataResponse);
                     break;
+                case SpeakType.SpeechInterrupted:
+                    var speechInterruptedResponse = data.Deserialize<SpeechInterruptedResponse>();
+                    if (_speechInterruptedReceived == null)
+                    {
+                        Log.Debug("ProcessTextMessage", "_speechInterruptedReceived has no listeners");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    if (speechInterruptedResponse == null)
+                    {
+                        Log.Warning("ProcessTextMessage", "SpeechInterruptedResponse is invalid");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    InvokeParallel(_speechInterruptedReceived, speechInterruptedResponse);
+                    break;
                 case SpeakType.Flushed:
                     var flushedResponse = data.Deserialize<FlushedResponse>();
                     if (_flushedReceived == null)
@@ -701,6 +831,39 @@ public class Client : AbstractWebSocketClient, IFluxSpeakWebSocketClient
                         return;
                     }
                     InvokeParallel(_warningReceived, warningResponse);
+                    break;
+                case SpeakType.ConfigureSuccess:
+                    var configureSuccessResponse = data.Deserialize<ConfigureSuccessResponse>();
+                    if (_configureSuccessReceived == null)
+                    {
+                        Log.Debug("ProcessTextMessage", "_configureSuccessReceived has no listeners");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    if (configureSuccessResponse == null)
+                    {
+                        Log.Warning("ProcessTextMessage", "ConfigureSuccessResponse is invalid");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    InvokeParallel(_configureSuccessReceived, configureSuccessResponse);
+                    break;
+                case SpeakType.ConfigureFailure:
+                    // Non-fatal - like Warning, NOT the error path. The connection stays open.
+                    var configureFailureResponse = data.Deserialize<ConfigureFailureResponse>();
+                    if (_configureFailureReceived == null)
+                    {
+                        Log.Debug("ProcessTextMessage", "_configureFailureReceived has no listeners");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    if (configureFailureResponse == null)
+                    {
+                        Log.Warning("ProcessTextMessage", "ConfigureFailureResponse is invalid");
+                        Log.Verbose("ProcessTextMessage", "LEAVE");
+                        return;
+                    }
+                    InvokeParallel(_configureFailureReceived, configureFailureResponse);
                     break;
                 case SpeakType.Error:
                     // Flux fatal errors use the wire type "Error" but carry a different shape

--- a/Deepgram/Clients/Flux/Speak/WebSocket/Constants.cs
+++ b/Deepgram/Clients/Flux/Speak/WebSocket/Constants.cs
@@ -5,14 +5,15 @@
 namespace Deepgram.Clients.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Constants for the Flux (v2 speak) text-to-speech WebSocket client.
+/// Constants for the Flux (v2 speak) text-to-speech WebSocket client.
 /// </summary>
 public static class Constants
 {
-    // Client message types. The Early Access surface sends exactly three: Speak, Flush, Close.
-    // (Interrupt and Configure are GA-only and not yet available on /v2/speak.)
+    // Client message types.
     public const string Speak = "Speak";
     public const string Flush = "Flush";
+    public const string Interrupt = "Interrupt";
+    public const string Configure = "Configure";
     public const string Close = "Close";
 
     /// <summary>

--- a/Deepgram/Clients/Flux/Speak/WebSocket/UriSegments.cs
+++ b/Deepgram/Clients/Flux/Speak/WebSocket/UriSegments.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Clients.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) URI segments for the Flux (v2 speak) text-to-speech WebSocket client.
+/// URI segments for the Flux (v2 speak) text-to-speech WebSocket client.
 /// </summary>
 public static class UriSegments
 {

--- a/Deepgram/Clients/Interfaces/v2/IFluxSpeakRESTClient.cs
+++ b/Deepgram/Clients/Interfaces/v2/IFluxSpeakRESTClient.cs
@@ -7,7 +7,7 @@ using Deepgram.Models.Flux.Speak.REST;
 namespace Deepgram.Clients.Interfaces.v2;
 
 /// <summary>
-/// (PREVIEW) Implements the Flux (v2 speak) batch text-to-speech REST Client (POST /v2/speak):
+/// Implements the Flux (v2 speak) batch text-to-speech REST Client (POST /v2/speak):
 /// synthesize a complete block of text into a single audio response.
 /// </summary>
 public interface IFluxSpeakRESTClient

--- a/Deepgram/Clients/Interfaces/v2/IFluxSpeakWebSocketClient.cs
+++ b/Deepgram/Clients/Interfaces/v2/IFluxSpeakWebSocketClient.cs
@@ -7,12 +7,11 @@ using Deepgram.Models.Flux.Speak.WebSocket;
 namespace Deepgram.Clients.Interfaces.v2;
 
 /// <summary>
-/// (PREVIEW) Implements the Flux (v2 speak) text-to-speech WebSocket Client: stream text in and
+/// Implements the Flux (v2 speak) text-to-speech WebSocket Client: stream text in and
 /// receive synthesized audio out, turn by turn, for voice-agent pipelines.
 ///
-/// The Early Access surface sends exactly three client messages — Speak, Flush, and Close. There
-/// are intentionally no binary-send members (the client receives audio, it does not send it) and
-/// no Interrupt/Configure members (those are GA-only and not yet available on /v2/speak).
+/// Sends five client messages — Speak, Flush, Interrupt, Configure, and Close. There
+/// are intentionally no binary-send members (the client receives audio, it does not send it).
 /// </summary>
 public interface IFluxSpeakWebSocketClient
 {
@@ -62,6 +61,12 @@ public interface IFluxSpeakWebSocketClient
     public Task<bool> Subscribe(EventHandler<SpeechMetadataResponse> eventHandler);
 
     /// <summary>
+    /// Subscribe to a SpeechInterrupted event, sent in response to a client Interrupt.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public Task<bool> Subscribe(EventHandler<SpeechInterruptedResponse> eventHandler);
+
+    /// <summary>
     /// Subscribe to a Flushed event echoing receipt of a manual Flush.
     /// </summary>
     /// <returns>True if successful</returns>
@@ -78,6 +83,19 @@ public interface IFluxSpeakWebSocketClient
     /// </summary>
     /// <returns>True if successful</returns>
     public Task<bool> Subscribe(EventHandler<WarningResponse> eventHandler);
+
+    /// <summary>
+    /// Subscribe to a ConfigureSuccess event, acknowledging a client Configure message.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public Task<bool> Subscribe(EventHandler<ConfigureSuccessResponse> eventHandler);
+
+    /// <summary>
+    /// Subscribe to a ConfigureFailure event, rejecting a client Configure message. Non-fatal —
+    /// the connection stays open.
+    /// </summary>
+    /// <returns>True if successful</returns>
+    public Task<bool> Subscribe(EventHandler<ConfigureFailureResponse> eventHandler);
 
     /// <summary>
     /// Subscribe to a fatal Error event. The server closes the connection after sending it.
@@ -109,6 +127,24 @@ public interface IFluxSpeakWebSocketClient
     /// replies with Flushed, then SpeechMetadata once the turn's audio has been sent.
     /// </summary>
     public Task SendFlush();
+
+    /// <summary>
+    /// Cancels the currently active turn (barge-in). The server replies with SpeechInterrupted,
+    /// or a Warning if it cannot act on the interrupt.
+    /// </summary>
+    public Task SendInterrupt(InterruptSchema? interrupt = null);
+
+    /// <summary>
+    /// Cancels the currently active turn (barge-in), reporting the given playback offset.
+    /// Convenience overload of <see cref="SendInterrupt(InterruptSchema?)"/>.
+    /// </summary>
+    public Task SendInterrupt(long playbackOffsetMs);
+
+    /// <summary>
+    /// Changes the speaking rate mid-session, without reconnecting. The server responds with
+    /// ConfigureSuccess or ConfigureFailure.
+    /// </summary>
+    public Task SendConfigure(ConfigureSchema configure);
 
     /// <summary>
     /// Sends a Close message ({"type":"Close"}) and waits briefly for the server to drain all

--- a/Deepgram/FluxSpeakRESTClient.cs
+++ b/Deepgram/FluxSpeakRESTClient.cs
@@ -8,7 +8,7 @@ using Deepgram.Models.Authenticate.v1;
 namespace Deepgram;
 
 /// <summary>
-/// (PREVIEW) Implements the latest supported version of the Flux (v2 speak) batch text-to-speech
+/// Implements the latest supported version of the Flux (v2 speak) batch text-to-speech
 /// REST Client.
 /// </summary>
 public class FluxSpeakRESTClient : Client

--- a/Deepgram/FluxSpeakWebSocketClient.cs
+++ b/Deepgram/FluxSpeakWebSocketClient.cs
@@ -8,7 +8,7 @@ using Deepgram.Models.Authenticate.v1;
 namespace Deepgram;
 
 /// <summary>
-/// (PREVIEW) Implements the latest supported version of the Flux (v2 speak) text-to-speech
+/// Implements the latest supported version of the Flux (v2 speak) text-to-speech
 /// WebSocket Client.
 /// </summary>
 public class FluxSpeakWebSocketClient : Client

--- a/Deepgram/Models/Flux/Speak/REST/AsyncResponse.cs
+++ b/Deepgram/Models/Flux/Speak/REST/AsyncResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) The acknowledgement returned by the Deepgram Flux (v2 speak) batch REST API when a
+/// The acknowledgement returned by the Deepgram Flux (v2 speak) batch REST API when a
 /// callback URL is supplied; the audio is delivered asynchronously to that URL.
 /// </summary>
 public record AsyncResponse

--- a/Deepgram/Models/Flux/Speak/REST/SpeakSchema.cs
+++ b/Deepgram/Models/Flux/Speak/REST/SpeakSchema.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) Query options for the Deepgram Flux (v2 speak) batch text-to-speech REST API
+/// Query options for the Deepgram Flux (v2 speak) batch text-to-speech REST API
 /// (POST /v2/speak). The text itself is sent in the request body via <see cref="TextSource"/>.
 /// </summary>
 public class SpeakSchema
@@ -87,6 +87,23 @@ public class SpeakSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("priority")]
     public string? Priority { get; set; }
+
+    /// <summary>
+    /// Speech-rate multiplier. Valid values are 0.85 through 1.15 in 0.05 increments. Not
+    /// range-checked client-side; the server rejects out-of-range values.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("speed")]
+    public double? Speed { get; set; }
+
+    /// <summary>
+    /// BETA. Delivery-register dial from -2 (calmer) to 2 (more animated). Default 0, the
+    /// tuned, production-validated setting.
+    /// <see href="https://developers.deepgram.com/docs/tts-expressivity"/>
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("expressivity")]
+    public int? Expressivity { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/REST/SyncResponse.cs
+++ b/Deepgram/Models/Flux/Speak/REST/SyncResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) The synchronous response from the Deepgram Flux (v2 speak) batch REST API. The
+/// The synchronous response from the Deepgram Flux (v2 speak) batch REST API. The
 /// synthesized audio is exposed as a <see cref="Stream"/>; the remaining properties are populated
 /// from the response headers.
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/REST/TextSource.cs
+++ b/Deepgram/Models/Flux/Speak/REST/TextSource.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.REST;
 
 /// <summary>
-/// (PREVIEW) The request body for the Deepgram Flux (v2 speak) batch REST API. Serializes to
+/// The request body for the Deepgram Flux (v2 speak) batch REST API. Serializes to
 /// {"text":"..."}. The server normalizes and preprocesses the text before synthesis.
 /// </summary>
 public class TextSource(string text)

--- a/Deepgram/Models/Flux/Speak/WebSocket/AudioResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/AudioResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) A binary audio chunk received from the Deepgram Flux (v2 speak) API, in the encoding
+/// A binary audio chunk received from the Deepgram Flux (v2 speak) API, in the encoding
 /// and sample rate requested on the connection. Correlate audio with a turn via the surrounding
 /// SpeechStarted / Flushed / SpeechMetadata events; audio chunks carry no envelope of their own.
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/WebSocket/CloseResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/CloseResponse.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Flux.Speak.WebSocket;
 using Common = Deepgram.Models.Common.v2.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Raised locally by the SDK when the Flux (v2 speak) WebSocket connection closes.
+/// Raised locally by the SDK when the Flux (v2 speak) WebSocket connection closes.
 /// </summary>
 public record CloseResponse : Common.CloseResponse
 {

--- a/Deepgram/Models/Flux/Speak/WebSocket/ConfigureApplied.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ConfigureApplied.cs
@@ -5,17 +5,16 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// A simple type-only control message for the Deepgram Flux (v2 speak) API.
-/// Used for the Flush ({"type":"Flush"}) and Close ({"type":"Close"}) client messages.
+/// The configuration the server actually applied, nested inside <see cref="ConfigureSuccessResponse"/>.
 /// </summary>
-public class ControlMessage(string text)
+public record ConfigureApplied
 {
     /// <summary>
-    /// Gets or sets the type of control message.
+    /// The speech-rate multiplier the server applied.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("type")]
-    public string? Type { get; set; } = text;
+    [JsonPropertyName("speed")]
+    public double? Speed { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/ConfigureFailureResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ConfigureFailureResponse.cs
@@ -5,47 +5,48 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// Sent immediately by the Deepgram Flux (v2 speak) API on a successful connection.
-/// Successor to the /v1/speak Metadata message.
+/// Emitted by the Deepgram Flux (v2 speak) API rejecting a client Configure message. Non-fatal —
+/// the connection stays open. <see cref="Code"/> is an open, growable set of values (e.g.
+/// SPEED_OUT_OF_RANGE); do not assume it is limited to any known list.
 /// </summary>
-public record ConnectedResponse
+public record ConfigureFailureResponse
 {
     /// <summary>
-    /// Connected event type.
+    /// ConfigureFailure event type.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("type")]
     [JsonConverter(typeof(JsonStringEnumConverter))]
-    public SpeakType? Type { get; set; } = SpeakType.Connected;
+    public SpeakType? Type { get; set; } = SpeakType.ConfigureFailure;
 
     /// <summary>
-    /// The unique identifier of the /v2/speak request.
+    /// A code identifying why the configuration was rejected, e.g. SPEED_OUT_OF_RANGE. Open set —
+    /// the server may introduce new codes without notice.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("request_id")]
-    public string? RequestId { get; set; }
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
 
     /// <summary>
-    /// Resolved model name, e.g. "flux-alexis-en".
+    /// Prose description of why the configuration was rejected.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("model_name")]
-    public string? ModelName { get; set; }
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
 
     /// <summary>
-    /// Resolved model version, e.g. "2026.06.01".
+    /// The rejected field's name, e.g. "speed".
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("model_version")]
-    public string? ModelVersion { get; set; }
+    [JsonPropertyName("field")]
+    public string? Field { get; set; }
 
     /// <summary>
-    /// Resolved model UUIDs. A list, because a resolved model may be backed by more than one
-    /// underlying model.
+    /// The rejected value, echoed back verbatim. Untyped because the field it names may vary.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("model_uuids")]
-    public List<string>? ModelUuids { get; set; }
+    [JsonPropertyName("value")]
+    public JsonElement? Value { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/ConfigureSchema.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ConfigureSchema.cs
@@ -5,25 +5,27 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// The Speak client message for the Deepgram Flux (v2 speak) API. Sends text to be
-/// synthesized into the active turn. Serializes to {"type":"Speak","text":"..."}. The server
-/// assigns the turn's speech_id; clients never specify one.
+/// Mid-stream reconfiguration message for the Deepgram Flux (v2 speak) API. Changes the speaking
+/// rate without reconnecting. Not validated client-side — an out-of-range value is rejected by the
+/// server via <see cref="ConfigureFailureResponse"/> (e.g. code SPEED_OUT_OF_RANGE), not thrown locally.
+/// <see href="https://developers.deepgram.com/docs/flux-tts/client-messages"/>
 /// </summary>
-public class SpeakMessage(string text)
+public class ConfigureSchema
 {
     /// <summary>
-    /// Message type identifier. Always "Speak".
+    /// Message type. Always "Configure".
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("type")]
-    public string? Type { get; set; } = "Speak";
+    public string? Type { get; set; } = "Configure";
 
     /// <summary>
-    /// The input text to synthesize.
+    /// Speech-rate multiplier. Valid values are 0.85 through 1.15 in 0.05 increments. Applies at
+    /// the next segment boundary. Not range-checked client-side.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("text")]
-    public string? Text { get; set; } = text;
+    [JsonPropertyName("speed")]
+    public double? Speed { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/ConfigureSuccessResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ConfigureSuccessResponse.cs
@@ -5,17 +5,24 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// A simple type-only control message for the Deepgram Flux (v2 speak) API.
-/// Used for the Flush ({"type":"Flush"}) and Close ({"type":"Close"}) client messages.
+/// Emitted by the Deepgram Flux (v2 speak) API acknowledging a client Configure message.
 /// </summary>
-public class ControlMessage(string text)
+public record ConfigureSuccessResponse
 {
     /// <summary>
-    /// Gets or sets the type of control message.
+    /// ConfigureSuccess event type.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("type")]
-    public string? Type { get; set; } = text;
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SpeakType? Type { get; set; } = SpeakType.ConfigureSuccess;
+
+    /// <summary>
+    /// The configuration the server applied.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("applied")]
+    public ConfigureApplied? Applied { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/ControlsApplied.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ControlsApplied.cs
@@ -5,14 +5,14 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Controls applied during a turn, nested inside <see cref="SpeechMetadataResponse"/>.
-/// Inline pronunciation and pause controls are not available during Early Access, so every count
-/// is currently 0.
+/// Controls applied during a turn, nested inside <see cref="SpeechMetadataResponse"/> and
+/// <see cref="SpeechInterruptedMetadata"/>. Inline pronunciation and pause controls are a coming-soon
+/// fast-follow, so every count is currently 0.
 /// </summary>
 public record ControlsApplied
 {
     /// <summary>
-    /// Pronunciation overrides successfully applied. Always 0 during Early Access.
+    /// Pronunciation overrides successfully applied. Currently always 0 (coming-soon fast-follow).
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("pronunciations_applied")]
@@ -20,11 +20,19 @@ public record ControlsApplied
 
     /// <summary>
     /// Pronunciation entries that triggered a warning (invalid IPA, word too long).
-    /// Always 0 during Early Access.
+    /// Currently always 0 (coming-soon fast-follow).
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("pronunciation_warnings")]
     public int? PronunciationWarnings { get; set; }
+
+    /// <summary>
+    /// Inline pause (break) controls successfully applied. Nullable because older server
+    /// responses predate this counter and omit the field entirely.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("breaks_applied")]
+    public int? BreaksApplied { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/ErrorResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/ErrorResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) A fatal, server-originated error from the Deepgram Flux (v2 speak) API. The wire
+/// A fatal, server-originated error from the Deepgram Flux (v2 speak) API. The wire
 /// value of the "type" property is literally "Error". Always followed by a WebSocket close. Codes
 /// use Deepgram's DOMAIN-NNNN convention (e.g. MESSAGE-0000, NET-0000).
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/WebSocket/FlushedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/FlushedResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Immediate echo from the Deepgram Flux (v2 speak) API on receipt of a manual Flush,
+/// Immediate echo from the Deepgram Flux (v2 speak) API on receipt of a manual Flush,
 /// confirming the server received it before synthesis completes. Not emitted for internal
 /// auto-flush boundaries.
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/WebSocket/InterruptSchema.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/InterruptSchema.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Flux.Speak.WebSocket;
+
+/// <summary>
+/// Barge-in message for the Deepgram Flux (v2 speak) API. Cancels the currently active turn.
+/// Stopping local audio playback is the caller's responsibility — Interrupt is for reconciling
+/// the server's record of what was spoken, not for stopping audio.
+///
+/// Including <see cref="PlaybackOffset"/> lets the server compute the text_spoken/text_remaining
+/// split reported on SpeechInterrupted; omitting it still cancels the turn, but that split comes
+/// back empty. An Interrupt the server cannot act on (no audio generated yet, an earlier interrupt
+/// still in flight, a non-advancing offset, or no active turn) is answered with a Warning instead
+/// of SpeechInterrupted.
+/// <see href="https://developers.deepgram.com/docs/flux-tts/interrupt-handling"/>
+/// </summary>
+public class InterruptSchema
+{
+    /// <summary>
+    /// Message type. Always "Interrupt".
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("type")]
+    public string? Type { get; set; } = "Interrupt";
+
+    /// <summary>
+    /// Playback position when the barge-in occurred. See <see cref="PlaybackOffset"/> for the
+    /// cumulative/advancing semantics. Optional — omit only if you don't need the spoken-text split.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("playback_offset")]
+    public PlaybackOffset? PlaybackOffset { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
+}

--- a/Deepgram/Models/Flux/Speak/WebSocket/OpenResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/OpenResponse.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Flux.Speak.WebSocket;
 using Common = Deepgram.Models.Common.v2.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Raised locally by the SDK when the Flux (v2 speak) WebSocket connection opens.
+/// Raised locally by the SDK when the Flux (v2 speak) WebSocket connection opens.
 /// </summary>
 public record OpenResponse : Common.OpenResponse
 {

--- a/Deepgram/Models/Flux/Speak/WebSocket/PlaybackOffset.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/PlaybackOffset.cs
@@ -1,0 +1,43 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Flux.Speak.WebSocket;
+
+/// <summary>
+/// A playback position, in milliseconds, measured from the start of the session's audio (not the
+/// current turn). Sent on <see cref="InterruptSchema"/> so the server can compute the
+/// text_spoken/text_remaining split on <see cref="SpeechInterruptedResponse"/>.
+/// </summary>
+public class PlaybackOffset
+{
+    /// <summary>
+    /// Creates a playback offset of the given value, in milliseconds.
+    /// </summary>
+    public PlaybackOffset(long valueMs)
+    {
+        Value = valueMs;
+    }
+
+    /// <summary>
+    /// Offset unit. Always "time_ms".
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("type")]
+    public string? Type { get; set; } = "time_ms";
+
+    /// <summary>
+    /// Milliseconds of audio played, cumulative from the start of the session. Each Interrupt's
+    /// offset must advance past the position established by the previous Interrupt.
+    /// </summary>
+    [JsonPropertyName("value")]
+    public long Value { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
+}

--- a/Deepgram/Models/Flux/Speak/WebSocket/SessionMetadataResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SessionMetadataResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Final server message from the Deepgram Flux (v2 speak) API before the WebSocket
+/// Final server message from the Deepgram Flux (v2 speak) API before the WebSocket
 /// closes. Reports cumulative session totals across all turns.
 /// </summary>
 public record SessionMetadataResponse

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeakSchema.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeakSchema.cs
@@ -5,9 +5,9 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Connection options for the Deepgram Flux (v2 speak) text-to-speech WebSocket API.
+/// Connection options for the Deepgram Flux (v2 speak) text-to-speech WebSocket API.
 /// These are sent as query parameters on the wss://api.deepgram.com/v2/speak connection.
-/// <see href="https://developers.deepgram.com/docs/flux/quickstart"/>
+/// <see href="https://developers.deepgram.com/docs/flux-tts/quickstart"/>
 /// </summary>
 public class SpeakSchema
 {
@@ -53,6 +53,24 @@ public class SpeakSchema
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("tag")]
     public List<string>? Tag { get; set; }
+
+    /// <summary>
+    /// Speech-rate multiplier. Valid values are 0.85 through 1.15 in 0.05 increments. Not
+    /// range-checked client-side; the server rejects out-of-range values. Can also be changed
+    /// mid-session with <see cref="Deepgram.Clients.Flux.Speak.WebSocket.Client.SendConfigure"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("speed")]
+    public double? Speed { get; set; }
+
+    /// <summary>
+    /// BETA. Delivery-register dial from -2 (calmer) to 2 (more animated). Default 0, the
+    /// tuned, production-validated setting.
+    /// <see href="https://developers.deepgram.com/docs/tts-expressivity"/>
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("expressivity")]
+    public int? Expressivity { get; set; }
 
     /// <summary>
     /// Override ToString method to serialize the object

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeakType.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeakType.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Flux.Speak.WebSocket;
 using Deepgram.Models.Common.v2.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Message types used by the Deepgram Flux (v2 speak) text-to-speech WebSocket API.
+/// Message types used by the Deepgram Flux (v2 speak) text-to-speech WebSocket API.
 /// </summary>
 public enum SpeakType
 {
@@ -25,7 +25,10 @@ public enum SpeakType
     Connected,
     SpeechStarted,
     SpeechMetadata,
+    SpeechInterrupted,
     Flushed,
     SessionMetadata,
     Warning,
+    ConfigureSuccess,
+    ConfigureFailure,
 }

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeechInterruptedMetadata.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeechInterruptedMetadata.cs
@@ -5,28 +5,21 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// Emitted by the Deepgram Flux (v2 speak) API at turn boundaries (manual Flush), after
-/// all audio for the turn has been sent. Reports billing and timing for the completed turn.
+/// Per-turn billing and timing for an interrupted turn, nested inside
+/// <see cref="SpeechInterruptedResponse"/>. Same shape as the metadata carried by
+/// <see cref="SpeechMetadataResponse"/>.
 /// </summary>
-public record SpeechMetadataResponse
+public record SpeechInterruptedMetadata
 {
     /// <summary>
-    /// SpeechMetadata event type.
-    /// </summary>
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    [JsonPropertyName("type")]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public SpeakType? Type { get; set; } = SpeakType.SpeechMetadata;
-
-    /// <summary>
-    /// Server-assigned turn identifier.
+    /// Server-assigned identifier of the interrupted turn.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("speech_id")]
     public string? SpeechId { get; set; }
 
     /// <summary>
-    /// Total audio duration produced for this turn, in milliseconds.
+    /// Total audio duration produced for this turn before it was cut off, in milliseconds.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("audio_duration_ms")]
@@ -40,15 +33,14 @@ public record SpeechMetadataResponse
     public int? InputCharacterCount { get; set; }
 
     /// <summary>
-    /// Billable character count for this turn (input character count with stripped control
-    /// characters removed). Always less than or equal to InputCharacterCount.
+    /// Billable character count for this turn. Always less than or equal to InputCharacterCount.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("billable_character_count")]
     public int? BillableCharacterCount { get; set; }
 
     /// <summary>
-    /// Controls applied during the turn. Currently always reports 0 (coming-soon fast-follow).
+    /// Controls applied during the turn before it was interrupted.
     /// </summary>
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("controls_applied")]

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeechInterruptedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeechInterruptedResponse.cs
@@ -1,0 +1,61 @@
+// Copyright 2026 Deepgram .NET SDK contributors. All Rights Reserved.
+// Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+// SPDX-License-Identifier: MIT
+
+namespace Deepgram.Models.Flux.Speak.WebSocket;
+
+/// <summary>
+/// Emitted by the Deepgram Flux (v2 speak) API in response to a client Interrupt. Reports how much
+/// audio actually played and, when the Interrupt carried a playback_offset, the exact split between
+/// what the user heard (<see cref="TextSpoken"/>) and what they didn't (<see cref="TextRemaining"/>).
+/// The next Speak begins a new turn; Interrupt does not reset the model's conversational state.
+/// <see href="https://developers.deepgram.com/docs/flux-tts/interrupt-handling"/>
+/// </summary>
+public record SpeechInterruptedResponse
+{
+    /// <summary>
+    /// SpeechInterrupted event type.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("type")]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public SpeakType? Type { get; set; } = SpeakType.SpeechInterrupted;
+
+    /// <summary>
+    /// Milliseconds of audio actually played before the cut, per the server's own record.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("audio_played_ms")]
+    public long? AudioPlayedMs { get; set; }
+
+    /// <summary>
+    /// The text the user actually heard before the interrupt. Present only when the Interrupt
+    /// carried a playback_offset.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("text_spoken")]
+    public string? TextSpoken { get; set; }
+
+    /// <summary>
+    /// The text that was cut off and never spoken. Present only when the Interrupt carried a
+    /// playback_offset.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("text_remaining")]
+    public string? TextRemaining { get; set; }
+
+    /// <summary>
+    /// Billing and timing for the interrupted turn.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("metadata")]
+    public SpeechInterruptedMetadata? Metadata { get; set; }
+
+    /// <summary>
+    /// Override ToString method to serialize the object
+    /// </summary>
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this, JsonSerializeOptions.DefaultOptions);
+    }
+}

--- a/Deepgram/Models/Flux/Speak/WebSocket/SpeechStartedResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/SpeechStartedResponse.cs
@@ -5,7 +5,7 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Emitted by the Deepgram Flux (v2 speak) API at the start of each new turn, before
+/// Emitted by the Deepgram Flux (v2 speak) API at the start of each new turn, before
 /// audio streaming begins. Carries the server-assigned speech_id that identifies the turn. Fires
 /// once per turn, not on internal auto-flush boundaries.
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/WebSocket/UnhandledResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/UnhandledResponse.cs
@@ -7,7 +7,7 @@ namespace Deepgram.Models.Flux.Speak.WebSocket;
 using Common = Deepgram.Models.Common.v2.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Raised when the Flux (v2 speak) API sends a message type this SDK version does not
+/// Raised when the Flux (v2 speak) API sends a message type this SDK version does not
 /// recognize. The Raw property contains the original JSON. An unrecognized frame never throws,
 /// never closes the connection, and never routes to the error event.
 /// </summary>

--- a/Deepgram/Models/Flux/Speak/WebSocket/WarningResponse.cs
+++ b/Deepgram/Models/Flux/Speak/WebSocket/WarningResponse.cs
@@ -5,10 +5,11 @@
 namespace Deepgram.Models.Flux.Speak.WebSocket;
 
 /// <summary>
-/// (PREVIEW) Informational message from the Deepgram Flux (v2 speak) API; synthesis continues and
-/// the connection is unaffected. Early Access codes are NO_ACTIVE_SPEECH (a speech-scoped message
-/// arrived with no active turn) and SYNTHESIS_RETRYING (a synthesis request failed and is being
-/// retried).
+/// Informational message from the Deepgram Flux (v2 speak) API; synthesis continues and
+/// the connection is unaffected. Known codes include NO_ACTIVE_SPEECH (a speech-scoped message
+/// arrived with no active turn), SYNTHESIS_RETRYING (a synthesis request failed and is being
+/// retried), NO_AUDIO_GENERATED, INTERRUPT_IN_PROGRESS, and INVALID_INTERRUPT_OFFSET (all three
+/// mean an Interrupt could not be acted on). The code set is open — do not assume it is exhaustive.
 /// </summary>
 public record WarningResponse
 {

--- a/README.md
+++ b/README.md
@@ -412,6 +412,18 @@ await speakClient.ToFile(
 
 [See the Examples for more info](./examples/text-to-speech/websocket/flux/) - and the [batch (REST) example](./examples/text-to-speech/rest/flux/).
 
+### Upgrading from 6.x (`IFluxSpeakWebSocketClient` interface members)
+
+Version 7.0 adds the GA barge-in/mid-stream controls above directly to the
+`IFluxSpeakWebSocketClient` interface: `SendInterrupt` (two overloads), `SendConfigure`, and
+`Subscribe` overloads for `SpeechInterruptedResponse`, `ConfigureSuccessResponse`, and
+`ConfigureFailureResponse`. If you use `FluxSpeakWebSocketClient`/`ClientFactory` as shipped, or a
+mocking framework (NSubstitute, Moq) to fake this interface in tests, nothing changes for you.
+
+This is a breaking change only if you have your own concrete class implementing
+`IFluxSpeakWebSocketClient` directly — add the six new members to keep it compiling. There is no
+old-API-to-new-API migration here (nothing was renamed or removed); it is a pure addition.
+
 ## Voice Agent
 
 Configure a Voice Agent.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Power your apps with world-class speech and Language AI models.
     - [Local Files (Asynchronous)](#local-files-asynchronous)
   - [Streaming Audio](#streaming-audio)
   - [Flux - Conversational Speech Recognition (Preview)](#flux---conversational-speech-recognition-preview)
-  - [Flux Text to Speech (Preview)](#flux-text-to-speech-preview)
+  - [Flux Text to Speech](#flux-text-to-speech)
   - [Voice Agent](#voice-agent)
   - [Text to Speech REST](#text-to-speech-rest)
   - [Text to Speech Streaming](#text-to-speech-streaming)
@@ -320,13 +320,11 @@ await fluxClient.Stop();
 
 [See the Examples for more info](./examples/speech-to-text/websocket/flux/) - including a [raw WebSocket version](./examples/speech-to-text/websocket/flux-raw/) that uses no SDK at all.
 
-## Flux Text to Speech (Preview)
+## Flux Text to Speech
 
-> Flux text-to-speech support is currently in preview. The API surface may change in a future release.
+Synthesize speech with [Deepgram Flux TTS](https://developers.deepgram.com/docs/flux-tts/overview), available on two transports. Stream text in and receive synthesized audio out turn by turn over a WebSocket (built for voice agents), or generate a complete block of audio in a single batch (REST) request. Models are `flux-{voice}-{language}` (e.g. `flux-alexis-en`); an Aura model on this endpoint is rejected — use the classic Speak client for Aura voices.
 
-Synthesize speech with [Deepgram Flux](https://developers.deepgram.com/docs/flux/quickstart) TTS, available on two transports. Stream text in and receive synthesized audio out turn by turn over a WebSocket (built for voice agents), or generate a complete block of audio in a single batch (REST) request. Models are `flux-{voice}-{language}` (e.g. `flux-alexis-en`); an Aura model on this endpoint is rejected — use the classic Speak client for Aura voices.
-
-Streaming sends exactly three client messages at Early Access — `Speak`, `Flush`, and `Close` (note: `Close`, not the listen client's `CloseStream`). Audio arrives as interleaved binary chunks alongside JSON control messages (`Connected`, `SpeechStarted`, `SpeechMetadata`, `Flushed`, `SessionMetadata`, `Warning`, `Error`).
+Streaming sends five client messages — `Speak`, `Flush`, `Interrupt`, `Configure`, and `Close` (note: `Close`, not the listen client's `CloseStream`). Audio arrives as interleaved binary chunks alongside JSON control messages (`Connected`, `SpeechStarted`, `SpeechMetadata`, `SpeechInterrupted`, `Flushed`, `ConfigureSuccess`/`ConfigureFailure`, `SessionMetadata`, `Warning`, `Error`).
 
 ```csharp
 using Deepgram;
@@ -351,15 +349,43 @@ var schema = new SpeakSchema()
     Model = "flux-alexis-en",
     Encoding = "linear16",
     SampleRate = 24000,
+    Speed = 1.0,          // optional: 0.85–1.15 in 0.05 steps
+    // Expressivity = 1,  // optional (beta): -2 (calmer) to 2 (more animated)
 };
 await speakClient.Connect(schema);
 
-// Stream text into the active turn, then flush to generate the remaining audio
+// Stream text into the active turn, then flush to mark the end of the turn.
+// The turn's SpeechMetadata (billing, timing) is your end-of-turn signal.
 await speakClient.SendText("Sure, I can help you cancel your subscription.");
 await speakClient.SendFlush();
 
 // Stop the connection (sends Close and waits for the server to drain the audio)
 await speakClient.Stop();
+```
+
+### Barge-in and mid-stream controls
+
+When the user speaks over the agent, stop your local playback immediately — don't wait for the server — then send `Interrupt` with how many milliseconds of audio the user actually heard. The server cancels the active turn and answers with `SpeechInterrupted`, splitting the turn's text into what was spoken and what wasn't, so you can feed exactly what the user heard back into your LLM context.
+
+```csharp
+await speakClient.Subscribe(new EventHandler<SpeechInterruptedResponse>((sender, e) =>
+{
+    Console.WriteLine($"Heard:  {e.TextSpoken}");
+    Console.WriteLine($"Unsaid: {e.TextRemaining}");
+}));
+
+// The offset is cumulative across the whole session (not per turn), and each
+// interrupt must advance past the previous one. Report your audio player's
+// actual position — not bytes received, which arrive much faster than realtime.
+await speakClient.SendInterrupt(playbackOffsetMs);
+```
+
+Omit the offset (`SendInterrupt()`) and the turn still stops, but the server can't compute the split — `TextSpoken`/`TextRemaining` come back empty.
+
+`Configure` changes the speaking rate mid-session without reconnecting. The server acknowledges with `ConfigureSuccess`, or rejects with a typed `ConfigureFailure` — the SDK does not range-check `speed` locally, so an out-of-range value comes back as `SPEED_OUT_OF_RANGE` rather than throwing.
+
+```csharp
+await speakClient.SendConfigure(new ConfigureSchema() { Speed = 1.05 });
 ```
 
 For batch (REST) synthesis of a complete block of text:
@@ -374,7 +400,7 @@ var speakClient = ClientFactory.CreateFluxSpeakRESTClient();
 await speakClient.ToFile(
     new TextSource("Your appointment is confirmed for 3pm tomorrow."),
     "output.mp3",
-    new SpeakSchema() { Model = "flux-alexis-en", Encoding = "mp3", BitRate = 48000 });
+    new SpeakSchema() { Model = "flux-alexis-en", Encoding = "mp3", BitRate = 48000, Speed = 1.05 });
 
 // Asynchronous: supply a callback URL and receive a request_id ack; the audio is
 // delivered to your callback
@@ -382,7 +408,7 @@ await speakClient.ToFile(
 //     new SpeakSchema() { Model = "flux-alexis-en" });
 ```
 
-[See our API reference for more info](https://developers.deepgram.com/reference/text-to-speech).
+[See our API reference for more info](https://developers.deepgram.com/reference/text-to-speech/speak-flux).
 
 [See the Examples for more info](./examples/text-to-speech/websocket/flux/) - and the [batch (REST) example](./examples/text-to-speech/rest/flux/).
 

--- a/examples/text-to-speech/rest/flux/Program.cs
+++ b/examples/text-to-speech/rest/flux/Program.cs
@@ -25,7 +25,8 @@ namespace SampleApp
             //   var speakClient = ClientFactory.CreateFluxSpeakRESTClient("", options);
 
             // Synthesize a complete block of text into a single audio file. Model is required and
-            // must be a flux-* voice.
+            // must be a flux-* voice. Speed (0.85-1.15 in 0.05 steps) and Expressivity (beta,
+            // -2 to 2) are optional GA params, available on both transports.
             var mp3 = await speakClient.ToFile(
                 new TextSource("Your appointment is confirmed for 3pm tomorrow."),
                 "output.mp3",
@@ -34,6 +35,7 @@ namespace SampleApp
                     Model = "flux-alexis-en",
                     Encoding = "mp3",
                     BitRate = 48000,
+                    Speed = 1.05,
                 });
             Console.WriteLine($"Wrote output.mp3 (request {mp3.RequestId}, {mp3.Characters} chars)");
 

--- a/examples/text-to-speech/websocket/flux/Program.cs
+++ b/examples/text-to-speech/websocket/flux/Program.cs
@@ -47,7 +47,6 @@ namespace SampleApp
                 // (not per turn), and each interrupt must advance past the previous one.
                 const long BytesPerMs = 48;
                 long audioBytesReceived = 0;
-                long audioBytesBeforeSecondTurn = 0;
                 var speechStartedCount = 0;
 
                 await speakClient.Subscribe(new EventHandler<ConnectedResponse>((sender, e) =>
@@ -163,13 +162,15 @@ namespace SampleApp
                 // GA: barge-in. Start a deliberately long second turn, then interrupt it partway
                 // through — in a real app, Interrupt fires the moment you detect the user
                 // speaking over the agent (e.g. Flux STT's StartOfTurn), not on a fixed delay.
-                audioBytesBeforeSecondTurn = Interlocked.Read(ref audioBytesReceived);
                 await speakClient.SendText(
                     "This sentence is deliberately long so that audio is still streaming when the " +
                     "interrupt is sent, which is what makes the barge-in observable.");
                 await Task.WhenAny(secondTurnStarted.Task, Task.Delay(10000));
                 await Task.Delay(500); // let some of the second turn's audio arrive before cutting it off
-                var playbackOffsetMs = (Interlocked.Read(ref audioBytesReceived) - audioBytesBeforeSecondTurn) / BytesPerMs;
+                // The offset sent to SendInterrupt is the SESSION total, not this turn's — it must
+                // keep growing across turns, or a later interrupt will fail the server's "must
+                // advance past the previous interrupt" check. Do not subtract a per-turn baseline.
+                var playbackOffsetMs = Interlocked.Read(ref audioBytesReceived) / BytesPerMs;
                 await speakClient.SendInterrupt(Math.Max(playbackOffsetMs, 1));
                 await Task.WhenAny(interruptAcked.Task, Task.Delay(10000));
 

--- a/examples/text-to-speech/websocket/flux/Program.cs
+++ b/examples/text-to-speech/websocket/flux/Program.cs
@@ -34,6 +34,21 @@ namespace SampleApp
                 // Signals the turn's audio is complete (SpeechMetadata fires after all of a turn's
                 // audio has been sent). Wait on this before closing so audio is not truncated.
                 var turnComplete = new TaskCompletionSource();
+                var secondTurnStarted = new TaskCompletionSource();
+                var configureAcked = new TaskCompletionSource();
+                var interruptAcked = new TaskCompletionSource();
+
+                // PLAYBACK OFFSET — the one thing to get right about barge-in:
+                // this example counts bytes RECEIVED (48 bytes/ms at linear16/24kHz) as a
+                // stand-in for playback position, so it stays self-contained. Audio arrives
+                // much faster than realtime, so a real client MUST report its audio player's
+                // actual position instead — the offset is what makes TextSpoken/TextRemaining
+                // reflect what the user really heard. It is cumulative across the session
+                // (not per turn), and each interrupt must advance past the previous one.
+                const long BytesPerMs = 48;
+                long audioBytesReceived = 0;
+                long audioBytesBeforeSecondTurn = 0;
+                var speechStartedCount = 0;
 
                 await speakClient.Subscribe(new EventHandler<ConnectedResponse>((sender, e) =>
                 {
@@ -43,6 +58,10 @@ namespace SampleApp
                 await speakClient.Subscribe(new EventHandler<SpeechStartedResponse>((sender, e) =>
                 {
                     Console.WriteLine($"Speech started: {e.SpeechId}");
+                    if (Interlocked.Increment(ref speechStartedCount) == 2)
+                    {
+                        secondTurnStarted.TrySetResult();
+                    }
                 }));
 
                 // Audio chunks arrive interleaved with the control messages.
@@ -53,6 +72,7 @@ namespace SampleApp
                     if (e.Stream is not null)
                     {
                         e.Stream.CopyTo(audioOut);
+                        Interlocked.Add(ref audioBytesReceived, e.Stream.Length);
                     }
                 }));
 
@@ -65,6 +85,28 @@ namespace SampleApp
                 {
                     Console.WriteLine($"Turn metadata: {e.AudioDurationMs}ms audio, {e.BillableCharacterCount} billable chars");
                     turnComplete.TrySetResult();
+                }));
+
+                // GA: barge-in. The server cancels the active turn and reports exactly what the
+                // user heard, so it can be fed back into your LLM context.
+                await speakClient.Subscribe(new EventHandler<SpeechInterruptedResponse>((sender, e) =>
+                {
+                    Console.WriteLine($"Interrupted after {e.AudioPlayedMs}ms.");
+                    Console.WriteLine($"  Heard:  {e.TextSpoken}");
+                    Console.WriteLine($"  Unsaid: {e.TextRemaining}");
+                    interruptAcked.TrySetResult();
+                }));
+
+                // GA: mid-stream speed changes, acknowledged by ConfigureSuccess/ConfigureFailure.
+                await speakClient.Subscribe(new EventHandler<ConfigureSuccessResponse>((sender, e) =>
+                {
+                    Console.WriteLine($"Configure applied: speed={e.Applied?.Speed}");
+                    configureAcked.TrySetResult();
+                }));
+                await speakClient.Subscribe(new EventHandler<ConfigureFailureResponse>((sender, e) =>
+                {
+                    Console.WriteLine($"Configure rejected: {e.Code} - {e.Description}");
+                    configureAcked.TrySetResult();
                 }));
 
                 await speakClient.Subscribe(new EventHandler<SessionMetadataResponse>((sender, e) =>
@@ -87,7 +129,9 @@ namespace SampleApp
                     Console.WriteLine("Connection closed");
                 }));
 
-                // Model is required and must be a flux-* voice.
+                // Model is required and must be a flux-* voice. Speed and Expressivity are
+                // optional GA connect params (see the mid-stream Configure below for changing
+                // speed without reconnecting).
                 var schema = new SpeakSchema()
                 {
                     Model = "flux-alexis-en",
@@ -111,6 +155,23 @@ namespace SampleApp
                 // Wait for the turn's audio to finish arriving before closing, so it isn't
                 // truncated. (Closing mid-turn only drains up to the client's close grace period.)
                 await Task.WhenAny(turnComplete.Task, Task.Delay(30000));
+
+                // GA: change the speaking rate mid-session, without reconnecting.
+                await speakClient.SendConfigure(new ConfigureSchema { Speed = 1.1 });
+                await Task.WhenAny(configureAcked.Task, Task.Delay(10000));
+
+                // GA: barge-in. Start a deliberately long second turn, then interrupt it partway
+                // through — in a real app, Interrupt fires the moment you detect the user
+                // speaking over the agent (e.g. Flux STT's StartOfTurn), not on a fixed delay.
+                audioBytesBeforeSecondTurn = Interlocked.Read(ref audioBytesReceived);
+                await speakClient.SendText(
+                    "This sentence is deliberately long so that audio is still streaming when the " +
+                    "interrupt is sent, which is what makes the barge-in observable.");
+                await Task.WhenAny(secondTurnStarted.Task, Task.Delay(10000));
+                await Task.Delay(500); // let some of the second turn's audio arrive before cutting it off
+                var playbackOffsetMs = (Interlocked.Read(ref audioBytesReceived) - audioBytesBeforeSecondTurn) / BytesPerMs;
+                await speakClient.SendInterrupt(Math.Max(playbackOffsetMs, 1));
+                await Task.WhenAny(interruptAcked.Task, Task.Delay(10000));
 
                 // Clean shutdown: sends {"type":"Close"} and waits briefly for the server to drain
                 // any remaining/queued audio and emit a final SessionMetadata before teardown.


### PR DESCRIPTION
## Summary

Flux TTS went GA on 2026-08-12 (Python 7.7.0, JS 5.8.0, Java shipped the same surface). This adds the GA delta on top of the EA client shipped in 6.9.0:

- `Interrupt` (barge-in) with optional session-cumulative `playback_offset`; server replies with `SpeechInterrupted` (`text_spoken`/`text_remaining` split) or a `Warning` when it can't act on the interrupt.
- `Configure` for mid-stream `speed` changes, acked by `ConfigureSuccess` or a typed `ConfigureFailure` (not range-checked client-side — matches Python/JS, server is the source of truth).
- `speed` and `expressivity` (beta) connect/query params on both the streaming WebSocket and batch REST transports.
- `controls_applied` gains a `breaks_applied` counter (nullable, so EA-era frames without the field keep parsing).
- Drops "(Preview)"/Early-Access markers now that the surface is GA.

Additive only: no changes to `/v1/speak` (Aura), Flux STT, or any other client. `ResetContext` was never part of the GA surface and is out of scope.

## ⚠️ Breaking change — targets 7.0.0, not a 6.x release

Adding `SendInterrupt`/`SendConfigure` and three `Subscribe` overloads to the public `IFluxSpeakWebSocketClient` interface is source-breaking for anyone with a **hand-written concrete class** implementing that interface directly. It does **not** affect:
- Consumers using `FluxSpeakWebSocketClient`/`ClientFactory` as shipped (the normal path).
- Consumers mocking the interface with NSubstitute/Moq (dynamic-proxy mocks don't break when an interface gains members).

This PR is intentionally scoped to ride the already-planned 7.0.0 major (the Serilog→Microsoft.Extensions.Logging break from #419/`056601c`), not a 6.x minor. **Do not backport this to a 6.x release** without first stripping the interface-member additions (the model/client additions themselves are additive and would be safe on 6.x; only the interface change is the blocker).

A callout for this is already in `README.md` under "Flux Text to Speech" → "Upgrading from 6.x (`IFluxSpeakWebSocketClient` interface members)". If 7.0.0 gets its own consolidated breaking-changes/migration doc (as the Serilog swap did), this should get a line there too.

## Test plan

- [x] Docker baseline (`mcr.microsoft.com/dotnet/sdk:8.0`, matches CI's 8.0.x): 302/302 passing before this change.
- [x] Full suite after: 327/333 passing (25 new tests, 6 pre-existing env-gated skips, 0 failed).
- [x] EA fixtures (`frames.json`/`golden.json`) confirmed byte-identical (regression-safe).
- [x] Live smoke against **production** (`DEEPGRAM_API_KEY`), including the `Configure`→`Interrupt` round trip end to end.
- [x] `frames-ga.json` is a real verbatim capture from production (not hand-authored) — built a standalone raw-`ClientWebSocket` script, independent of the SDK's own parser, to capture ground truth rather than re-validate the parser against itself. The real capture caught two errors in an earlier doc-derived draft of this fixture (`model_name` is the bare voice `"alexis"`, not `"flux-alexis-en"`; `model_version` was a placeholder) — direct evidence for why a real capture, not a doc transcription, is the right fixture.
- [x] Both example projects (`examples/text-to-speech/websocket/flux`, `examples/text-to-speech/rest/flux`) build clean in Docker, individually and as part of the full `Deepgram.Dev.sln` (see #424, a separate pre-existing dev-solution fix merged/pending ahead of this one).
- [x] devrel-review run against this diff found and fixed one real bug: the barge-in example (and its mirrored live test) computed `playback_offset` as the current turn's delta instead of the session-cumulative total the API requires — would have silently broken every barge-in after the first in a real multi-turn agent. Fixed in a follow-up commit, re-verified against production with the corrected math.
- [x] `release-v6` pushed as a dormant fork point (at the last pre-Serilog-break commit) in case a customer needs a 6.x patch after this ships — insurance, not active maintenance; policy remains "upgrade for fixes."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
